### PR TITLE
release: prepare v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## [Unreleased]
 
-## [0.4.0] - 2026-07-19
+## [0.4.1] - 2026-07-19
 
 ### Added
 
@@ -24,7 +24,7 @@
 
 ### Changed
 
-- Breaking: v0.4.0 删除 `pixiv auth add`、`pixiv auth token` 与 `--token`，不保留 alias/stub；direct token 入口统一为 `auth import`，显式 secret stdout 统一为不带 `--output` 的 `auth export [UID]` 或 `auth export --all`。
+- Breaking: v0.4.1 删除 `pixiv auth add`、`pixiv auth token` 与 `--token`，不保留 alias/stub；direct token 入口统一为 `auth import`，显式 secret stdout 统一为不带 `--output` 的 `auth export [UID]` 或 `auth export --all`。
 - `auth import` 的 direct 与 bundle 成功报告统一使用不含 secret 的 `{user_id,username,status}` account item，其中 `status` 为 `added|updated`；bundle JSON 固定为 `{accounts,default_user_id}` 并按输入 bundle 顺序逐项报告，不再暴露 `default`/`has_token` 或按 added/updated 分组。
 - `auth import --file` 严格解码未加密 bundle，并按 UID merge 后原子保存：保留本地已有 default，仅空 store 采用 bundle default；该离线路径拒绝 token/proxy 组合，不刷新、不联网。bundle 是 point-in-time backup 而非 live sync，token rotation 后旧 bundle 与其他机器副本可能 stale。
 - 有 refresh token 的搜索始终使用 App API，失败不回落 Web；无 token 的 Web 搜索只执行可靠筛选，R18/R18G/mature 与动态搜索选项会明确要求登录。分级与仅 AI 在 public SDK 筛选，其余新增筛选优先由 App 服务端执行；收藏数筛选仍不提供。
@@ -206,8 +206,8 @@
 
 [Keep a Changelog 1.1.0]: https://keepachangelog.com/zh-CN/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
-[Unreleased]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.0...HEAD
-[0.4.0]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.0
+[Unreleased]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.1
 [0.3.0]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.0...v0.1.1

--- a/README.ja.md
+++ b/README.ja.md
@@ -41,7 +41,7 @@ curl.exe -fsSLo "%TEMP%\pixiv-install.cmd" https://raw.githubusercontent.com/Fla
 
 どちらのスクリプトも AMD64/ARM64 を検出し、最新の安定版公式 Release archive を選択して公開 SHA-256 を検証します。staging した binary を事前確認してからユーザー単位でインストールし、その後にのみ PATH を変更します。PATH を変更しない場合は `--no-path`、別の保存先には `--install-dir DIR` を使用できます。実行前にダウンロードしたスクリプトを確認できます。
 
-Linux の互換性に関する注意：v0.3.0 archive は Ubuntu 24.04 で link されており、glibc 2.39 を要求する場合があるため Debian 12 では動作しません。v0.4.0 では build 側で修正し、Linux asset の glibc 要求を最大 2.35 に固定して ABI gate で検証します。installer は既存の install を置き換える前に staged binary を確認し、非互換を明示します。
+Linux の互換性に関する注意：v0.3.0 archive は Ubuntu 24.04 で link されており、glibc 2.39 を要求する場合があるため Debian 12 では動作しません。v0.4.1 では build 側で修正し、Linux asset の glibc 要求を最大 2.35 に固定して ABI gate で検証します。installer は既存の install を置き換える前に staged binary を確認し、非互換を明示します。
 
 ### Coding Agent にインストールさせる
 
@@ -143,7 +143,7 @@ pixiv auth use 12345678
 pixiv auth check
 ```
 
-v0.4.0 では `auth add`/`auth token` を `auth import`/`auth export` に置き換え、削除した名前と `--token` に alias はありません。import は引数なしの非表示入力または raw stdin を推奨します。位置引数の token は argv/shell history に残ります。stdout へ secret を出力できるのは、`--output` を付けない `pixiv auth export [UID]` と `pixiv auth export --all` だけです。ファイルには `--output` で private bundle を作成します。bundle は暗号化されていない point-in-time backup であり live sync ではなく、token rotation 後は stale になる場合があります。secret 出力を chat、log、shell history、issue、Agent transcript に貼り付けないでください。他の stdout/stderr、JSON、MCP result、log、error は refresh token を公開してはなりません。完全な契約は [CLI リファレンス](docs/ja/cli-reference.md#refresh-token-の取得)を参照してください。
+v0.4.1 では `auth add`/`auth token` を `auth import`/`auth export` に置き換え、削除した名前と `--token` に alias はありません。import は引数なしの非表示入力または raw stdin を推奨します。位置引数の token は argv/shell history に残ります。stdout へ secret を出力できるのは、`--output` を付けない `pixiv auth export [UID]` と `pixiv auth export --all` だけです。ファイルには `--output` で private bundle を作成します。bundle は暗号化されていない point-in-time backup であり live sync ではなく、token rotation 後は stale になる場合があります。secret 出力を chat、log、shell history、issue、Agent transcript に貼り付けないでください。他の stdout/stderr、JSON、MCP result、log、error は refresh token を公開してはなりません。完全な契約は [CLI リファレンス](docs/ja/cli-reference.md#refresh-token-の取得)を参照してください。
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ preflight the staged binary, and install per-user before changing PATH. Use `--n
 `--install-dir DIR` to choose another destination. You can inspect the downloaded script before running it.
 
 Linux compatibility note: the v0.3.0 archives were linked on Ubuntu 24.04 and can require glibc 2.39, so they do not
-run on Debian 12. v0.4.0 fixes this at build time: Linux assets are built against and checked for a glibc 2.35
+run on Debian 12. v0.4.1 fixes this at build time: Linux assets are built against and checked for a glibc 2.35
 maximum requirement. The installer preflight reports an incompatible staged binary before replacing an installation.
 
 ### Install with a coding agent
@@ -147,7 +147,7 @@ pixiv auth use 12345678
 pixiv auth check
 ```
 
-v0.4.0 replaces `auth add`/`auth token` with `auth import`/`auth export`; the removed names and `--token` have no aliases. Prefer hidden `pixiv auth import` input or raw stdin because a positional token is visible in argv/shell history. `pixiv auth export [UID]` and `pixiv auth export --all`, both without `--output`, are the only explicit secret stdout forms; use `--output` for a private bundle file. Bundles are unencrypted point-in-time backups, not live sync, and may become stale after token rotation. Never paste secret output into chat, logs, shell history, issues, or agent transcripts; other stdout/stderr, JSON, MCP results, logs, and errors must not reveal refresh tokens. See the [CLI reference](docs/en/cli-reference.md#getting-a-refresh-token) for the complete import/export and file-protection contract.
+v0.4.1 replaces `auth add`/`auth token` with `auth import`/`auth export`; the removed names and `--token` have no aliases. Prefer hidden `pixiv auth import` input or raw stdin because a positional token is visible in argv/shell history. `pixiv auth export [UID]` and `pixiv auth export --all`, both without `--output`, are the only explicit secret stdout forms; use `--output` for a private bundle file. Bundles are unencrypted point-in-time backups, not live sync, and may become stale after token rotation. Never paste secret output into chat, logs, shell history, issues, or agent transcripts; other stdout/stderr, JSON, MCP results, logs, and errors must not reveal refresh tokens. See the [CLI reference](docs/en/cli-reference.md#getting-a-refresh-token) for the complete import/export and file-protection contract.
 
 ## Documentation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,7 +44,7 @@ binary，并在修改 PATH 前完成用户级安装。可用 `--no-path` 保持 
 选择其他目录；执行前也可以先审阅下载的脚本。
 
 Linux 兼容性说明：v0.3.0 archive 在 Ubuntu 24.04 上链接，可能要求 glibc 2.39，因此不能在 Debian 12
-运行。v0.4.0 已从构建侧修复：Linux 资产以 glibc 2.35 为最高依赖并经过 ABI 门禁。安装器会在
+运行。v0.4.1 已从构建侧修复：Linux 资产以 glibc 2.35 为最高依赖并经过 ABI 门禁。安装器会在
 替换现有安装前预检 staged binary，并明确报告不兼容。
 
 ### 让 Coding Agent 安装
@@ -147,7 +147,7 @@ pixiv auth use 12345678
 pixiv auth check
 ```
 
-v0.4.0 以 `auth import`/`auth export` 取代 `auth add`/`auth token`，已删除的名称和 `--token` 均无 alias。导入时优先使用无参隐藏输入或 raw stdin；位置参数会暴露在 argv/shell history。只有不带 `--output` 的 `pixiv auth export [UID]` 与 `pixiv auth export --all` 可以向 stdout 输出 secret；需要文件时使用 `--output` 写私有 bundle。bundle 是未加密的 point-in-time backup，不是 live sync，token rotation 后可能 stale。不要把 secret 输出粘贴到聊天、日志、shell history、issue 或 Agent transcript；其他 stdout/stderr、JSON、MCP result、日志和错误均不得暴露 refresh token。完整 import/export 与文件保护契约见 [CLI reference](docs/zh-CN/cli-reference.md#获取-refresh-token)。
+v0.4.1 以 `auth import`/`auth export` 取代 `auth add`/`auth token`，已删除的名称和 `--token` 均无 alias。导入时优先使用无参隐藏输入或 raw stdin；位置参数会暴露在 argv/shell history。只有不带 `--output` 的 `pixiv auth export [UID]` 与 `pixiv auth export --all` 可以向 stdout 输出 secret；需要文件时使用 `--output` 写私有 bundle。bundle 是未加密的 point-in-time backup，不是 live sync，token rotation 后可能 stale。不要把 secret 输出粘贴到聊天、日志、shell history、issue 或 Agent transcript；其他 stdout/stderr、JSON、MCP result、日志和错误均不得暴露 refresh token。完整 import/export 与文件保护契约见 [CLI reference](docs/zh-CN/cli-reference.md#获取-refresh-token)。
 
 ## 文档
 

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -179,7 +179,7 @@ touch real Pixiv.
 
 ### Importing authentication
 
-v0.4.0 removes `auth add`, `auth token`, and `--token` with no aliases. Direct import is now:
+v0.4.1 removes `auth add`, `auth token`, and `--token` with no aliases. Direct import is now:
 
 ```bash
 pixiv auth import                         # hidden prompt on a TTY

--- a/docs/ja/cli-reference.md
+++ b/docs/ja/cli-reference.md
@@ -157,7 +157,7 @@ pixiv auth login --proxy http://127.0.0.1:7890
 
 ### 認証の import
 
-v0.4.0 では `auth add`、`auth token`、`--token` を alias なしで削除します。direct import は次の形式です：
+v0.4.1 では `auth add`、`auth token`、`--token` を alias なしで削除します。direct import は次の形式です：
 
 ```bash
 pixiv auth import                         # TTY では非表示入力

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -159,7 +159,7 @@ pixiv auth login --proxy http://127.0.0.1:7890
 
 ### 导入认证
 
-v0.4.0 删除 `auth add`、`auth token` 与 `--token`，且不保留 alias。direct import 改为：
+v0.4.1 删除 `auth add`、`auth token` 与 `--token`，且不保留 alias。direct import 改为：
 
 ```bash
 pixiv auth import                         # TTY 隐藏输入


### PR DESCRIPTION
Prepare the actual patch release after the pre-publication v0.4.0 tag failed its Windows release gate before any GitHub Release or assets were created. v0.4.1 contains the original v0.4 feature set plus the merged Windows safety-check fix; v0.4.0 remains an immutable, unpublished tag.\n\nValidation: go test ./scripts/documentation ./scripts/releaseassets -count=1; pre-commit hook go test ./...; git diff --check.