### PR TITLE
fix(homebrew): keep Linux build paths in prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -557,10 +557,11 @@ jobs:
           set -euo pipefail
           if [ '${{ matrix.os }}' = linux ]; then
             eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-            # GitHub Linux runner 的 /var/tmp 会使 Homebrew 安装触发 EINVAL；只为
-            # Linux Homebrew 验证使用 runner 私有的普通临时目录，macOS 保持默认行为。
-            mkdir -p "$RUNNER_TEMP/homebrew-tmp"
-            export HOMEBREW_TEMP="$RUNNER_TEMP/homebrew-tmp"
+            # Formula buildpath 必须与 Homebrew Cellar 同属 prefix filesystem，避免
+            # Linux runner 上 FileUtils 跨设备移动 buildpath 时返回 EINVAL。
+            homebrew_temp="$(brew --prefix)/var/tmp"
+            mkdir -p "$homebrew_temp"
+            export HOMEBREW_TEMP="$homebrew_temp"
           fi
           formula_name=$(cat staging-formula/formula-name)
           case "$formula_name" in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复 Linux Homebrew packaging validation 的 formula buildpath 可能与 Cellar 跨文件系统、使 FileUtils 移动返回 `EINVAL` 的问题；Linux gate 现将 `HOMEBREW_TEMP` 置于 Homebrew prefix 内，macOS 与公开 formula 路径保持不变。
+
 ## [0.4.3] - 2026-07-19
 
 ### Fixed

--- a/scripts/releaseworkflow/homebrew_policy.go
+++ b/scripts/releaseworkflow/homebrew_policy.go
@@ -95,10 +95,11 @@ func checkVerifyHomebrewJob(job *yaml.Node) error {
 set -euo pipefail
 if [ '${{ matrix.os }}' = linux ]; then
 eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-# GitHub Linux runner 的 /var/tmp 会使 Homebrew 安装触发 EINVAL；只为
-# Linux Homebrew 验证使用 runner 私有的普通临时目录，macOS 保持默认行为。
-mkdir -p "$RUNNER_TEMP/homebrew-tmp"
-export HOMEBREW_TEMP="$RUNNER_TEMP/homebrew-tmp"
+# Formula buildpath 必须与 Homebrew Cellar 同属 prefix filesystem，避免
+# Linux runner 上 FileUtils 跨设备移动 buildpath 时返回 EINVAL。
+homebrew_temp="$(brew --prefix)/var/tmp"
+mkdir -p "$homebrew_temp"
+export HOMEBREW_TEMP="$homebrew_temp"
 fi
 formula_name=$(cat staging-formula/formula-name)
 case "$formula_name" in

--- a/scripts/releaseworkflow/homebrew_policy_test.go
+++ b/scripts/releaseworkflow/homebrew_policy_test.go
@@ -50,23 +50,26 @@ func TestCheckWorkflowRequiresStagingTapTrust(t *testing.T) {
 	}
 }
 
-// GitHub Linux runner 的 Homebrew 默认临时目录 /var/tmp 会在实际安装时触发
-// EINVAL；验证门禁必须仅在 Linux 分支创建并导出 runner 私有临时目录。
-func TestWorkflowUsesRunnerTemporaryDirectoryForLinuxHomebrew(t *testing.T) {
+// Linux Homebrew 的 formula buildpath 必须和 Cellar 位于同一 Homebrew prefix
+// filesystem；runner 临时目录及裸 /var/tmp 都可能跨设备，从而令 FileUtils mv 返回 EINVAL。
+func TestWorkflowUsesHomebrewPrefixTemporaryDirectoryForLinuxHomebrew(t *testing.T) {
 	t.Parallel()
 
 	root := releaseWorkflowRoot(t)
 	step := stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install")
 	run := requireMappingValue(t, step, "run").Value
-	const linuxTemporaryDirectory = `if [ '${{ matrix.os }}' = linux ]; then
-  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-  # GitHub Linux runner 的 /var/tmp 会使 Homebrew 安装触发 EINVAL；只为
-  # Linux Homebrew 验证使用 runner 私有的普通临时目录，macOS 保持默认行为。
-  mkdir -p "$RUNNER_TEMP/homebrew-tmp"
-  export HOMEBREW_TEMP="$RUNNER_TEMP/homebrew-tmp"
-fi`
-	if !strings.Contains(run, linuxTemporaryDirectory) {
-		t.Fatalf("Homebrew install gate must create and export the Linux-only runner temporary directory")
+	for _, command := range []string{
+		`eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"`,
+		`homebrew_temp="$(brew --prefix)/var/tmp"`,
+		`mkdir -p "$homebrew_temp"`,
+		`export HOMEBREW_TEMP="$homebrew_temp"`,
+	} {
+		if !strings.Contains(run, command) {
+			t.Fatalf("Homebrew install gate must create and export a Linux-only Homebrew prefix temporary directory; missing %q", command)
+		}
+	}
+	if strings.Contains(run, "$RUNNER_TEMP/homebrew-tmp") || strings.Contains(run, `export HOMEBREW_TEMP="/var/tmp"`) {
+		t.Fatal("Homebrew install gate must not use a runner temporary directory or a bare /var/tmp")
 	}
 }
 
@@ -165,10 +168,17 @@ func TestCheckWorkflowRejectsHomebrewReleaseGateMutations(t *testing.T) {
 			},
 		},
 		{
-			name: "Linux Homebrew temporary directory export removed",
+			name: "Linux Homebrew temporary directory leaves the Homebrew prefix",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				removeRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "HOMEBREW_TEMP"), "export HOMEBREW_TEMP=\"$RUNNER_TEMP/homebrew-tmp\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "HOMEBREW_TEMP"), "homebrew_temp=\"$(brew --prefix)/var/tmp\"", "homebrew_temp=\"$RUNNER_TEMP/homebrew-tmp\"")
+			},
+		},
+		{
+			name: "Linux Homebrew temporary directory uses bare var tmp",
+			want: "Homebrew native install gate must use the required direct command sequence",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "HOMEBREW_TEMP"), "homebrew_temp=\"$(brew --prefix)/var/tmp\"", "homebrew_temp=\"/var/tmp\"")
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- stage Linuxbrew formula build paths under `brew --prefix` to avoid hosted-runner cross-filesystem moves
- preserve the formula, archive, matrix, trust and deploy gates
- lock the prefix-temp requirement in the release workflow policy

## Evidence
- v0.4.3 failures moved with `HOMEBREW_TEMP`, including to `$RUNNER_TEMP`
- Homebrew FileUtils moves formula buildpaths to Cellar and both Linux architectures fail before the binary version check

## Validation
- `go test ./scripts/releaseworkflow -count=1`
- `go test -race ./scripts/releaseworkflow -count=1`
- `sh scripts/test-release-workflow.sh`
- `sh scripts/test-homebrew-formula.sh`
- `git diff --check`

The next immutable patch Release retains Linuxbrew AMD64/ARM64 staging installation as the required real-world gate.