### PR TITLE
fix(release): pin native Rust provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
       contents: read
     env:
       CC: ${{ matrix.cc }}
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust_toolchain }}
       # Git for Windows 会按 runner 默认值把 immutable tag 的 Go 源码转换为 CRLF；质量门必须
       # 检查 Git blob 的 LF bytes，避免 gofmt 将 checkout 转换误报为源码格式错误。
       GIT_CONFIG_COUNT: '1'
@@ -87,36 +88,42 @@ jobs:
             goos: darwin
             goarch: amd64
             rust_target: x86_64-apple-darwin
+            rust_toolchain: '1.96.0'
             artifact: darwin-amd64
             cc: clang
           - runner: macos-15
             goos: darwin
             goarch: arm64
             rust_target: aarch64-apple-darwin
+            rust_toolchain: '1.96.1'
             artifact: darwin-arm64
             cc: clang
           - runner: ubuntu-24.04
             goos: linux
             goarch: amd64
             rust_target: x86_64-unknown-linux-gnu
+            rust_toolchain: '1.96.1'
             artifact: linux-amd64
             cc: gcc
           - runner: ubuntu-24.04-arm
             goos: linux
             goarch: arm64
             rust_target: aarch64-unknown-linux-gnu
+            rust_toolchain: '1.96.1'
             artifact: linux-arm64
             cc: gcc
           - runner: windows-2025
             goos: windows
             goarch: amd64
             rust_target: x86_64-pc-windows-msvc
+            rust_toolchain: '1.96.0'
             artifact: windows-amd64
             cc: clang -fuse-ld=lld
           - runner: windows-11-arm
             goos: windows
             goarch: arm64
             rust_target: aarch64-pc-windows-msvc
+            rust_toolchain: '1.96.1'
             artifact: windows-arm64
             cc: clang -fuse-ld=lld
     steps:
@@ -132,9 +139,9 @@ jobs:
       - name: Validate the exact immutable release source
         shell: bash
         run: go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"
-      - name: Install the native Rust target
+      - name: Install the pinned native Rust toolchain
         shell: bash
-        run: rustup target add '${{ matrix.rust_target }}'
+        run: rustup toolchain install '${{ matrix.rust_toolchain }}' --profile minimal --component 'clippy,rustfmt' --target '${{ matrix.rust_target }}' --no-self-update
       - name: Check vendored Rust sources
         shell: bash
         run: sh scripts/test-rust-vendor.sh
@@ -198,6 +205,7 @@ jobs:
       contents: read
     env:
       CC: ${{ matrix.cc }}
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust_toolchain }}
     strategy:
       fail-fast: false
       matrix:
@@ -206,36 +214,42 @@ jobs:
             goos: darwin
             goarch: amd64
             rust_target: x86_64-apple-darwin
+            rust_toolchain: '1.96.0'
             artifact: darwin-amd64
             cc: clang
           - runner: macos-15
             goos: darwin
             goarch: arm64
             rust_target: aarch64-apple-darwin
+            rust_toolchain: '1.96.1'
             artifact: darwin-arm64
             cc: clang
           - runner: ubuntu-24.04
             goos: linux
             goarch: amd64
             rust_target: x86_64-unknown-linux-gnu
+            rust_toolchain: '1.96.1'
             artifact: linux-amd64
             cc: gcc
           - runner: ubuntu-24.04-arm
             goos: linux
             goarch: arm64
             rust_target: aarch64-unknown-linux-gnu
+            rust_toolchain: '1.96.1'
             artifact: linux-arm64
             cc: gcc
           - runner: windows-2025
             goos: windows
             goarch: amd64
             rust_target: x86_64-pc-windows-msvc
+            rust_toolchain: '1.96.0'
             artifact: windows-amd64
             cc: clang -fuse-ld=lld
           - runner: windows-11-arm
             goos: windows
             goarch: arm64
             rust_target: aarch64-pc-windows-msvc
+            rust_toolchain: '1.96.1'
             artifact: windows-arm64
             cc: clang -fuse-ld=lld
     steps:
@@ -252,9 +266,9 @@ jobs:
       - name: Validate the exact immutable production source
         shell: bash
         run: go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"
-      - name: Install the native Rust target
+      - name: Install the pinned native Rust toolchain
         shell: bash
-        run: rustup target add '${{ matrix.rust_target }}'
+        run: rustup toolchain install '${{ matrix.rust_toolchain }}' --profile minimal --target '${{ matrix.rust_target }}' --no-self-update
       - name: Rebuild the selected static library from the immutable tag
         shell: bash
         run: |

--- a/docs/adr/0007-platform-staticlibs-for-supported-source-builds.md
+++ b/docs/adr/0007-platform-staticlibs-for-supported-source-builds.md
@@ -23,6 +23,10 @@ source 的关系保留给发布审计，需要可重算的 source digest、每�
   `staticlib/manifest.json` 必须同时记录 six target、path、SHA-256 与 Rust source digest。
 - `scripts/build-staticlibs.sh` 仅在同一份 source 成功取得全部六个真实库后写 manifest。单 target
   生成会使旧 manifest 失效，不能被误用为跨平台发布证明。
+- release workflow 必须把生成 committed staticlib 的 Rust toolchain 作为 target provenance 固定：
+  `x86_64-apple-darwin` 与 `x86_64-pc-windows-msvc` 使用 `1.96.0`，其余四个 release target 使用
+  `1.96.1`。test 与 production job 必须从同一受审计 matrix 选择版本，禁止使用可移动的 `stable`
+  或 runner 默认值；production 仍只 checkout immutable tag，toolchain pin 不构成源码 overlay。
 - Rust `target/` 始终是忽略的机器产物；已验证 staticlib 与 manifest 是可审计发布输入，不能忽略。
 - production ugoira 路径只使用 Rust encoder；`ffmpeg` 仅保留给显式启用的开发质量对照，不作为运行
   时 fallback。
@@ -38,5 +42,8 @@ source 的关系保留给发布审计，需要可重算的 source digest、每�
 - run `29192425899` 已取得六个真实 staticlib、同源 manifest 与每平台 GIF/APNG/cgo smoke 证据，
   并经 fail-closed consolidation 回填；source build 与 future exact-tag `go install` 会消费这些
   committed libraries。正式 Release 与安装验收仍由后续发布任务独立证明。
+- 上述 per-target pin 是当前六库及 v0.3.0 immutable-tag recovery 的实际 provenance。后续 Rust
+  升级必须从同一受审计 source 成套重建、链接并 smoke 验证六目标，同时更新 staticlib、manifest、
+  native evidence 与 release matrix；不能单独漂移某个 target 或用新编译器覆盖既有 tag 的 library。
 - Cargo `--locked --offline` 现在经 crate 内 source replacement 使用完整 vendor 闭包；空 Cargo cache
   的 metadata/build/test 与六 target 许可证检查证明 native Rust 输入不依赖开发机或 runner registry cache。

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,6 +42,15 @@ Cargo 输入生成 target library；只有同一次成功得到全部六个真�
 `consolidate` 又在本地重验 source identity、staticlib/binary/archive SHA 和全部 archive members 后
 生成提交输入。`sh scripts/build.sh` 现会先校验完整 manifest，再在具备本机 cgo/C linker 时构建。
 
+这些 committed library 的编译器 provenance 按 target 固定，而不是使用可移动的 runner 默认
+toolchain：`x86_64-apple-darwin` 与 `x86_64-pc-windows-msvc` 来自 Rust `1.96.0`；
+`aarch64-apple-darwin`、`aarch64-pc-windows-msvc`、`x86_64-unknown-linux-gnu` 与
+`aarch64-unknown-linux-gnu` 来自 Rust `1.96.1`。release test 与 production matrix 都必须携带这份
+精确映射，并通过 `RUSTUP_TOOLCHAIN` 和带 `--no-self-update` 的 `rustup toolchain install` 使用它；
+不能让 runner image 的 `stable` 更新改变重建 bytes。该映射记录当前六库及 v0.3.0 recovery 的来源，
+不是允许永久混用工具链的惯例。后续升级 Rust 时必须从同一受审计 source 完整重建、链接并 smoke
+验证六目标，同时更新六库、manifest、native evidence 与 release matrix；不得只更新单个平台的 pin。
+
 可在具备目标工具链的受控环境运行：
 
 ```bash
@@ -294,6 +303,12 @@ release artifact。该 job 成功后，独立的新 runner
 `pkg/pixiv/account_external_test.go`；它是该次已完成恢复的历史证据，不能被改写为当前工作树路径。当前
 workflow 只覆盖顶层 `pixiv/account_external_test.go`，用于之后采用顶层 SDK 的新 tag。
 
+恢复 workflow 的定义可以来自受审计的默认分支，但 production worktree 仍只含 tag bytes。为重现
+v0.3.0 tag 已提交 staticlib，test 与 production job 从相同六目标 matrix 读取上述 per-target Rust
+toolchain，并在执行 tag 自带的构建脚本前精确安装；这属于 runner 构建环境约束，不把 main 文件或新库
+覆盖进 production。重建库必须继续与 tag blob 通过 `git diff --exit-code` 的 byte-for-byte 检查；
+toolchain pin 不能用来替换 tag staticlib、恢复 manifest、放宽 diff 或移动 tag。
+
 `sh scripts/test-release-workflow.sh` 启动 `scripts/releaseworkflow` 的 YAML AST policy，而不是依赖
 文本排版或行号。它精确检查 tag trigger、八份 job 的权限/依赖、六个 test/production runner matrix、每一个
 `uses` 的 40 位 SHA，以及 publish 的 SemVer channel 调用。默认分支 ancestry 必须在无
@@ -302,8 +317,8 @@ workflow 只覆盖顶层 `pixiv/account_external_test.go`，用于之后采用�
 拒绝 required job、默认分支 ancestry step 与 quality gate 的 `continue-on-error` 或条件 `if`；validate
 与 build checkout 也必须显式 `persist-credentials: false`。为避免 shell 控制流隐藏 gate，每项质量
 检查都是唯一的单命令 `bash` step：policy 精确验证其 run、crate cwd（Rust gate）和 shell，并拒绝
-未审计的 `env`、`defaults` 或其它 step 字段。唯一允许的变量是 root 的 `RELEASE_TAG` 和 build
-matrix 绑定的 `CC`；Windows 必须使用 `clang -fuse-ld=lld` 链接 MSVC Rust staticlib，避免 MinGW
+未审计的 `env`、`defaults` 或其它 step 字段。唯一允许的变量是 root 的 `RELEASE_TAG`，以及 build
+matrix 绑定的 `CC` 与 per-target `RUSTUP_TOOLCHAIN`；Windows 必须使用 `clang -fuse-ld=lld` 链接 MSVC Rust staticlib，避免 MinGW
 GCC 与 `.lib` ABI 混用。解析器同时 fail-closed 地拒绝 YAML alias、merge key 和任何重复 mapping key，
 因此 GitHub 的覆盖或工作目录语义不会与本地检查分叉。validate 固定 checkout 受审计的 workflow SHA；
 其余生产 source checkout 固定为精确 tag。尤其

--- a/scripts/releaseworkflow/main.go
+++ b/scripts/releaseworkflow/main.go
@@ -21,15 +21,15 @@ const canonicalCheckoutAction = "actions/checkout@34e114876b0b11c390a56381ad16eb
 // （包括 bare、toJSON(secrets)、dot 和 bracket）都视为凭据引用，不能依赖具体访问语法。
 var secretReferencePattern = regexp.MustCompile(`(?is)\$\{\{[^}]*\bsecrets\b[^}]*\}\}`)
 
-// releaseMatrixTargets 将 runner、Go 平台、Rust target 和 release asset 名称绑为同一集合，
-// 防止任一字段的局部改动让六平台发布遗漏或错配。
+// releaseMatrixTargets 将 runner、Go 平台、Rust target、生成已提交 staticlib 的 Rust toolchain
+// 和 release asset 名称绑为同一集合，防止任一字段的局部改动让六平台发布遗漏或错配。
 var releaseMatrixTargets = map[string]struct{}{
-	"macos-15-intel|darwin|amd64|x86_64-apple-darwin|darwin-amd64|clang":                    {},
-	"macos-15|darwin|arm64|aarch64-apple-darwin|darwin-arm64|clang":                         {},
-	"ubuntu-24.04|linux|amd64|x86_64-unknown-linux-gnu|linux-amd64|gcc":                     {},
-	"ubuntu-24.04-arm|linux|arm64|aarch64-unknown-linux-gnu|linux-arm64|gcc":                {},
-	"windows-2025|windows|amd64|x86_64-pc-windows-msvc|windows-amd64|clang -fuse-ld=lld":    {},
-	"windows-11-arm|windows|arm64|aarch64-pc-windows-msvc|windows-arm64|clang -fuse-ld=lld": {},
+	"macos-15-intel|darwin|amd64|x86_64-apple-darwin|1.96.0|darwin-amd64|clang":                    {},
+	"macos-15|darwin|arm64|aarch64-apple-darwin|1.96.1|darwin-arm64|clang":                         {},
+	"ubuntu-24.04|linux|amd64|x86_64-unknown-linux-gnu|1.96.1|linux-amd64|gcc":                     {},
+	"ubuntu-24.04-arm|linux|arm64|aarch64-unknown-linux-gnu|1.96.1|linux-arm64|gcc":                {},
+	"windows-2025|windows|amd64|x86_64-pc-windows-msvc|1.96.0|windows-amd64|clang -fuse-ld=lld":    {},
+	"windows-11-arm|windows|arm64|aarch64-pc-windows-msvc|1.96.1|windows-arm64|clang -fuse-ld=lld": {},
 }
 
 // homebrewMatrixTargets 绑定四个 Homebrew 验证 runner 与其实际平台，避免仅在单一
@@ -46,6 +46,8 @@ const (
 	uploadArtifactAction   = "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
 	downloadArtifactAction = "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
 	githubKnownHostsLine   = "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl\n"
+	testRustInstallCommand = "rustup toolchain install '${{ matrix.rust_toolchain }}' --profile minimal --component 'clippy,rustfmt' --target '${{ matrix.rust_target }}' --no-self-update"
+	prodRustInstallCommand = "rustup toolchain install '${{ matrix.rust_toolchain }}' --profile minimal --target '${{ matrix.rust_target }}' --no-self-update"
 )
 
 func main() {
@@ -243,8 +245,8 @@ func checkRecoveryPolicy(root *yaml.Node) error {
 		return errors.New("workflow must have a build job for recovery policy")
 	}
 	buildEnv, ok := mappingValue(build, "env")
-	if !ok || requireOnlyMappingKeys(buildEnv, "CC", "GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0") != nil || requireScalar(buildEnv, "CC", "${{ matrix.cc }}") != nil || requireScalar(buildEnv, "GIT_CONFIG_COUNT", "1") != nil || requireScalar(buildEnv, "GIT_CONFIG_KEY_0", "core.autocrlf") != nil || requireScalar(buildEnv, "GIT_CONFIG_VALUE_0", "false") != nil {
-		return errors.New("build job must bind the audited compiler and immutable source byte checkout")
+	if !ok || requireOnlyMappingKeys(buildEnv, "CC", "RUSTUP_TOOLCHAIN", "GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0") != nil || requireScalar(buildEnv, "CC", "${{ matrix.cc }}") != nil || requireScalar(buildEnv, "RUSTUP_TOOLCHAIN", "${{ matrix.rust_toolchain }}") != nil || requireScalar(buildEnv, "GIT_CONFIG_COUNT", "1") != nil || requireScalar(buildEnv, "GIT_CONFIG_KEY_0", "core.autocrlf") != nil || requireScalar(buildEnv, "GIT_CONFIG_VALUE_0", "false") != nil {
+		return errors.New("build job must bind the audited compiler, Rust toolchain, and immutable source byte checkout")
 	}
 	matrix := mustMappingPath(build, "strategy", "matrix")
 	if matrix == nil {
@@ -349,7 +351,7 @@ func requireCanonicalBuildSteps(steps []*yaml.Node) error {
 		directory string
 	}{
 		{name: "Validate the exact immutable release source", command: `go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"`},
-		{name: "Install the native Rust target", command: "rustup target add '${{ matrix.rust_target }}'"},
+		{name: "Install the pinned native Rust toolchain", command: testRustInstallCommand},
 		{name: "Check vendored Rust sources", command: "sh scripts/test-rust-vendor.sh"},
 		{name: "Check Rust formatting from vendored sources", command: "cargo fmt --check", directory: "internal/download/ugoira_rs"},
 		{name: "Lint vendored Rust sources", command: "cargo clippy --locked --offline --all-targets -- -D warnings", directory: "internal/download/ugoira_rs"},
@@ -722,8 +724,8 @@ func checkProductionBuildJob(job *yaml.Node) error {
 		return fmt.Errorf("build_production job: %w", err)
 	}
 	env, ok := mappingValue(job, "env")
-	if !ok || requireOnlyMappingKeys(env, "CC") != nil || requireScalar(env, "CC", "${{ matrix.cc }}") != nil {
-		return errors.New("build_production job must bind CC from the audited matrix")
+	if !ok || requireOnlyMappingKeys(env, "CC", "RUSTUP_TOOLCHAIN") != nil || requireScalar(env, "CC", "${{ matrix.cc }}") != nil || requireScalar(env, "RUSTUP_TOOLCHAIN", "${{ matrix.rust_toolchain }}") != nil {
+		return errors.New("build_production job must bind CC and the Rust toolchain from the audited release policy")
 	}
 	strategy, ok := mappingValue(job, "strategy")
 	if !ok || requireOnlyMappingKeys(strategy, "fail-fast", "matrix") != nil || requireScalar(strategy, "fail-fast", "false") != nil {
@@ -746,7 +748,7 @@ func checkProductionBuildJob(job *yaml.Node) error {
 	if err := requireCanonicalNamedRunStep(steps[2], "Validate the exact immutable production source", `go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"`); err != nil {
 		return err
 	}
-	if err := requireCanonicalNamedRunStep(steps[3], "Install the native Rust target", "rustup target add '${{ matrix.rust_target }}'"); err != nil {
+	if err := requireCanonicalNamedRunStep(steps[3], "Install the pinned native Rust toolchain", prodRustInstallCommand); err != nil {
 		return err
 	}
 	if err := requireProductionRebuildStep(steps[4]); err != nil || requireScalar(steps[4], "name", "Rebuild the selected static library from the immutable tag") != nil {
@@ -895,11 +897,11 @@ func checkReleaseMatrix(matrix *yaml.Node) error {
 		if entry.Kind != yaml.MappingNode {
 			return errors.New("build matrix must contain exactly the six release targets")
 		}
-		if err := requireOnlyMappingKeys(entry, "runner", "goos", "goarch", "rust_target", "artifact", "cc"); err != nil {
+		if err := requireOnlyMappingKeys(entry, "runner", "goos", "goarch", "rust_target", "rust_toolchain", "artifact", "cc"); err != nil {
 			return errors.New("build matrix entries must contain only the canonical release target fields")
 		}
-		fields := make([]string, 0, 6)
-		for _, key := range []string{"runner", "goos", "goarch", "rust_target", "artifact", "cc"} {
+		fields := make([]string, 0, 7)
+		for _, key := range []string{"runner", "goos", "goarch", "rust_target", "rust_toolchain", "artifact", "cc"} {
 			value, ok := mappingValue(entry, key)
 			if !ok || value.Kind != yaml.ScalarNode {
 				return errors.New("build matrix must contain exactly the six release targets")

--- a/scripts/releaseworkflow/main_test.go
+++ b/scripts/releaseworkflow/main_test.go
@@ -21,6 +21,180 @@ func TestCheckWorkflowRequiresRustFormatGate(t *testing.T) {
 	}
 }
 
+// release staticlib 的字节身份包含 Rust compiler；test gate 与 production rebuild
+// 必须按 target 选择生成对应已提交 staticlib 的精确 toolchain。
+func TestCheckWorkflowRequiresPinnedRustToolchainForReleaseBuilds(t *testing.T) {
+	t.Parallel()
+
+	root := releaseWorkflowRoot(t)
+	wantToolchains := map[string]string{
+		"x86_64-apple-darwin":       "1.96.0",
+		"aarch64-apple-darwin":      "1.96.1",
+		"x86_64-unknown-linux-gnu":  "1.96.1",
+		"aarch64-unknown-linux-gnu": "1.96.1",
+		"x86_64-pc-windows-msvc":    "1.96.0",
+		"aarch64-pc-windows-msvc":   "1.96.1",
+	}
+	for _, test := range []struct {
+		job     string
+		command string
+	}{
+		{
+			job:     "build",
+			command: "rustup toolchain install '${{ matrix.rust_toolchain }}' --profile minimal --component 'clippy,rustfmt' --target '${{ matrix.rust_target }}' --no-self-update",
+		},
+		{
+			job:     "build_production",
+			command: "rustup toolchain install '${{ matrix.rust_toolchain }}' --profile minimal --target '${{ matrix.rust_target }}' --no-self-update",
+		},
+	} {
+		t.Run(test.job, func(t *testing.T) {
+			job := jobNode(t, root, test.job)
+			env := requireMappingValue(t, job, "env")
+			toolchain, ok := mappingValue(env, "RUSTUP_TOOLCHAIN")
+			if !ok {
+				t.Fatalf("%s RUSTUP_TOOLCHAIN is missing", test.job)
+			}
+			if toolchain.Value != "${{ matrix.rust_toolchain }}" {
+				t.Fatalf("%s RUSTUP_TOOLCHAIN = %q, want matrix provenance pin", test.job, toolchain.Value)
+			}
+			if stepIndexWithRunFragment(requireMappingValue(t, job, "steps").Content, test.command) < 0 {
+				t.Fatalf("%s must install the exact pinned Rust toolchain", test.job)
+			}
+
+			gotToolchains := make(map[string]string, len(wantToolchains))
+			matrix := mustMappingPath(job, "strategy", "matrix")
+			include := requireMappingValue(t, matrix, "include")
+			for _, entry := range include.Content {
+				target := requireMappingValue(t, entry, "rust_target").Value
+				gotToolchains[target] = requireMappingValue(t, entry, "rust_toolchain").Value
+			}
+			if len(gotToolchains) != len(wantToolchains) {
+				t.Fatalf("%s pinned Rust target count = %d, want %d", test.job, len(gotToolchains), len(wantToolchains))
+			}
+			for target, want := range wantToolchains {
+				if got := gotToolchains[target]; got != want {
+					t.Errorf("%s Rust toolchain for %s = %q, want %q", test.job, target, got, want)
+				}
+			}
+		})
+	}
+	if err := checkWorkflow(mustMarshalYAML(t, root)); err != nil {
+		t.Fatalf("release workflow policy rejected the pinned Rust toolchain: %v", err)
+	}
+}
+
+func TestCheckWorkflowRejectsReleaseRustToolchainMutations(t *testing.T) {
+	t.Parallel()
+
+	matrixEntry := func(t *testing.T, root *yaml.Node, jobName, rustTarget string) *yaml.Node {
+		t.Helper()
+		matrix := mustMappingPath(jobNode(t, root, jobName), "strategy", "matrix")
+		include := requireMappingValue(t, matrix, "include")
+		for _, entry := range include.Content {
+			if requireMappingValue(t, entry, "rust_target").Value == rustTarget {
+				return entry
+			}
+		}
+		t.Fatalf("%s matrix has no Rust target %s", jobName, rustTarget)
+		return nil
+	}
+
+	for _, test := range []struct {
+		name   string
+		want   string
+		mutate func(t *testing.T, root *yaml.Node)
+	}{
+		{
+			name: "test toolchain env missing",
+			want: "build job must bind the audited compiler, Rust toolchain",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				removeMappingValue(t, requireMappingValue(t, jobNode(t, root, "build"), "env"), "RUSTUP_TOOLCHAIN")
+			},
+		},
+		{
+			name: "production toolchain env is mutable stable",
+			want: "build_production job must bind CC and the Rust toolchain",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				requireMappingValue(t, requireMappingValue(t, jobNode(t, root, "build_production"), "env"), "RUSTUP_TOOLCHAIN").Value = "stable"
+			},
+		},
+		{
+			name: "test matrix toolchain missing",
+			want: "canonical release target fields",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				entry := matrixEntry(t, root, "build", "x86_64-unknown-linux-gnu")
+				removeMappingValue(t, entry, "rust_toolchain")
+			},
+		},
+		{
+			name: "test matrix toolchain drifts",
+			want: "exactly the six release targets",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				entry := matrixEntry(t, root, "build", "x86_64-unknown-linux-gnu")
+				requireMappingValue(t, entry, "rust_toolchain").Value = "1.97.0"
+			},
+		},
+		{
+			name: "production matrix disagrees with test provenance",
+			want: "exactly the six release targets",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				entry := matrixEntry(t, root, "build_production", "x86_64-apple-darwin")
+				requireMappingValue(t, entry, "rust_toolchain").Value = "1.96.1"
+			},
+		},
+		{
+			name: "test install omits components",
+			want: "Install the pinned native Rust toolchain",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				step := stepWithRun(t, jobNode(t, root, "build"), testRustInstallCommand)
+				removeRunFragment(t, step, "--component 'clippy,rustfmt'")
+			},
+		},
+		{
+			name: "test install omits target",
+			want: "Install the pinned native Rust toolchain",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				step := stepWithRun(t, jobNode(t, root, "build"), testRustInstallCommand)
+				removeRunFragment(t, step, "--target '${{ matrix.rust_target }}'")
+			},
+		},
+		{
+			name: "production install omits minimal profile",
+			want: "Install the pinned native Rust toolchain must use the required direct command sequence",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				step := stepWithRun(t, jobNode(t, root, "build_production"), prodRustInstallCommand)
+				removeRunFragment(t, step, "--profile minimal")
+			},
+		},
+		{
+			name: "production install permits rustup self update",
+			want: "Install the pinned native Rust toolchain must use the required direct command sequence",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				step := stepWithRun(t, jobNode(t, root, "build_production"), prodRustInstallCommand)
+				removeRunFragment(t, step, "--no-self-update")
+			},
+		},
+		{
+			name: "production install uses stable instead of matrix provenance",
+			want: "Install the pinned native Rust toolchain must use the required direct command sequence",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				step := stepWithRun(t, jobNode(t, root, "build_production"), prodRustInstallCommand)
+				replaceRunFragment(t, step, "'${{ matrix.rust_toolchain }}'", "stable")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := releaseWorkflowRoot(t)
+			test.mutate(t, root)
+			err := checkWorkflow(mustMarshalYAML(t, root))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("policy error = %v, want rejection containing %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestCheckWorkflowRequiresProductionCacheIsolation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- pin the exact Rust toolchain that produced each committed platform staticlib
- enforce the per-target provenance in release workflow policy and mutation tests
- document immutable-tag recovery and future coordinated toolchain upgrades

## Root cause
The Linux runner image moved from Rust 1.96.1 to 1.97.0 while the v0.3.0 tag staticlibs were built with 1.96.1. Darwin/Windows amd64 libraries were built with 1.96.0, so the fix is intentionally per-target rather than a global pin.

## Safety
- v0.3.0 tag remains immutable
- production still checks out only the tag and performs byte-for-byte staticlib comparison
- recovery overlay and credential boundaries are unchanged

## Verification
- go test ./scripts/releaseworkflow -count=1
- sh scripts/test-release-workflow.sh
- go test ./...
- go test -race ./...
- go vet ./...
- sh scripts/test-rust-vendor.sh
- sh scripts/test-package-release.sh
- pre-commit run --all-files
- git diff --check