### PR TITLE
fix: stabilize Windows understandgraph safety checks

### DIFF
--- a/scripts/understandgraph/contained_file.go
+++ b/scripts/understandgraph/contained_file.go
@@ -63,13 +63,23 @@ func verifyOpenedContainedFile(file *os.File, initialInfo os.FileInfo, root, rel
 	if err != nil {
 		return err
 	}
-	if !os.SameFile(openedInfo, currentFile.info) {
+	if !sameContainedFile(openedInfo, currentFile.info) {
 		return fmt.Errorf("path %q within %s changed during secure read", relativePath, boundaryName)
 	}
-	if !os.SameFile(initialInfo, openedInfo) {
+	if !sameContainedFile(initialInfo, openedInfo) {
 		return fmt.Errorf("path %q within %s changed after initial validation", relativePath, boundaryName)
 	}
 	return nil
+}
+
+// sameContainedFile 同时校验文件身份和可观察元数据。Windows 文件系统可能在
+// 替换发生后仍给出相同的身份信息；大小、权限或修改时间变化时一律在解析前拒绝，
+// 避免这类已观测到的替换把受控源码内容带入错误或图谱产物。
+func sameContainedFile(left, right os.FileInfo) bool {
+	return os.SameFile(left, right) &&
+		left.Mode() == right.Mode() &&
+		left.Size() == right.Size() &&
+		left.ModTime().Equal(right.ModTime())
 }
 
 // resolveContainedRegularFile 校验生成器输入只能指向指定根目录内的普通文件。
@@ -116,6 +126,11 @@ func resolveContainedRegularFile(root, relativePath, boundaryName string) (resol
 	}
 	if !info.Mode().IsRegular() {
 		return resolvedContainedFile{}, fmt.Errorf("path %q within %s is not a regular file", relativePath, boundaryName)
+	}
+	// Windows 的 os.SameFile 会延迟按路径取得文件 ID。必须在路径仍对应本次
+	// 解析结果时触发该读取；否则替换后的路径会被误当成初始文件。
+	if !os.SameFile(info, info) {
+		return resolvedContainedFile{}, fmt.Errorf("stat path %q within %s cannot establish a stable file identity", relativePath, boundaryName)
 	}
 	return resolvedContainedFile{path: resolvedPath, info: info}, nil
 }

--- a/scripts/understandgraph/go_packages_security_test.go
+++ b/scripts/understandgraph/go_packages_security_test.go
@@ -90,7 +90,9 @@ func TestNormalizeRejectsUnsafeGoSourcesBeforeWritingArtifacts(t *testing.T) {
 
 			err := Normalize(root)
 			require.ErrorContains(t, err, test.want)
-			require.ErrorContains(t, err, controlledPath)
+			// scan-result.json 的路径协议固定为 slash；Windows 上错误也必须反映该输入，
+			// 不能把宿主文件系统的分隔符当成安全契约的一部分。
+			require.ErrorContains(t, err, filepath.ToSlash(controlledPath))
 			require.NotContains(t, err.Error(), secret)
 			for _, artifact := range artifacts {
 				require.Equal(t, before[artifact], readFile(t, artifact), "failed normalization changed %s", artifact)
@@ -190,6 +192,35 @@ func TestNormalizeRejectsGoSourceIdentityChangeBeforeWritingArtifacts(t *testing
 
 	err := normalizeWithContainedFileReader(root, reader)
 	require.True(t, swapped)
+	require.ErrorContains(t, err, "changed after initial validation")
+	require.NotContains(t, err.Error(), secret)
+	for _, artifact := range artifacts {
+		require.Equal(t, before[artifact], readFile(t, artifact), "failed normalization changed %s", artifact)
+	}
+}
+
+func TestNormalizeRejectsGoSourceContentChangeBeforeWritingArtifacts(t *testing.T) {
+	root := writeGraphFixture(t, map[string]string{
+		"go.mod": "module example.com/pixiv\n\ngo 1.26.3\n",
+		"a/a.go": "package a\n",
+	})
+	secret := "IN_PLACE_RACE_SECRET_MUST_NOT_BE_READ"
+	artifacts := graphArtifactPaths(root)
+	before := snapshotFiles(t, artifacts)
+
+	changed := false
+	reader := func(root, relativePath, boundaryName string) ([]byte, error) {
+		return readContainedRegularFileWithHook(root, relativePath, boundaryName, func(resolvedPath string) error {
+			if changed || boundaryName != "repository" {
+				return nil
+			}
+			changed = true
+			return os.WriteFile(resolvedPath, []byte(secret+"\n"), 0o600)
+		})
+	}
+
+	err := normalizeWithContainedFileReader(root, reader)
+	require.True(t, changed)
 	require.ErrorContains(t, err, "changed after initial validation")
 	require.NotContains(t, err.Error(), secret)
 	for _, artifact := range artifacts {


### PR DESCRIPTION
## Summary

- stabilize contained-file identity validation on Windows before parsing replacement content
- make graph scan path assertions follow the slash-based JSON protocol
- preserve secret suppression and artifact immutability guarantees

## Validation

- go test ./scripts/understandgraph -count=10
- go test -race ./scripts/understandgraph -count=1
- GOOS=windows GOARCH=amd64 go test -c ./scripts/understandgraph
- GOOS=windows GOARCH=arm64 go test -c ./scripts/understandgraph
- go test ./... -count=1
- git diff --check

This fixes the Windows build failures from the pre-publication v0.4.0 Release run. The existing v0.4.0 tag remains unchanged; a new patch version is required for assets containing this fix.