### PR TITLE
fix: align v0.2 recovery overlay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,43 +155,14 @@ jobs:
           test -z "$(git diff --cached --name-only)"
           git archive --format=tar "$GITHUB_SHA" -- \
             .github/workflows/release.yml \
-            internal/cli/account_test.go \
-            internal/cli/config_test.go \
-            internal/download/ugoira_rust_test.go \
-            internal/storage/auth/account_test.go \
-            internal/update/installer_test.go \
-            internal/update/releases_reader_nonwindows_test.go \
-            internal/update/releases_reader_windows_test.go \
-            internal/update/releases_test.go \
-            internal/update/source_test.go \
-            internal/utils/files/files_test.go \
             pkg/pixiv/account_external_test.go \
-            scripts/licensebundle/main_test.go \
             scripts/releaseworkflow/main.go \
-            scripts/releaseworkflow/main_test.go \
-            scripts/test-package-release.sh \
-            test/e2e/pixiv_binary_test.go | tar -xf -
-          git add -N \
-            internal/update/releases_reader_nonwindows_test.go \
-            internal/update/releases_reader_windows_test.go
+            scripts/releaseworkflow/main_test.go | tar -xf -
           test "$(git diff --name-only)" = "$(printf '%s\n' \
             .github/workflows/release.yml \
-            internal/cli/account_test.go \
-            internal/cli/config_test.go \
-            internal/download/ugoira_rust_test.go \
-            internal/storage/auth/account_test.go \
-            internal/update/installer_test.go \
-            internal/update/releases_reader_nonwindows_test.go \
-            internal/update/releases_reader_windows_test.go \
-            internal/update/releases_test.go \
-            internal/update/source_test.go \
-            internal/utils/files/files_test.go \
             pkg/pixiv/account_external_test.go \
-            scripts/licensebundle/main_test.go \
             scripts/releaseworkflow/main.go \
-            scripts/releaseworkflow/main_test.go \
-            scripts/test-package-release.sh \
-            test/e2e/pixiv_binary_test.go)"
+            scripts/releaseworkflow/main_test.go)"
           test -z "$(git diff --cached --name-only)"
       - name: Test Go sources
         shell: bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -280,12 +280,10 @@ GitHub Release。workflow 使用 full-SHA Actions、最小权限及 `release` En
 若不可变 tag 的首次 run 在创建 GitHub Release 前失败，维护者只能从默认分支通过
 `workflow_dispatch` 提交同一个 `release_tag` 进行恢复。validate 会校验该 tag 为 SemVer、存在、
 已包含于默认分支且尚未有 Release；构建与发布始终 checkout 该 tag。恢复 run 可以只在无 Environment
-的六平台 test job 中应用固定白名单的默认分支测试覆盖：Windows ACL、`.exe`、CRLF 和文件共享语义所需的
-14 个测试文件、`scripts/test-package-release.sh` package 测试脚本、仅在该 test gate 使用的
-`known_hosts` 验证器，以及供该 verifier 读取的当前 release workflow 配置（共 17 条路径）。覆盖通过
-一次 `git archive` 提取；其中两条
-在 tag 中不存在的平台 reader 仅以 `git add -N` 标为 intent-to-add，再逐项核对工作树 diff 与空 cached diff，
-不能加入任意路径或生产源码，且不生成 release artifact。该 job 成功后，独立的新 runner
+的六平台 test job 中应用固定白名单的默认分支测试覆盖：当前 release workflow、Windows ACL 所需的
+`pkg/pixiv/account_external_test.go`，以及该 workflow 的 canonical verifier 与其测试（共 4 条路径）。覆盖通过
+一次 `git archive` 提取，再逐项核对工作树 diff 与空 cached diff，不能加入任意路径或生产源码，且不生成
+release artifact。该 job 成功后，独立的新 runner
 才会以 `clean: true` checkout tag、重新构建 selected staticlib 并生成唯一可被 publish 下载的
 `verified-release-*` assets；测试进程对环境变量、PATH 或临时目录的副作用不会进入生产 job。因此它不能用于
 替换生产资产源码、移动 tag，或重发已经存在的 Release。

--- a/goal-1/tasks.md
+++ b/goal-1/tasks.md
@@ -18,10 +18,10 @@
 
 ## T03 — 审查 recovery 修改并 dispatch/验收 v0.2.0 Release
 
-- 状态：未完成
-- 实际：
-- 证据：
-- 风险/下一步：
+- 状态：阻塞
+- 实际：已创建并推送 recovery PR #4；Linux 双架构、macOS arm64 与 quality 通过。
+- 证据：GitHub Actions `29276437342`、`29276437349`；macOS amd64、Windows amd64/arm64 连续多个 goal 回合仍为 in-progress，未提供失败日志或完成结论。
+- 风险/下一步：等待 GitHub Actions 外部 runner 完成后，复查全部门禁；全绿才合并 main 并 dispatch `release_tag=v0.2.0`，tag 保持不可变。
 
 ## C01 — 集中检查：恢复链路、tag 不变性、文档与外部发布证据
 

--- a/goal-1/tasks.md
+++ b/goal-1/tasks.md
@@ -18,10 +18,17 @@
 
 ## T03 — 审查 recovery 修改并 dispatch/验收 v0.2.0 Release
 
-- 状态：阻塞
-- 实际：已创建并推送 recovery PR #4；Linux 双架构、macOS arm64 与 quality 通过。
-- 证据：GitHub Actions `29276437342`、`29276437349`；macOS amd64、Windows amd64/arm64 连续多个 goal 回合仍为 in-progress，未提供失败日志或完成结论。
-- 风险/下一步：等待 GitHub Actions 外部 runner 完成后，复查全部门禁；全绿才合并 main 并 dispatch `release_tag=v0.2.0`，tag 保持不可变。
+- 状态：待修复
+- 实际：recovery PR #4 已合并至 main；审计 recovery run 已从不可变 `v0.2.0` tag 启动，但六个平台均在覆盖层步骤失败，未创建 Release。
+- 证据：GitHub Actions `29304765177`（failure）。逐字复现其 overlay 后，实际 diff 仅为 `.github/workflows/release.yml`、`pkg/pixiv/account_external_test.go`、`scripts/releaseworkflow/main.go`、`scripts/releaseworkflow/main_test.go` 四项，而 workflow 的严格断言仍要求历史遗留的 17 项全集；失败发生在 Go 测试前，故与平台或 Windows ACL 无关。
+- 风险/下一步：新增 T03a 以把审计白名单和运行时断言改为同一个、基于实际 tag-to-main 差异的最小集合；修复必须继续不移动 tag，且经实现/规格/质量三阶段审查和多平台 CI 后才可重新 dispatch。
+
+## T03a — 收敛 recovery overlay 至实际最小审计差异并复验 policy
+
+- 状态：未完成
+- 实际：
+- 证据：
+- 风险/下一步：
 
 ## C01 — 集中检查：恢复链路、tag 不变性、文档与外部发布证据
 

--- a/goal-1/tasks.md
+++ b/goal-1/tasks.md
@@ -25,10 +25,10 @@
 
 ## T03a — 收敛 recovery overlay 至实际最小审计差异并复验 policy
 
-- 状态：未完成
-- 实际：
-- 证据：
-- 风险/下一步：
+- 状态：完成
+- 实际：将 test-only recovery overlay 的 archive、工作树 diff 断言和 Go canonical verifier 同步收敛为 tag 与当前默认分支实际不同的四条路径；移除遗留的两条 `git add -N`，并把聚焦策略测试改为精确四路径命令、逐条缺失和额外路径拒绝。
+- 证据：提交 `59105ed`；TDD RED `go test ./scripts/releaseworkflow -run '^TestCheckRecoveryPolicyRequiresExactFourPathOverlay$' -count=1` 在旧 17 条命令下失败，GREEN 后通过；`go test ./scripts/releaseworkflow -count=1`、`sh scripts/test-release-workflow.sh`、`go test ./...`、`git diff --check origin/main..HEAD` 和 pre-commit 均通过。临时 detached `v0.2.0` worktree 从 `origin/main` archive 四条路径后，`git diff --name-only` 精确等于该集合且 cached diff 为空。规格审查与质量审查均批准。
+- 风险/下一步：仍需把修复推送、通过六平台 PR CI，并从默认分支重新 dispatch `release_tag=v0.2.0`；tag 保持不可变，生产构建隔离仍待远端实际 run 验证。
 
 ## C01 — 集中检查：恢复链路、tag 不变性、文档与外部发布证据
 

--- a/scripts/releaseworkflow/main.go
+++ b/scripts/releaseworkflow/main.go
@@ -401,43 +401,14 @@ test -z "$(git diff --name-only)"
 test -z "$(git diff --cached --name-only)"
 git archive --format=tar "$GITHUB_SHA" -- \
   .github/workflows/release.yml \
-  internal/cli/account_test.go \
-  internal/cli/config_test.go \
-  internal/download/ugoira_rust_test.go \
-  internal/storage/auth/account_test.go \
-  internal/update/installer_test.go \
-  internal/update/releases_reader_nonwindows_test.go \
-  internal/update/releases_reader_windows_test.go \
-  internal/update/releases_test.go \
-  internal/update/source_test.go \
-  internal/utils/files/files_test.go \
   pkg/pixiv/account_external_test.go \
-  scripts/licensebundle/main_test.go \
   scripts/releaseworkflow/main.go \
-  scripts/releaseworkflow/main_test.go \
-  scripts/test-package-release.sh \
-  test/e2e/pixiv_binary_test.go | tar -xf -
-git add -N \
-  internal/update/releases_reader_nonwindows_test.go \
-  internal/update/releases_reader_windows_test.go
+  scripts/releaseworkflow/main_test.go | tar -xf -
 test "$(git diff --name-only)" = "$(printf '%s\n' \
   .github/workflows/release.yml \
-  internal/cli/account_test.go \
-  internal/cli/config_test.go \
-  internal/download/ugoira_rust_test.go \
-  internal/storage/auth/account_test.go \
-  internal/update/installer_test.go \
-  internal/update/releases_reader_nonwindows_test.go \
-  internal/update/releases_reader_windows_test.go \
-  internal/update/releases_test.go \
-  internal/update/source_test.go \
-  internal/utils/files/files_test.go \
   pkg/pixiv/account_external_test.go \
-  scripts/licensebundle/main_test.go \
   scripts/releaseworkflow/main.go \
-  scripts/releaseworkflow/main_test.go \
-  scripts/test-package-release.sh \
-  test/e2e/pixiv_binary_test.go)"
+  scripts/releaseworkflow/main_test.go)"
 test -z "$(git diff --cached --name-only)"`
 	if err := requireCanonicalConditionalRunStep(step, "recovery overlay", "github.event_name == 'workflow_dispatch'", commands); err != nil {
 		return errors.New("recovery overlay must use only the exact audited Windows-compatible test paths and verifier")

--- a/scripts/releaseworkflow/main_test.go
+++ b/scripts/releaseworkflow/main_test.go
@@ -299,48 +299,60 @@ func TestCheckRecoveryPolicyRequiresTrustedReleaseTag(t *testing.T) {
 	}
 }
 
-// v0.2.0 的 Windows test gate 只能恢复这一份跨平台权限断言测试；生产源码仍只来自 tag。
-func TestCheckRecoveryPolicyRequiresExactPixivConfigTestOverlay(t *testing.T) {
+// v0.2.0 恢复只覆盖 tag 与默认分支之间实际变化的四个审计文件；生产源码仍只来自 tag。
+func TestCheckRecoveryPolicyRequiresExactFourPathOverlay(t *testing.T) {
 	t.Parallel()
 
-	const path = "pkg/pixiv/account_external_test.go"
+	const commands = `set -euo pipefail
+test -z "$(git diff --name-only)"
+test -z "$(git diff --cached --name-only)"
+git archive --format=tar "$GITHUB_SHA" -- \
+  .github/workflows/release.yml \
+  pkg/pixiv/account_external_test.go \
+  scripts/releaseworkflow/main.go \
+  scripts/releaseworkflow/main_test.go | tar -xf -
+test "$(git diff --name-only)" = "$(printf '%s\n' \
+  .github/workflows/release.yml \
+  pkg/pixiv/account_external_test.go \
+  scripts/releaseworkflow/main.go \
+  scripts/releaseworkflow/main_test.go)"
+test -z "$(git diff --cached --name-only)"`
+	paths := []string{
+		".github/workflows/release.yml",
+		"pkg/pixiv/account_external_test.go",
+		"scripts/releaseworkflow/main.go",
+		"scripts/releaseworkflow/main_test.go",
+	}
 	root := releaseWorkflowRoot(t)
 	step := stepWithRun(t, jobNode(t, root, "build"), `git archive --format=tar "$GITHUB_SHA"`)
 	run := requireMappingValue(t, step, "run")
-	if !strings.Contains(run.Value, "  "+path+" \\\n") {
-		t.Fatalf("recovery overlay does not include %q", path)
+	if run.Value != commands+"\n" {
+		t.Fatalf("recovery overlay command = %q, want exact four-path audited command", run.Value)
 	}
 	if err := checkRecoveryPolicy(root); err != nil {
 		t.Fatalf("checked-in recovery policy rejected: %v", err)
 	}
 
-	for _, mutation := range []struct {
-		name  string
-		apply func(*yaml.Node)
-	}{
-		{
-			name: "required test path omitted",
-			apply: func(root *yaml.Node) {
-				removeRunFragment(t, stepWithRun(t, jobNode(t, root, "build"), `git archive --format=tar "$GITHUB_SHA"`), "  "+path+" \\\n")
-			},
-		},
-		{
-			name: "extra test path added",
-			apply: func(root *yaml.Node) {
-				step := stepWithRun(t, jobNode(t, root, "build"), `git archive --format=tar "$GITHUB_SHA"`)
-				run := requireMappingValue(t, step, "run")
-				run.Value = strings.Replace(run.Value, "  "+path+" \\\n", "  "+path+" \\\n  pkg/pixiv/other_test.go \\\n", 1)
-			},
-		},
-	} {
-		t.Run(mutation.name, func(t *testing.T) {
+	for _, path := range paths {
+		t.Run("required path omitted: "+path, func(t *testing.T) {
 			root := releaseWorkflowRoot(t)
-			mutation.apply(root)
+			step := stepWithRun(t, jobNode(t, root, "build"), `git archive --format=tar "$GITHUB_SHA"`)
+			run := requireMappingValue(t, step, "run")
+			run.Value = strings.Replace(run.Value, path, "", 1)
 			if err := checkRecoveryPolicy(root); err == nil {
-				t.Fatal("release recovery policy accepted an overlay allowlist mutation")
+				t.Fatal("release recovery policy accepted a missing audited overlay path")
 			}
 		})
 	}
+	t.Run("extra path added", func(t *testing.T) {
+		root := releaseWorkflowRoot(t)
+		step := stepWithRun(t, jobNode(t, root, "build"), `git archive --format=tar "$GITHUB_SHA"`)
+		run := requireMappingValue(t, step, "run")
+		run.Value = strings.Replace(run.Value, "  scripts/releaseworkflow/main_test.go | tar -xf -", "  scripts/releaseworkflow/main_test.go \\\n  pkg/pixiv/other_test.go | tar -xf -", 1)
+		if err := checkRecoveryPolicy(root); err == nil {
+			t.Fatal("release recovery policy accepted an extra overlay path")
+		}
+	})
 }
 
 // Windows 的 Go+cgo 质量门和最终 binary 必须统一使用 Clang+LLD，不能只修某个 step。
@@ -399,7 +411,7 @@ func TestCheckRecoveryPolicyRejectsRecoveryTrustMutations(t *testing.T) {
 		}},
 		{name: "overlay writes production source", mutate: func(t *testing.T, root *yaml.Node) {
 			step := stepWithRun(t, jobNode(t, root, "build"), `git archive --format=tar "$GITHUB_SHA"`)
-			replaceRunFragment(t, step, "internal/cli/account_test.go", "internal/cli/account.go")
+			replaceRunFragment(t, step, "pkg/pixiv/account_external_test.go", "pkg/pixiv/account.go")
 		}},
 		{name: "production source switches to workflow sha", mutate: func(t *testing.T, root *yaml.Node) {
 			appendRunStep(t, jobNode(t, root, "build"), "Bypass immutable tag", `git checkout "$GITHUB_SHA"`)


### PR DESCRIPTION
## Summary

- 收敛 v0.2.0 recovery test-only overlay 至 tag 与默认分支实际不同的四条审计路径
- 同步 workflow、canonical verifier 和缺失/额外路径拒绝测试
- 保持 production build、不可变 tag 与发布信任链不变

## Verification

- ?   	github.com/FlanChanXwO/pixiv-cli/cmd/pixiv	[no test files]
ok  	github.com/FlanChanXwO/pixiv-cli/internal/application	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/bootstrap	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/buildinfo	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/cli	(cached)
?   	github.com/FlanChanXwO/pixiv-cli/internal/common/constants	[no test files]
ok  	github.com/FlanChanXwO/pixiv-cli/internal/config	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/download	2.521s
ok  	github.com/FlanChanXwO/pixiv-cli/internal/download/staticlib	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/mcpserver	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/pixiv	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/pixiv/appapi	(cached)
?   	github.com/FlanChanXwO/pixiv-cli/internal/pixiv/model	[no test files]
ok  	github.com/FlanChanXwO/pixiv-cli/internal/pixiv/oauth	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/pixiv/resource	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/pixiv/webapi	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/storage/auth	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/update	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/utils	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/utils/files	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/utils/media	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/utils/parse	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/utils/text	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/internal/utils/uri	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/pkg/pixiv	(cached)
?   	github.com/FlanChanXwO/pixiv-cli/scripts/homebrewformula	[no test files]
ok  	github.com/FlanChanXwO/pixiv-cli/scripts/licensebundle	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/scripts/nativeevidence	12.217s
ok  	github.com/FlanChanXwO/pixiv-cli/scripts/platformsmokeworkflow	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/scripts/releaseassets	1.621s
ok  	github.com/FlanChanXwO/pixiv-cli/scripts/releaseworkflow	(cached)
ok  	github.com/FlanChanXwO/pixiv-cli/test/e2e	15.952s
- ok  	github.com/FlanChanXwO/pixiv-cli/scripts/releaseworkflow	0.599s
- 
- 临时 detached v0.2.0 worktree overlay 精确复现（4 条 diff、无 cached diff）
- pre-commit

等待六平台 CI 通过后，再从 main dispatch 。