### PR TITLE
fix(release): narrow v0.3.0 recovery overlay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,12 +162,10 @@ jobs:
           test -z "$(git diff --cached --name-only)"
           git archive --format=tar "$GITHUB_SHA" -- \
             .github/workflows/release.yml \
-            pixiv/account_external_test.go \
             scripts/releaseworkflow/main.go \
             scripts/releaseworkflow/main_test.go | tar -xf -
           test "$(git diff --name-only)" = "$(printf '%s\n' \
             .github/workflows/release.yml \
-            pixiv/account_external_test.go \
             scripts/releaseworkflow/main.go \
             scripts/releaseworkflow/main_test.go)"
           test -z "$(git diff --cached --name-only)"

--- a/docs/development.md
+++ b/docs/development.md
@@ -293,15 +293,19 @@ GitHub Release。workflow 使用 full-SHA Actions、最小权限及 `release` En
 若不可变 tag 的首次 run 在创建 GitHub Release 前失败，维护者只能从默认分支通过
 `workflow_dispatch` 提交同一个 `release_tag` 进行恢复。validate 会校验该 tag 为 SemVer、存在、
 已包含于默认分支且尚未有 Release；构建与发布始终 checkout 该 tag。恢复 run 可以只在无 Environment
-的六平台 test job 中应用固定白名单的默认分支测试覆盖：当前 release workflow、Windows ACL 所需的
-`pixiv/account_external_test.go`，以及该 workflow 的 canonical verifier 与其测试（共 4 条路径）。覆盖通过
-一次 `git archive` 提取，再逐项核对工作树 diff 与空 cached diff，不能加入任意路径或生产源码，且不生成
-release artifact。该 job 成功后，独立的新 runner
+的六平台 test job 中应用固定白名单的默认分支测试覆盖。v0.2.0 已完成的历史恢复使用四条路径：当时的
+release workflow、位于 `pkg/pixiv/account_external_test.go` 的 Windows ACL 测试，以及 canonical
+verifier 与其测试；这是不可改写的历史证据，不定义后续 tag 的 allowlist。
+
+当前 v0.3.0 tag 已包含与默认分支相同的顶层 `pixiv/account_external_test.go`，质量门直接运行 tag 中的
+测试，不需要也不能再次 overlay。v0.3.0 恢复 allowlist 因而精确收敛为三条实际有 diff 的路径：
+`.github/workflows/release.yml`、`scripts/releaseworkflow/main.go` 与
+`scripts/releaseworkflow/main_test.go`。覆盖通过一次 `git archive` 提取，再逐项核对工作树 diff 与空
+cached diff；重新加入 account test、任意第四路径或生产源码都必须失败，test job 也不生成 release
+artifact。该 job 成功后，独立的新 runner
 才会以 `clean: true` checkout tag、重新构建 selected staticlib 并生成唯一可被 publish 下载的
 `verified-release-*` assets；测试进程对环境变量、PATH 或临时目录的副作用不会进入生产 job。因此它不能用于
-替换生产资产源码、移动 tag，或重发已经存在的 Release。v0.2.0 的不可变 tag 中对应测试仍位于
-`pkg/pixiv/account_external_test.go`；它是该次已完成恢复的历史证据，不能被改写为当前工作树路径。当前
-workflow 只覆盖顶层 `pixiv/account_external_test.go`，用于之后采用顶层 SDK 的新 tag。
+替换生产资产源码、移动 tag，或重发已经存在的 Release。
 
 恢复 workflow 的定义可以来自受审计的默认分支，但 production worktree 仍只含 tag bytes。为重现
 v0.3.0 tag 已提交 staticlib，test 与 production job 从相同六目标 matrix 读取上述 per-target Rust

--- a/scripts/releaseworkflow/main.go
+++ b/scripts/releaseworkflow/main.go
@@ -403,12 +403,10 @@ test -z "$(git diff --name-only)"
 test -z "$(git diff --cached --name-only)"
 git archive --format=tar "$GITHUB_SHA" -- \
   .github/workflows/release.yml \
-  pixiv/account_external_test.go \
   scripts/releaseworkflow/main.go \
   scripts/releaseworkflow/main_test.go | tar -xf -
 test "$(git diff --name-only)" = "$(printf '%s\n' \
   .github/workflows/release.yml \
-  pixiv/account_external_test.go \
   scripts/releaseworkflow/main.go \
   scripts/releaseworkflow/main_test.go)"
 test -z "$(git diff --cached --name-only)"`

--- a/scripts/releaseworkflow/main_test.go
+++ b/scripts/releaseworkflow/main_test.go
@@ -473,8 +473,9 @@ func TestCheckRecoveryPolicyRequiresTrustedReleaseTag(t *testing.T) {
 	}
 }
 
-// v0.2.0 恢复只覆盖 tag 与默认分支之间实际变化的四个审计文件；生产源码仍只来自 tag。
-func TestCheckRecoveryPolicyRequiresExactFourPathOverlay(t *testing.T) {
+// v0.3.0 tag 已包含顶层 account external test；恢复只覆盖 tag 与默认分支之间
+// 实际变化的 workflow 及其 verifier，生产源码仍只来自 tag。
+func TestCheckRecoveryPolicyRequiresExactThreePathOverlay(t *testing.T) {
 	t.Parallel()
 
 	const commands = `set -euo pipefail
@@ -482,18 +483,15 @@ test -z "$(git diff --name-only)"
 test -z "$(git diff --cached --name-only)"
 git archive --format=tar "$GITHUB_SHA" -- \
   .github/workflows/release.yml \
-  pixiv/account_external_test.go \
   scripts/releaseworkflow/main.go \
   scripts/releaseworkflow/main_test.go | tar -xf -
 test "$(git diff --name-only)" = "$(printf '%s\n' \
   .github/workflows/release.yml \
-  pixiv/account_external_test.go \
   scripts/releaseworkflow/main.go \
   scripts/releaseworkflow/main_test.go)"
 test -z "$(git diff --cached --name-only)"`
 	paths := []string{
 		".github/workflows/release.yml",
-		"pixiv/account_external_test.go",
 		"scripts/releaseworkflow/main.go",
 		"scripts/releaseworkflow/main_test.go",
 	}
@@ -501,7 +499,7 @@ test -z "$(git diff --cached --name-only)"`
 	step := stepWithRun(t, jobNode(t, root, "build"), `git archive --format=tar "$GITHUB_SHA"`)
 	run := requireMappingValue(t, step, "run")
 	if run.Value != commands+"\n" {
-		t.Fatalf("recovery overlay command = %q, want exact four-path audited command", run.Value)
+		t.Fatalf("recovery overlay command = %q, want exact three-path audited command", run.Value)
 	}
 	if err := checkRecoveryPolicy(root); err != nil {
 		t.Fatalf("checked-in recovery policy rejected: %v", err)
@@ -518,11 +516,20 @@ test -z "$(git diff --cached --name-only)"`
 			}
 		})
 	}
-	t.Run("extra path added", func(t *testing.T) {
+	t.Run("account external test re-added", func(t *testing.T) {
 		root := releaseWorkflowRoot(t)
 		step := stepWithRun(t, jobNode(t, root, "build"), `git archive --format=tar "$GITHUB_SHA"`)
 		run := requireMappingValue(t, step, "run")
-		run.Value = strings.Replace(run.Value, "  scripts/releaseworkflow/main_test.go | tar -xf -", "  scripts/releaseworkflow/main_test.go \\\n  pkg/pixiv/other_test.go | tar -xf -", 1)
+		run.Value = strings.ReplaceAll(run.Value, "  scripts/releaseworkflow/main.go \\", "  pixiv/account_external_test.go \\\n  scripts/releaseworkflow/main.go \\")
+		if err := checkRecoveryPolicy(root); err == nil {
+			t.Fatal("release recovery policy accepted the redundant account test overlay")
+		}
+	})
+	t.Run("arbitrary fourth path added", func(t *testing.T) {
+		root := releaseWorkflowRoot(t)
+		step := stepWithRun(t, jobNode(t, root, "build"), `git archive --format=tar "$GITHUB_SHA"`)
+		run := requireMappingValue(t, step, "run")
+		run.Value = strings.ReplaceAll(run.Value, "  scripts/releaseworkflow/main.go \\", "  pkg/pixiv/other_test.go \\\n  scripts/releaseworkflow/main.go \\")
 		if err := checkRecoveryPolicy(root); err == nil {
 			t.Fatal("release recovery policy accepted an extra overlay path")
 		}
@@ -585,7 +592,8 @@ func TestCheckRecoveryPolicyRejectsRecoveryTrustMutations(t *testing.T) {
 		}},
 		{name: "overlay writes production source", mutate: func(t *testing.T, root *yaml.Node) {
 			step := stepWithRun(t, jobNode(t, root, "build"), `git archive --format=tar "$GITHUB_SHA"`)
-			replaceRunFragment(t, step, "pixiv/account_external_test.go", "pixiv/account.go")
+			run := requireMappingValue(t, step, "run")
+			run.Value = strings.ReplaceAll(run.Value, "  scripts/releaseworkflow/main.go \\", "  pixiv/account.go \\\n  scripts/releaseworkflow/main.go \\")
 		}},
 		{name: "production source switches to workflow sha", mutate: func(t *testing.T, root *yaml.Node) {
 			appendRunStep(t, jobNode(t, root, "build"), "Bypass immutable tag", `git checkout "$GITHUB_SHA"`)


### PR DESCRIPTION
## Summary
- narrow the v0.3.0 test-only recovery overlay to the three files that actually differ from the immutable tag
- keep exact allowlist enforcement and reject the redundant account test or any fourth path
- document the v0.2.0 historical four-path overlay separately from the v0.3.0 recovery

## Evidence
Release run 29399903383 failed on all six test jobs at the exact-four diff comparison. The v0.3.0 tag and current main have the same `pixiv/account_external_test.go` Git blob, so copying it cannot create the required fourth diff. The Rust toolchain installation, fmt, clippy and vendor gates passed before this step.

## Safety
- production still checks out only immutable v0.3.0 tag bytes
- staticlib byte-for-byte comparison is unchanged
- credential boundaries and per-target Rust pins are unchanged
- the overlay allowlist becomes smaller, not broader

## Verification
- focused recovery policy tests
- sh scripts/test-release-workflow.sh
- go test ./...
- go test -race ./...
- go vet ./...
- pre-commit run --all-files
- git diff --check