### PR TITLE
chore(release): prepare v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-07-19
+
+### Fixed
+
+- 修复 Linux Homebrew Release validation 使用 `/var/tmp` 时可能触发 `EINVAL`、导致 staging formula 无法安装的问题；该验证步骤现仅在 Linux 使用 runner 私有临时目录，macOS 与公开 formula 路径保持不变。
+
 ## [0.4.2] - 2026-07-19
 
 ### Added
@@ -32,7 +38,6 @@
 
 ### Fixed
 
-- 修复 GitHub Linux runner 的 Homebrew Release 验证默认使用 `/var/tmp` 时触发 `EINVAL`、导致 staging formula 无法安装的问题；验证步骤现仅在 Linux 创建并导出 runner 私有临时目录，macOS 与公开 formula 路径保持不变。
 - 修复 Windows `install.cmd` 在 Release 使用 `core.autocrlf=false` checkout 时仍可借由 Git 属性保留 CRLF 并正常运行。
 - 修复 Linux Release 在 Ubuntu 24.04 上通过 cgo 链接后隐式要求 `GLIBC_2.39`、导致 Debian 12 等
   glibc 2.35–2.38 系统无法启动的问题；后续 Linux amd64/arm64 资产统一在 Ubuntu 22.04 构建，
@@ -208,7 +213,8 @@
 
 [Keep a Changelog 1.1.0]: https://keepachangelog.com/zh-CN/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
-[Unreleased]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.2
 [0.3.0]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.1...v0.2.0


### PR DESCRIPTION
## Summary
- prepare a new immutable patch release after v0.4.2 Homebrew Linux staging validation did not deploy the tap
- preserve the public v0.4.2 release history
- isolate the runner-private Linuxbrew temporary-directory fix in v0.4.3 notes

## Validation
- `go test ./scripts/documentation -count=1`
- `go test ./scripts/releaseworkflow -count=1`
- `go run ./scripts/releaseassets validate --version 0.4.3`
- `git diff --check`