### PR TITLE
fix(release): isolate Linuxbrew temporary directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -557,6 +557,10 @@ jobs:
           set -euo pipefail
           if [ '${{ matrix.os }}' = linux ]; then
             eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            # GitHub Linux runner 的 /var/tmp 会使 Homebrew 安装触发 EINVAL；只为
+            # Linux Homebrew 验证使用 runner 私有的普通临时目录，macOS 保持默认行为。
+            mkdir -p "$RUNNER_TEMP/homebrew-tmp"
+            export HOMEBREW_TEMP="$RUNNER_TEMP/homebrew-tmp"
           fi
           formula_name=$(cat staging-formula/formula-name)
           case "$formula_name" in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- 修复 GitHub Linux runner 的 Homebrew Release 验证默认使用 `/var/tmp` 时触发 `EINVAL`、导致 staging formula 无法安装的问题；验证步骤现仅在 Linux 创建并导出 runner 私有临时目录，macOS 与公开 formula 路径保持不变。
 - 修复 Windows `install.cmd` 在 Release 使用 `core.autocrlf=false` checkout 时仍可借由 Git 属性保留 CRLF 并正常运行。
 - 修复 Linux Release 在 Ubuntu 24.04 上通过 cgo 链接后隐式要求 `GLIBC_2.39`、导致 Debian 12 等
   glibc 2.35–2.38 系统无法启动的问题；后续 Linux amd64/arm64 资产统一在 Ubuntu 22.04 构建，

--- a/scripts/releaseworkflow/homebrew_policy.go
+++ b/scripts/releaseworkflow/homebrew_policy.go
@@ -95,6 +95,10 @@ func checkVerifyHomebrewJob(job *yaml.Node) error {
 set -euo pipefail
 if [ '${{ matrix.os }}' = linux ]; then
 eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+# GitHub Linux runner 的 /var/tmp 会使 Homebrew 安装触发 EINVAL；只为
+# Linux Homebrew 验证使用 runner 私有的普通临时目录，macOS 保持默认行为。
+mkdir -p "$RUNNER_TEMP/homebrew-tmp"
+export HOMEBREW_TEMP="$RUNNER_TEMP/homebrew-tmp"
 fi
 formula_name=$(cat staging-formula/formula-name)
 case "$formula_name" in

--- a/scripts/releaseworkflow/homebrew_policy_test.go
+++ b/scripts/releaseworkflow/homebrew_policy_test.go
@@ -50,6 +50,26 @@ func TestCheckWorkflowRequiresStagingTapTrust(t *testing.T) {
 	}
 }
 
+// GitHub Linux runner 的 Homebrew 默认临时目录 /var/tmp 会在实际安装时触发
+// EINVAL；验证门禁必须仅在 Linux 分支创建并导出 runner 私有临时目录。
+func TestWorkflowUsesRunnerTemporaryDirectoryForLinuxHomebrew(t *testing.T) {
+	t.Parallel()
+
+	root := releaseWorkflowRoot(t)
+	step := stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install")
+	run := requireMappingValue(t, step, "run").Value
+	const linuxTemporaryDirectory = `if [ '${{ matrix.os }}' = linux ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+  # GitHub Linux runner 的 /var/tmp 会使 Homebrew 安装触发 EINVAL；只为
+  # Linux Homebrew 验证使用 runner 私有的普通临时目录，macOS 保持默认行为。
+  mkdir -p "$RUNNER_TEMP/homebrew-tmp"
+  export HOMEBREW_TEMP="$RUNNER_TEMP/homebrew-tmp"
+fi`
+	if !strings.Contains(run, linuxTemporaryDirectory) {
+		t.Fatalf("Homebrew install gate must create and export the Linux-only runner temporary directory")
+	}
+}
+
 func TestCheckWorkflowRejectsHomebrewReleaseGateMutations(t *testing.T) {
 	t.Parallel()
 
@@ -142,6 +162,13 @@ func TestCheckWorkflowRejectsHomebrewReleaseGateMutations(t *testing.T) {
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
 				removeRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "/home/linuxbrew/.linuxbrew/bin/brew"), "eval \"$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"")
+			},
+		},
+		{
+			name: "Linux Homebrew temporary directory export removed",
+			want: "Homebrew native install gate must use the required direct command sequence",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				removeRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "HOMEBREW_TEMP"), "export HOMEBREW_TEMP=\"$RUNNER_TEMP/homebrew-tmp\"")
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- move only Linux Homebrew staging validation temporary work under `$RUNNER_TEMP`
- preserve formula, archive, tap, and macOS behavior
- lock the runner-temp contract in release workflow policy tests

## Evidence
- v0.4.2 release assets and all builds succeeded
- Linuxbrew staging installs failed only with `apply2files` EINVAL under `/var/tmp`
- macOS staging installs succeeded with the same formula

## Validation
- `go test ./scripts/releaseworkflow -count=1`
- `go test -race ./scripts/releaseworkflow -count=1`
- `sh scripts/test-release-workflow.sh`
- `git diff --check`

Actual Linuxbrew installation remains the v0.4.3 release gate.