### PR TITLE
fix: identify GitHub release update requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - `pixiv search` 新增 `--rating`、`--type` 与 `--ai-type` 本地结果过滤；带 `--limit`/`--page` 时会按匹配结果继续读取 opaque cursor。
 
+### Fixed
+
+- 修复显式与自动更新检查未向 GitHub Releases API 发送项目识别性 `User-Agent` 而可能收到 HTTP 403 的兼容性问题。
+
 ## [0.2.0] - 2026-07-13
 
 ### Added

--- a/goal-1/tasks.md
+++ b/goal-1/tasks.md
@@ -32,10 +32,10 @@
 
 ## T03b — 对齐 protected release Environment 与受审计 main recovery dispatch
 
-- 状态：未完成
-- 实际：
-- 证据：
-- 风险/下一步：
+- 状态：完成
+- 实际：在 GitHub `release` Environment 的 custom deployment branch policies 中新增精确 `main` branch 规则；保留既有 `v*` tag 规则、required reviewer 及 `prevent_self_review=false`，未更改 secrets、环境名或 workflow。
+- 证据：GitHub API 创建 policy `54575656`（`main` / `branch`）；复查显示 policy 集合仅为 `main` branch 与 `v*` tag，Environment 仍含 required_reviewers 和 branch_policy protection rules；`main` 的 GitHub branch 元数据为 `protected=true`。
+- 风险/下一步：需重新从 main dispatch immutable `v0.2.0`；publish 应进入 required reviewer gate，而非 runner 前 branch policy 拒绝。随后验收签名 Release、Homebrew 与更新检查；不得删除这两条 policy 或绕过 reviewer。
 
 ## C01 — 集中检查：恢复链路、tag 不变性、文档与外部发布证据
 

--- a/goal-1/tasks.md
+++ b/goal-1/tasks.md
@@ -19,9 +19,9 @@
 ## T03 — 审查 recovery 修改并 dispatch/验收 v0.2.0 Release
 
 - 状态：待修复
-- 实际：recovery PR #4 已合并至 main；审计 recovery run 已从不可变 `v0.2.0` tag 启动，但六个平台均在覆盖层步骤失败，未创建 Release。
-- 证据：GitHub Actions `29304765177`（failure）。逐字复现其 overlay 后，实际 diff 仅为 `.github/workflows/release.yml`、`pkg/pixiv/account_external_test.go`、`scripts/releaseworkflow/main.go`、`scripts/releaseworkflow/main_test.go` 四项，而 workflow 的严格断言仍要求历史遗留的 17 项全集；失败发生在 Go 测试前，故与平台或 Windows ACL 无关。
-- 风险/下一步：新增 T03a 以把审计白名单和运行时断言改为同一个、基于实际 tag-to-main 差异的最小集合；修复必须继续不移动 tag，且经实现/规格/质量三阶段审查和多平台 CI 后才可重新 dispatch。
+- 实际：recovery PR #4 与 overlay 修复 PR #5 已合并至 main。run `29306391898` 已在六个原生 test job 通过 overlay、Go/race/vet/package/pre-commit gate，并在六个隔离 production job 从 immutable tag 成功重建资产；但 publish job 在 runner 分配前被 GitHub Environment branch policy 拒绝，未创建 Release。
+- 证据：`29304765177` 失败由 17/4 overlay 断言差异引起，已由 T03a 修复；PR #5 的 quality 与六平台 CI 全绿。run `29306391898` 的 validate、六个 build 和六个 build_production 均成功；`Sign and publish the GitHub Release`（job `87002181764`）无 steps、无 runner、failure。GitHub API 显示 `release` environment custom branch policy 唯一为 tag `v*`，而 workflow dispatch 的安全约束要求 `main`，形成确定性冲突。
+- 风险/下一步：新增 T03b，以最小 Environment 配置变更允许受保护 `main` 进入已有人审的 release environment；随后重新 dispatch 同一 immutable tag。不得移动 tag、删除 release policy 或绕过 required reviewer。
 
 ## T03a — 收敛 recovery overlay 至实际最小审计差异并复验 policy
 
@@ -29,6 +29,13 @@
 - 实际：将 test-only recovery overlay 的 archive、工作树 diff 断言和 Go canonical verifier 同步收敛为 tag 与当前默认分支实际不同的四条路径；移除遗留的两条 `git add -N`，并把聚焦策略测试改为精确四路径命令、逐条缺失和额外路径拒绝。
 - 证据：提交 `59105ed`；TDD RED `go test ./scripts/releaseworkflow -run '^TestCheckRecoveryPolicyRequiresExactFourPathOverlay$' -count=1` 在旧 17 条命令下失败，GREEN 后通过；`go test ./scripts/releaseworkflow -count=1`、`sh scripts/test-release-workflow.sh`、`go test ./...`、`git diff --check origin/main..HEAD` 和 pre-commit 均通过。临时 detached `v0.2.0` worktree 从 `origin/main` archive 四条路径后，`git diff --name-only` 精确等于该集合且 cached diff 为空。规格审查与质量审查均批准。
 - 风险/下一步：仍需把修复推送、通过六平台 PR CI，并从默认分支重新 dispatch `release_tag=v0.2.0`；tag 保持不可变，生产构建隔离仍待远端实际 run 验证。
+
+## T03b — 对齐 protected release Environment 与受审计 main recovery dispatch
+
+- 状态：未完成
+- 实际：
+- 证据：
+- 风险/下一步：
 
 ## C01 — 集中检查：恢复链路、tag 不变性、文档与外部发布证据
 

--- a/goal-1/tasks.md
+++ b/goal-1/tasks.md
@@ -19,9 +19,9 @@
 ## T03 — 审查 recovery 修改并 dispatch/验收 v0.2.0 Release
 
 - 状态：待修复
-- 实际：recovery PR #4 与 overlay 修复 PR #5 已合并至 main。run `29306391898` 已在六个原生 test job 通过 overlay、Go/race/vet/package/pre-commit gate，并在六个隔离 production job 从 immutable tag 成功重建资产；但 publish job 在 runner 分配前被 GitHub Environment branch policy 拒绝，未创建 Release。
-- 证据：`29304765177` 失败由 17/4 overlay 断言差异引起，已由 T03a 修复；PR #5 的 quality 与六平台 CI 全绿。run `29306391898` 的 validate、六个 build 和六个 build_production 均成功；`Sign and publish the GitHub Release`（job `87002181764`）无 steps、无 runner、failure。GitHub API 显示 `release` environment custom branch policy 唯一为 tag `v*`，而 workflow dispatch 的安全约束要求 `main`，形成确定性冲突。
-- 风险/下一步：新增 T03b，以最小 Environment 配置变更允许受保护 `main` 进入已有人审的 release environment；随后重新 dispatch 同一 immutable tag。不得移动 tag、删除 release policy 或绕过 required reviewer。
+- 实际：recovery PR #4 与 overlay 修复 PR #5 已合并至 main；T03b 对齐 Environment 后，run `29307406643` 完成并成功公开 v0.2.0 Release、四平台验证 Homebrew formula 与 tap 部署。发布产物、tag 与公式均已验收，但实际 CLI `update --check --json` 仍被 GitHub API 403 拒绝。
+- 证据：`29304765177` 失败由 17/4 overlay 差异引起，已由 T03a 修复；`29306391898` 的 publish job 由 Environment branch policy 拒绝，已由 T03b 修复。`29307406643` 的 validate、六个 build、六个 build_production、release publish、四个 Homebrew verify 与 tap deploy 均为 success；Release `v0.2.0` 为非 draft/non-prerelease，含六平台 archive 与 `checksums.{txt,json}`，tag commit 仍为 `329711121588d9f054fb3d15540bb0fd6c134e42`。`homebrew-tap` 的 `Formula/pixiv-cli.rb` version/URL/SHA 与 Release 对齐，commit `710f997`。但以 v0.2.0 buildinfo 运行 `pixiv update --check --json` 得 `GitHub Releases ... HTTP 403 Forbidden`；同端点带 User-Agent curl 返回 HTTP 200、匿名配额剩余 57，且 `internal/update/releases.go` 的请求仅设 ETag，未设 User-Agent。
+- 风险/下一步：新增 T03c，补齐 GitHub Releases 请求 User-Agent 的聚焦回归与实现；修复后需要完整 CI 和对已发布 v0.2.0 的 update-check 兼容性策略评估，不能重写 immutable tag 或 Release。
 
 ## T03a — 收敛 recovery overlay 至实际最小审计差异并复验 policy
 
@@ -36,6 +36,13 @@
 - 实际：在 GitHub `release` Environment 的 custom deployment branch policies 中新增精确 `main` branch 规则；保留既有 `v*` tag 规则、required reviewer 及 `prevent_self_review=false`，未更改 secrets、环境名或 workflow。
 - 证据：GitHub API 创建 policy `54575656`（`main` / `branch`）；复查显示 policy 集合仅为 `main` branch 与 `v*` tag，Environment 仍含 required_reviewers 和 branch_policy protection rules；`main` 的 GitHub branch 元数据为 `protected=true`。
 - 风险/下一步：需重新从 main dispatch immutable `v0.2.0`；publish 应进入 required reviewer gate，而非 runner 前 branch policy 拒绝。随后验收签名 Release、Homebrew 与更新检查；不得删除这两条 policy 或绕过 reviewer。
+
+## T03c — 修复 GitHub Releases update check 的 User-Agent 兼容性
+
+- 状态：未完成
+- 实际：
+- 证据：
+- 风险/下一步：
 
 ## C01 — 集中检查：恢复链路、tag 不变性、文档与外部发布证据
 

--- a/goal-1/tasks.md
+++ b/goal-1/tasks.md
@@ -39,10 +39,10 @@
 
 ## T03c — 修复 GitHub Releases update check 的 User-Agent 兼容性
 
-- 状态：未完成
-- 实际：
-- 证据：
-- 风险/下一步：
+- 状态：完成
+- 实际：给 GitHub Releases 每个分页请求加入固定、非敏感 `User-Agent: pixiv-cli`，保持 ETag、缓存、分页、proxy、timeout、错误和 fallback 语义不变；新增经公开 `GitHubReleaseClient.Check` 的首页/next-page 回归，并更新 Unreleased changelog。
+- 证据：提交 `3b46b9f`；TDD RED 显示默认 Go User-Agent/403，GREEN `go test ./internal/update -run '^TestGitHubReleaseClientUsesStableUserAgentForEveryReleasePage$' -count=1`、`go test ./internal/update -count=1`、`go test ./internal/cli -count=1`、`go test ./...`、pre-commit 和 diff check 全通过；规格与质量审查批准。将正式 v0.2.0 buildinfo 编入临时 binary，在隔离 HOME/cache 下连续两次 `pixiv update --check --json` 均返回 source release、latest `v0.2.0`、`update_available=false`，第二次覆盖 ETag cache 重验证。
+- 风险/下一步：不可变 v0.2.0 资产不包含该源码修复；必须把修复经 PR CI 合并，使后续 v0.3.0 包含。T03 的 release/Homebrew/tag 已完成，更新修复的公开分发留待 v0.3.0 Release。
 
 ## C01 — 集中检查：恢复链路、tag 不变性、文档与外部发布证据
 

--- a/internal/update/releases.go
+++ b/internal/update/releases.go
@@ -18,7 +18,9 @@ import (
 const (
 	defaultGitHubAPIBaseURL = "https://api.github.com"
 	defaultGitHubRepository = "FlanChanXwO/pixiv-cli"
-	releaseCacheFilename    = "github-releases.json"
+	// githubReleaseUserAgent 让匿名 Releases 请求满足 GitHub 的可识别客户端要求，且不包含版本或用户信息。
+	githubReleaseUserAgent = "pixiv-cli"
+	releaseCacheFilename   = "github-releases.json"
 	// releaseCacheSchemaVersion 2 起缓存页保留 Release assets；旧 schema 不能接受 304，
 	// 否则显式 self-update 会永久看到缺少资产，直到用户手动删除缓存。
 	releaseCacheSchemaVersion = 2
@@ -264,6 +266,7 @@ func (c *GitHubReleaseClient) fetchReleasePage(ctx context.Context, pageURL *url
 	if err != nil {
 		return releaseCachePage{}, nil, fmt.Errorf("create GitHub Releases request: %w", err)
 	}
+	request.Header.Set("User-Agent", githubReleaseUserAgent)
 	if hasCachedPage && cachedPage.ETag != "" {
 		request.Header.Set("If-None-Match", cachedPage.ETag)
 	}

--- a/internal/update/releases_test.go
+++ b/internal/update/releases_test.go
@@ -55,6 +55,50 @@ func TestGitHubReleaseClientSelectsLatestStableRelease(t *testing.T) {
 	}
 }
 
+func TestGitHubReleaseClientUsesStableUserAgentForEveryReleasePage(t *testing.T) {
+	const wantUserAgent = "pixiv-cli"
+	requests := make(map[string]int)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != wantUserAgent {
+			t.Errorf("User-Agent for %q = %q, want %q", r.URL.RequestURI(), got, wantUserAgent)
+			http.Error(w, "missing or incorrect User-Agent", http.StatusForbidden)
+			return
+		}
+		requests[r.URL.RequestURI()]++
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "":
+			w.Header().Set("Link", "<"+server.URL+"/repos/FlanChanXwO/pixiv-cli/releases?page=2>; rel=\"next\"")
+			fmt.Fprint(w, `[{"tag_name":"v1.0.0","draft":false,"prerelease":false}]`)
+		case "2":
+			fmt.Fprint(w, `[{"tag_name":"v1.0.1","draft":false,"prerelease":false}]`)
+		default:
+			t.Fatalf("unexpected release page %q", r.URL.RequestURI())
+		}
+	}))
+	defer server.Close()
+
+	client, err := update.NewGitHubReleaseClient(update.ReleaseClientOptions{
+		APIBaseURL: server.URL,
+		CacheDir:   t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("NewGitHubReleaseClient() error = %v", err)
+	}
+
+	result, err := client.Check(context.Background(), update.ReleaseCheckOptions{})
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if result.Release == nil || result.Release.TagName != "v1.0.1" {
+		t.Fatalf("Check() release = %#v, want v1.0.1 from the second page", result.Release)
+	}
+	if requests["/repos/FlanChanXwO/pixiv-cli/releases"] != 1 || requests["/repos/FlanChanXwO/pixiv-cli/releases?page=2"] != 1 {
+		t.Fatalf("release page requests = %#v, want one request for each page", requests)
+	}
+}
+
 func TestGitHubReleaseClientCarriesSelectedReleaseAssets(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

- 给 GitHub Releases 每个分页请求加入固定、非敏感的 `User-Agent: pixiv-cli`
- 覆盖首页与分页请求的 403 回归场景
- 记录 update check 的 GitHub API 兼容性修复

## Verification

- `go test ./...`
- `go test ./internal/update -count=1`
- `go test ./internal/cli -count=1`
- pre-commit
- 正式 v0.2.0 buildinfo 的临时二进制在隔离 HOME/cache 下连续两次 `pixiv update --check --json` 均返回 latest v0.2.0 / no update

不改 v0.2.0 tag 或已发布资产；修复将随 v0.3.0 分发。