### PR TITLE
feat: add search result filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `pixiv search` 新增 `--rating`、`--type` 与 `--ai-type` 本地结果过滤；带 `--limit`/`--page` 时会按匹配结果继续读取 opaque cursor。
+
 ## [0.2.0] - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ CLI 使用 Cobra/pflag，选项可以写在位置参数前后，例如 `pixiv au
 | `search` | `--search-target` | `partial_match_for_tags` | 搜索范围。 |
 | `search` | `--sort` | `date_desc` | 排序方式。 |
 | `search` | `--duration` | 空 | Pixiv API 的时间范围参数。 |
+| `search` | `--rating` | `all` | 本地结果分级筛选：`sfw`、`r18`、`r18g`、`mature` 或 `all`。 |
+| `search` | `--type` | `all` | 本地作品类型筛选：`illust`、`comics`（Pixiv `manga`）、`ugoira` 或 `all`。 |
+| `search` | `--ai-type` | `2` | 本地 AI 类型筛选：`0` 非 AI、`1` 仅 AI、`2` 全部。 |
 | 列表命令 | `--limit` | 一个上游批次 | 最大条数；`0` 表示持续读取到没有下一批。 |
 | 列表命令 | `--page` | 空 | 从 1 开始的逻辑页；必须与正数 `--limit` 同用。 |
 | 列表命令 | `--offset` | `0` | 已废弃的逻辑偏移；不能与 `--page` 同用。 |
@@ -225,6 +228,8 @@ CLI 使用 Cobra/pflag，选项可以写在位置参数前后，例如 `pixiv au
 | `recommended` | `--offset` | `0` | 分页偏移。 |
 | `detail` | `ILLUST_ID` | 必填 | Pixiv 作品 ID。 |
 | `download` | `ILLUST_ID...` | 必填 | 一个或多个 Pixiv 作品 ID。 |
+
+`search` 的 `--rating`、`--type` 与 `--ai-type` 在 CLI 输出端筛选上游结果，不改变 SDK 请求或 opaque cursor。当指定正数 `--limit` 或 `--page` 时，CLI 会持续读取上游批次直到收集到对应数量的匹配作品、上游没有下一批，或检测到重复 cursor；未指定 `--limit` 时仍保持只读取一个上游批次的兼容默认行为。
 
 ### 通用参数
 

--- a/internal/cli/api_cmd.go
+++ b/internal/cli/api_cmd.go
@@ -17,7 +17,10 @@ type searchOptions struct {
 	sortMode string
 	duration string
 	listOptions
-	r18 bool
+	r18    bool
+	rating string
+	typ    string
+	aiType int
 }
 
 type rankingOptions struct {
@@ -36,6 +39,9 @@ func (a app) newSearchCommand() *cobra.Command {
 	opts := searchOptions{
 		target:   string(sdk.SearchTargetPartialMatchForTags),
 		sortMode: string(sdk.SortModeDateDesc),
+		rating:   "all",
+		typ:      "all",
+		aiType:   2,
 	}
 	cmd := &cobra.Command{
 		Use:     "search WORD",
@@ -51,12 +57,18 @@ func (a app) newSearchCommand() *cobra.Command {
 	flags.StringVar(&opts.target, "search-target", opts.target, "search target")
 	flags.StringVar(&opts.sortMode, "sort", opts.sortMode, "sort mode")
 	flags.StringVar(&opts.duration, "duration", "", "duration")
+	flags.StringVar(&opts.rating, "rating", opts.rating, "rating filter: sfw, r18, r18g, mature, all")
+	flags.StringVar(&opts.typ, "type", opts.typ, "artwork type filter: illust, comics, ugoira, all")
+	flags.IntVar(&opts.aiType, "ai-type", opts.aiType, "AI artwork filter: 0 non-AI, 1 AI only, 2 all")
 	bindListFlags(cmd, &opts.listOptions)
 	flags.BoolVar(&opts.r18, "r18", false, "append R-18 to the search word")
 	return cmd
 }
 
 func (a app) runSearch(cmd *cobra.Command, args []string, opts searchOptions) error {
+	if err := validateSearchFilters(opts); err != nil {
+		return err
+	}
 	word := strings.Join(args, " ")
 	if opts.r18 {
 		word += " R-18"
@@ -86,8 +98,76 @@ func (a app) runSearch(cmd *cobra.Command, args []string, opts searchOptions) er
 		if err != nil {
 			return nil, "", err
 		}
-		return result.Illusts, result.NextCursor, nil
+		return filterSearchIllusts(result.Illusts, opts), result.NextCursor, nil
 	}, func(items []sdk.Illust, start int) { printIllusts(a.out, items, start, false) })
+}
+
+func validateSearchFilters(opts searchOptions) error {
+	switch opts.rating {
+	case "sfw", "r18", "r18g", "mature", "all":
+	default:
+		return fmt.Errorf("rating must be one of sfw, r18, r18g, mature, all")
+	}
+	switch opts.typ {
+	case "illust", "comics", "ugoira", "all":
+	default:
+		return fmt.Errorf("type must be one of illust, comics, ugoira, all")
+	}
+	if opts.aiType < 0 || opts.aiType > 2 {
+		return fmt.Errorf("ai-type must be 0, 1, or 2")
+	}
+	return nil
+}
+
+// filterSearchIllusts 保持上游原始 cursor 不变，仅在 CLI 输出边界筛选结果。
+// 因此 --limit/--page 仍由通用分页器按筛选后的逻辑结果计数，并会在未满足数量时继续取下一批。
+func filterSearchIllusts(illusts []sdk.Illust, opts searchOptions) []sdk.Illust {
+	filtered := make([]sdk.Illust, 0, len(illusts))
+	for _, illust := range illusts {
+		if !matchesSearchRating(illust.XRestrict, opts.rating) || !matchesSearchType(illust.Type, opts.typ) || !matchesSearchAIType(illust.AIType, opts.aiType) {
+			continue
+		}
+		filtered = append(filtered, illust)
+	}
+	return filtered
+}
+
+func matchesSearchRating(xRestrict int, rating string) bool {
+	switch rating {
+	case "sfw":
+		return xRestrict == 0
+	case "r18":
+		return xRestrict == 1
+	case "r18g":
+		return xRestrict == 2
+	case "mature":
+		return xRestrict == 0 || xRestrict == 1
+	case "all":
+		return true
+	default:
+		return false
+	}
+}
+
+func matchesSearchType(actual, want string) bool {
+	if want == "all" {
+		return true
+	}
+	if want == "comics" {
+		return actual == string(sdk.IllustTypeManga)
+	}
+	return actual == want
+}
+
+func matchesSearchAIType(actual, want int) bool {
+	switch want {
+	case 0, 1:
+		return actual == want
+	case 2:
+		return true
+	default:
+		return false
+	}
 }
 
 func (a app) newDetailCommand() *cobra.Command {

--- a/internal/cli/api_test.go
+++ b/internal/cli/api_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -67,6 +69,29 @@ func TestSearchFiltersResultsAndFollowsCursorUntilLimit(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
 	assert.Equal(t, []int64{4, 5}, []int64{out.Illusts[0].ID, out.Illusts[1].ID})
+}
+
+func TestSearchAITypeFilterPreservesAnonymousWebResult(t *testing.T) {
+	useTempPaths(t)
+	web := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		require.Equal(t, "/ajax/search/artworks/miku", request.URL.Path)
+		_, _ = io.WriteString(writer, `{"error":false,"body":{"illustManga":{"data":[{"id":"1","title":"AI work","illustType":"0","xRestrict":"0","aiType":"1","userId":"10","userName":"artist","pageCount":"1"}]}}}`)
+	}))
+	defer web.Close()
+	setTestSDKCommandFactory(t, func(application.SDKClientRequest) (application.SDKClient, error) {
+		return sdk.NewClient(sdk.Options{HTTPClient: web.Client(), WebAPIBaseURL: web.URL, WebFallbackEnabled: true})
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"pixiv", "search", "miku", "--ai-type", "1", "--json"}, strings.NewReader(""), &stdout, &stderr)
+
+	require.Equal(t, 0, code, stderr.String())
+	var out struct {
+		Illusts []sdk.Illust `json:"illusts"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
+	require.Len(t, out.Illusts, 1)
+	assert.Equal(t, 1, out.Illusts[0].AIType)
 }
 
 func TestSearchRejectsInvalidFilterValuesBeforeOpeningSDK(t *testing.T) {

--- a/internal/cli/api_test.go
+++ b/internal/cli/api_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -31,6 +33,67 @@ func TestSearchRoutesArgumentsAndPrintsSDKJSON(t *testing.T) {
 		Word: "初音ミク", Target: sdk.SearchTargetPartialMatchForTags, Sort: sdk.SortModeDateDesc,
 	}, got)
 	assert.JSONEq(t, `{"illusts":[{"id":123,"title":"work","type":"","page_count":0,"total_bookmarks":0,"total_view":0,"x_restrict":0,"user":{"id":0,"name":"artist","account":"","comment":"","is_followed":false},"tags":null,"image_urls":{"square_medium":"","medium":"","large":"","original":""},"meta_single_page":{"original_image_url":""},"meta_pages":null,"ai_type":0,"create_date":"","width":0,"height":0}]}`, stdout.String())
+}
+
+func TestSearchFiltersResultsAndFollowsCursorUntilLimit(t *testing.T) {
+	useTempPaths(t)
+	var cursors []sdk.Cursor
+	setTestSDKCommandClient(t, sdkCommandFake{search: func(_ context.Context, request sdk.SearchIllustRequest) (*sdk.IllustListResult, error) {
+		cursors = append(cursors, request.Cursor)
+		switch request.Cursor {
+		case "":
+			return &sdk.IllustListResult{Illusts: []sdk.Illust{
+				{ID: 1, Type: "illust", XRestrict: 1, AIType: 1},
+				{ID: 2, Type: "manga", XRestrict: 0, AIType: 1},
+				{ID: 3, Type: "manga", XRestrict: 1, AIType: 0},
+				{ID: 4, Type: "manga", XRestrict: 1, AIType: 1},
+			}, NextCursor: "second"}, nil
+		case "second":
+			return &sdk.IllustListResult{Illusts: []sdk.Illust{
+				{ID: 5, Type: "manga", XRestrict: 1, AIType: 1},
+			}}, nil
+		default:
+			return nil, fmt.Errorf("unexpected cursor %q", request.Cursor)
+		}
+	}})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"pixiv", "search", "miku", "--rating", "r18", "--type", "comics", "--ai-type", "1", "--limit", "2", "--json"}, strings.NewReader(""), &stdout, &stderr)
+
+	require.Equal(t, 0, code, stderr.String())
+	assert.Equal(t, []sdk.Cursor{"", "second"}, cursors)
+	var out struct {
+		Illusts []sdk.Illust `json:"illusts"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
+	assert.Equal(t, []int64{4, 5}, []int64{out.Illusts[0].ID, out.Illusts[1].ID})
+}
+
+func TestSearchRejectsInvalidFilterValuesBeforeOpeningSDK(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "rating", args: []string{"--rating", "adult"}, want: "rating must be one of"},
+		{name: "type", args: []string{"--type", "novel"}, want: "type must be one of"},
+		{name: "ai type", args: []string{"--ai-type", "3"}, want: "ai-type must be 0, 1, or 2"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			useTempPaths(t)
+			calls := 0
+			setTestSDKCommandFactory(t, func(application.SDKClientRequest) (application.SDKClient, error) {
+				calls++
+				return sdkCommandFake{}, nil
+			})
+			var stdout, stderr bytes.Buffer
+			code := Run(append([]string{"pixiv", "search", "miku"}, test.args...), strings.NewReader(""), &stdout, &stderr)
+
+			require.NotZero(t, code)
+			assert.Contains(t, stderr.String(), test.want)
+			assert.Zero(t, calls)
+		})
+	}
 }
 
 func TestSearchUsesOutputJSONFromConfig(t *testing.T) {

--- a/internal/pixiv/webapi/client.go
+++ b/internal/pixiv/webapi/client.go
@@ -472,6 +472,7 @@ func mapSearchIllust(item webSearchIllust) model.Illust {
 		},
 		Tags:      tags,
 		ImageURLs: imageURLs,
+		AIType:    int(item.AIType),
 	}
 }
 
@@ -665,6 +666,7 @@ type webSearchIllust struct {
 	Title         string    `json:"title"`
 	IllustType    flexInt   `json:"illustType"`
 	XRestrict     flexInt   `json:"xRestrict"`
+	AIType        flexInt   `json:"aiType"`
 	URL           string    `json:"url"`
 	Tags          []string  `json:"tags"`
 	UserID        flexInt64 `json:"userId"`

--- a/internal/pixiv/webapi/client_test.go
+++ b/internal/pixiv/webapi/client_test.go
@@ -163,7 +163,7 @@ func TestClientSearchIllustMapsWebArtworkResults(t *testing.T) {
 		assert.Equal(t, "date_d", r.URL.Query().Get("order"))
 		assert.Equal(t, "s_tag", r.URL.Query().Get("s_mode"))
 		assert.Equal(t, "1", r.URL.Query().Get("p"))
-		fmt.Fprint(w, `{"error":false,"message":"","body":{"illustManga":{"data":[{"id":"123","title":"Miku","illustType":0,"xRestrict":0,"url":"https://i.pximg.net/thumb.jpg","tags":["初音ミク"],"userId":"456","userName":"artist","pageCount":1}]}}}`)
+		fmt.Fprint(w, `{"error":false,"message":"","body":{"illustManga":{"data":[{"id":"123","title":"Miku","illustType":0,"xRestrict":0,"aiType":1,"url":"https://i.pximg.net/thumb.jpg","tags":["初音ミク"],"userId":"456","userName":"artist","pageCount":1}]}}}`)
 	}))
 	defer server.Close()
 
@@ -176,6 +176,7 @@ func TestClientSearchIllustMapsWebArtworkResults(t *testing.T) {
 	assert.Equal(t, int64(123), illust.ID)
 	assert.Equal(t, "Miku", illust.Title)
 	assert.Equal(t, "illust", illust.Type)
+	assert.Equal(t, 1, illust.AIType)
 	assert.Equal(t, int64(456), illust.User.ID)
 	assert.Equal(t, "artist", illust.User.Name)
 	assert.Equal(t, "https://i.pximg.net/thumb.jpg", illust.ImageURLs.Medium)


### PR DESCRIPTION
## Summary
- add CLI result filters for rating, artwork type, and AI type
- continue opaque-cursor pagination until filtered page/limit requirements are met
- preserve `aiType` in anonymous Web search results

## Verification
- go test ./... -count=1
- go test -race ./... -count=1
- go vet ./...
- sh scripts/build.sh
- pre-commit run --all-files
- git diff --check origin/main..HEAD