### PR TITLE
chore(release): prepare v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-07-19
+
 ### Fixed
 
-- 修复 Linux Homebrew packaging validation 的 formula buildpath 可能与 Cellar 跨文件系统、使 FileUtils 移动返回 `EINVAL` 的问题；Linux gate 现将 `HOMEBREW_TEMP` 置于 Homebrew prefix 内，macOS 与公开 formula 路径保持不变。
+- Linux Homebrew release validation keeps buildpaths in Homebrew prefix to avoid cross-filesystem FileUtils EINVAL.
 
 ## [0.4.3] - 2026-07-19
 
@@ -217,7 +219,8 @@
 
 [Keep a Changelog 1.1.0]: https://keepachangelog.com/zh-CN/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
-[Unreleased]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.4...HEAD
+[0.4.4]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.2
 [0.3.0]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.2.0...v0.3.0

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -12,10 +12,11 @@ User-visible changes are recorded in [CHANGELOG.md](../../CHANGELOG.md).
 
 > **Release status**: the Ed25519 public key, key ID, and fingerprint for supported binaries are committed in
 > [`internal/bootstrap/release_trust.go`](../../internal/bootstrap/release_trust.go); the public source/tap repositories,
-> the protected `release` Environment, and isolated credentials are configured. v0.3.0 has been published as an
-> official GitHub Release with six platform archives, checksums, and a signed manifest; the stable Homebrew formula
-> has been pushed. Future versions must still pass the same tag, signing, asset, and Homebrew gates before they can
-> be treated as trusted download sources.
+> the protected `release` Environment, and isolated credentials are configured. v0.4.3 has been published as a
+> public GitHub Release with six platform archives, checksums, and a signed manifest. The stable Homebrew formula in
+> the public tap remains v0.3.0 pending v0.4.4 Linuxbrew installation validation; v0.4.4 is not published. Future
+> versions must still pass the same tag, signing, asset, and Homebrew gates before they can be treated as trusted
+> download sources.
 
 ### Official installer scripts
 
@@ -75,7 +76,7 @@ go install github.com/FlanChanXwO/pixiv-cli/cmd/pixiv@vX.Y.Z
 ```
 
 This still uses the local Go toolchain, cgo, a C linker, and the committed staticlib for the target. The six target
-libraries and manifest are complete — for example, the current official release can be installed with `@v0.3.0`;
+libraries and manifest are complete — for example, the current official release can be installed with `@v0.4.3`;
 always use the exact tag for later versions, never a branch name.
 
 ### Homebrew
@@ -94,14 +95,15 @@ brew install FlanChanXwO/tap/pixiv-cli-beta
 ```
 
 Both formulas install the same `pixiv` binary and therefore conflict with each other; they only download verified
-macOS/Linux Release assets and introduce no `ffmpeg` dependency. The current stable `pixiv-cli` formula is in the
-public tap; the beta formula will only ship with future pre-releases.
+macOS/Linux Release assets and introduce no `ffmpeg` dependency. The public tap's current stable `pixiv-cli` formula
+remains v0.3.0; v0.4.3 is available from GitHub Release only while v0.4.4 Linuxbrew installation validation is
+pending. The beta formula will only ship with future pre-releases.
 
 ### Direct download
 
 The release process produces six fixed-name archives for darwin, linux, and windows on amd64/arm64:
 `pixiv-cli_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows), plus `checksums.txt` and an Ed25519-signed
-`checksums.json`. v0.3.0 ships the complete asset set; later versions should only be trusted as direct download
+`checksums.json`. v0.4.3 ships the complete asset set; later versions should only be trusted as direct download
 sources after passing the same release gates.
 
 Current Releases do not include Apple notarization or Windows Authenticode. Even when downloading from a verified
@@ -501,7 +503,7 @@ Update checks only select canonical SemVer tags. Stable checks first exclude Git
 non-SemVer tag, the check reports that tag and fails closed instead of skipping it for an older version.
 
 Supported binaries embed the production Ed25519 public key/key ID/fingerprint; the private key exists only in the
-protected `release` Environment and a controlled macOS Keychain recovery copy. v0.3.0 is the current signed
+protected `release` Environment and a controlled macOS Keychain recovery copy. v0.4.3 is the current signed
 Release; `pixiv update --check` remains a read-only check and is not a substitute for verifying the selected
 version's assets, checksums, and signatures at install time.
 

--- a/docs/ja/cli-reference.md
+++ b/docs/ja/cli-reference.md
@@ -13,9 +13,10 @@ fallback、更新を扱います。SDK と MCP の詳細は重複させず、[�
 > **Release の状態**：対応 binary の Ed25519 public key、key ID、fingerprint は
 > [`internal/bootstrap/release_trust.go`](../../internal/bootstrap/release_trust.go) に commit されています。
 > public source/tap repository、保護された `release` Environment、分離された credential は設定済みです。
-> v0.3.0 は 6 platform archive、checksum、署名付き manifest を含む公式 GitHub Release として公開され、
-> stable Homebrew formula も push 済みです。将来の version も同じ tag、署名、asset、Homebrew gate を
-> 通過するまでは信頼済み download source とみなしません。
+> v0.4.3 は 6 platform archive、checksum、署名付き manifest を含む公開 GitHub Release として公開されています。
+> public tap の stable Homebrew formula は v0.3.0 のままで、v0.4.4 の Linuxbrew install validation 待ちです。
+> v0.4.4 はまだ公開されていません。将来の version も同じ tag、署名、asset、Homebrew gate を通過するまでは
+> 信頼済み download source とみなしません。
 
 ### 公式インストールスクリプト
 
@@ -91,11 +92,14 @@ brew install FlanChanXwO/tap/pixiv-cli-beta
 両 formula は同じ `pixiv` binary を配置するため競合します。macOS/Linux の検証済み Release asset だけを
 取得し、runtime の `ffmpeg` dependency は追加しません。
 
+public tap の現在の stable `pixiv-cli` formula は v0.3.0 のままです。v0.4.3 は現在 GitHub Release からのみ
+取得でき、tap の更新は v0.4.4 の Linuxbrew install validation 完了後です。
+
 ### 直接ダウンロード
 
 Release は darwin、linux、windows の amd64/arm64 向けに
 `pixiv-cli_<version>_<os>_<arch>.tar.gz`（Windows は `.zip`）を生成し、`checksums.txt` と Ed25519 署名付き
-`checksums.json` を添付します。v0.3.0 は 6 種類すべてを含みます。
+`checksums.json` を添付します。v0.4.3 は 6 種類すべてを含みます。
 
 現在 Apple notarization と Windows Authenticode はありません。macOS Gatekeeper や Windows SmartScreen が
 警告する場合があります。公式 GitHub Release からだけ取得し、version、checksum、signature note を確認し、

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -11,9 +11,10 @@ SDK 与 MCP 细节不在此重复，入口见[相关文档](#相关文档)。
 
 > **发布状态**：受支持 binary 的 Ed25519 公钥、key ID 与 fingerprint 已提交到
 > [`internal/bootstrap/release_trust.go`](../../internal/bootstrap/release_trust.go)；公开 source/tap repositories、
-> 受保护 `release` Environment 与隔离 credentials 已配置。v0.3.0 已作为正式 GitHub Release 发布，包含六个
-> 平台 archive、checksum 与签名清单；stable Homebrew formula 已推送。后续版本仍必须通过同一套 tag、签名、资产与
-> Homebrew 门禁后才可作为可用下载来源。
+> 受保护 `release` Environment 与隔离 credentials 已配置。v0.4.3 已作为公开 GitHub Release 发布，包含六个
+> 平台 archive、checksum 与签名清单。公开 tap 中的 stable Homebrew formula 仍为 v0.3.0，待 v0.4.4 的
+> Linuxbrew 安装验证完成后才会更新；v0.4.4 尚未发布。后续版本仍必须通过同一套 tag、签名、资产与 Homebrew
+> 门禁后才可作为可用下载来源。
 
 ### 官方安装脚本
 
@@ -70,7 +71,7 @@ go install github.com/FlanChanXwO/pixiv-cli/cmd/pixiv@vX.Y.Z
 ```
 
 它仍使用本机 Go、cgo、C linker 和该 target 的 committed staticlib。六目标库与 manifest 已完整，
-例如当前正式版本可使用 `@v0.3.0`；后续版本始终使用其精确 tag，而不是分支名。
+例如当前正式版本可使用 `@v0.4.3`；后续版本始终使用其精确 tag，而不是分支名。
 
 ### Homebrew
 
@@ -87,14 +88,15 @@ brew install FlanChanXwO/tap/pixiv-cli-beta
 ```
 
 两个 formula 都安装同名 `pixiv`，因此相互冲突；它们只下载已验证的 macOS/Linux Release
-资产，不引入 `ffmpeg` 依赖。当前 stable `pixiv-cli` formula 已在公开 tap；beta formula 只随
-后续 pre-release 发布。
+资产，不引入 `ffmpeg` 依赖。公开 tap 中当前 stable `pixiv-cli` formula 仍为 v0.3.0；v0.4.3 目前仅可通过
+GitHub Release 获取，待 v0.4.4 的 Linuxbrew 安装验证完成后才会更新 tap。beta formula 只随后续 pre-release
+发布。
 
 ### 直接下载
 
 发布流程会为 darwin、linux、windows 的 amd64/arm64 生成六个固定名称的 archive：
 `pixiv-cli_<version>_<os>_<arch>.tar.gz`（Windows 为 `.zip`），以及 `checksums.txt` 与
-Ed25519 签名的 `checksums.json`。v0.3.0 已提供完整资产；后续版本只有在同一发布门禁完成后才应作为
+Ed25519 签名的 `checksums.json`。v0.4.3 已提供完整资产；后续版本只有在同一发布门禁完成后才应作为
 可供信任的直接下载来源。
 
 当前 Release 不包含 Apple notarization 或 Windows Authenticode。即使从已验证 Release
@@ -420,7 +422,7 @@ tag；Release binary 在下载前校验 Ed25519 签名的 checksum 清单和 arc
 SemVer tag，检查会报告该 tag 并 fail-closed，不会跳过它而选择较旧版本。
 
 受支持 binary 已内置 production Ed25519 public key/key ID/fingerprint；私钥只保存在受保护的
-`release` Environment 与受控 macOS Keychain 恢复副本。v0.3.0 是当前已发布的受签名 Release；
+`release` Environment 与受控 macOS Keychain 恢复副本。v0.4.3 是当前已发布的受签名 Release；
 `pixiv update --check` 仍只是只读检查，不能替代对选中版本资产、checksum 与签名的安装验证。
 
 普通 CLI 命令成功后会尽力检查 stable 更新。它跳过 MCP、help、`version`、`update`、全部 `auth export`、`auth import --file` 与开发构建，


### PR DESCRIPTION
## Summary
- prepare an immutable patch release for the Linuxbrew prefix-local buildpath fix
- retain all published v0.4.3 history
- correct three-language reference status: v0.4.3 GitHub Release is public; tap remains at v0.3.0 until v0.4.4 verifies Linuxbrew

## Validation
- `go test ./scripts/documentation -count=1`
- `go test ./scripts/releaseassets ./scripts/releaseworkflow -count=1`
- `go run ./scripts/releaseassets validate --version 0.4.4`
- `sh scripts/test-release-workflow.sh`
- `git diff --check`