### PR TITLE
fix(homebrew): retain Linux staging build paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -569,7 +569,11 @@ jobs:
           brew tap-new "$staging_tap" --no-git
           brew trust --tap "$staging_tap"
           cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
-          brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+          if [ '${{ matrix.os }}' = linux ]; then
+            brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+          else
+            brew install --formula "$staging_tap/$formula_name"
+          fi
           pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"
 
   deploy_homebrew_tap:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -557,11 +557,6 @@ jobs:
           set -euo pipefail
           if [ '${{ matrix.os }}' = linux ]; then
             eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-            # Formula buildpath 必须与 Homebrew Cellar 同属 prefix filesystem，避免
-            # Linux runner 上 FileUtils 跨设备移动 buildpath 时返回 EINVAL。
-            homebrew_temp="$(brew --prefix)/var/tmp"
-            mkdir -p "$homebrew_temp"
-            export HOMEBREW_TEMP="$homebrew_temp"
           fi
           formula_name=$(cat staging-formula/formula-name)
           case "$formula_name" in
@@ -574,7 +569,7 @@ jobs:
           brew tap-new "$staging_tap" --no-git
           brew trust --tap "$staging_tap"
           cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
-          brew install --formula "$staging_tap/$formula_name"
+          brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
           pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"
 
   deploy_homebrew_tap:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Linux Homebrew release validation now retains its staging buildpath with `brew install --keep-tmp --verbose` to bypass the documented GitHub runner cleanup `chmod` `EINVAL`; this affects only the short-lived release-validation runner, not end-user Homebrew installs.
+
 ## [0.4.4] - 2026-07-19
 
 ### Fixed

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -446,7 +446,7 @@ prerelease 结果直接映射为 `pixiv-cli`/`pixiv-cli-beta`。随后精确四�
 Linux amd64/arm64）先用 `brew tap-new pixiv-cli-release/staging --no-git` 创建各 runner 的隔离
 local tap，再以 `brew trust --tap pixiv-cli-release/staging` 显式信任这一个临时命名空间；将唯一
 staging formula 放入其 `Formula/`，随后用 `pixiv-cli-release/staging/<formula>` 执行真实
-`brew install --formula`，解析
+`brew install --keep-tmp --verbose --formula`，解析
 `pixiv version --json` 并与 tag 比较。它不使用 workspace formula path、developer/环境变量 bypass，
 也不克隆、写入或信任公开 tap。只有全部成功，最终受保护 `deploy_homebrew_tap` 才以 HTTPS
 clone public tap、核对唯一 staged formula，并在最后一个 step 读取 deploy key；SSH push 固定官方
@@ -458,6 +458,11 @@ secret 和 tag protection 的远端实际状态；它不替代 Task 20 的远端
 产生的四架构 Homebrew 外部安装证据。由于 draft asset 的匿名 URL 不可被 Homebrew 下载，workflow
 会先公开 Release 再安装；若安装失败，Release 已公开但 tap 不变，需要维护者显式处置，不能绕过 gate
 手工 push。
+
+`--keep-tmp` 仅用于短命 GitHub release-validation runner：Linuxbrew 的 Resource/Mktemp cleanup 已有
+直接 backtrace 证据会在 runner 上触发 `FileUtils.chmod` 的 `EINVAL`，而保留 buildpath 能让该 cleanup
+不执行；`--verbose` 则保留可审计的 Homebrew 操作输出。二者不进入公开 formula，也不改变终端用户的
+`brew install` 行为。
 
 正式发布目前仍必须被正式 tag、签名 GitHub Release、tap formula 与后续安装验收阻断。完整
 six-target staticlib/manifest 与真实 native artifact 证据已由 run `29192425899` 收集并受控回填；

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -459,7 +459,8 @@ secret 和 tag protection 的远端实际状态；它不替代 Task 20 的远端
 会先公开 Release 再安装；若安装失败，Release 已公开但 tap 不变，需要维护者显式处置，不能绕过 gate
 手工 push。
 
-`--keep-tmp` 仅用于短命 GitHub release-validation runner：Linuxbrew 的 Resource/Mktemp cleanup 已有
+`--keep-tmp --verbose` 仅用于短命 GitHub release-validation runner 的 Linux 分支，macOS 继续使用
+原来的 `brew install --formula`：Linuxbrew 的 Resource/Mktemp cleanup 已有
 直接 backtrace 证据会在 runner 上触发 `FileUtils.chmod` 的 `EINVAL`，而保留 buildpath 能让该 cleanup
 不执行；`--verbose` 则保留可审计的 Homebrew 操作输出。二者不进入公开 formula，也不改变终端用户的
 `brew install` 行为。

--- a/scripts/releaseworkflow/homebrew_policy.go
+++ b/scripts/releaseworkflow/homebrew_policy.go
@@ -107,7 +107,11 @@ tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
 brew tap-new "$staging_tap" --no-git
 brew trust --tap "$staging_tap"
 cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
+if [ '${{ matrix.os }}' = linux ]; then
 brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+else
+brew install --formula "$staging_tap/$formula_name"
+fi
 pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"`
 
 	if err := requireRequiredJobExecution(job, "verify_homebrew_formula job"); err != nil {

--- a/scripts/releaseworkflow/homebrew_policy.go
+++ b/scripts/releaseworkflow/homebrew_policy.go
@@ -95,11 +95,6 @@ func checkVerifyHomebrewJob(job *yaml.Node) error {
 set -euo pipefail
 if [ '${{ matrix.os }}' = linux ]; then
 eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-# Formula buildpath 必须与 Homebrew Cellar 同属 prefix filesystem，避免
-# Linux runner 上 FileUtils 跨设备移动 buildpath 时返回 EINVAL。
-homebrew_temp="$(brew --prefix)/var/tmp"
-mkdir -p "$homebrew_temp"
-export HOMEBREW_TEMP="$homebrew_temp"
 fi
 formula_name=$(cat staging-formula/formula-name)
 case "$formula_name" in
@@ -112,7 +107,7 @@ tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
 brew tap-new "$staging_tap" --no-git
 brew trust --tap "$staging_tap"
 cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
-brew install --formula "$staging_tap/$formula_name"
+brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
 pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"`
 
 	if err := requireRequiredJobExecution(job, "verify_homebrew_formula job"); err != nil {

--- a/scripts/releaseworkflow/homebrew_policy_test.go
+++ b/scripts/releaseworkflow/homebrew_policy_test.go
@@ -51,7 +51,7 @@ func TestCheckWorkflowRequiresStagingTapTrust(t *testing.T) {
 }
 
 // Linuxbrew 的 Mktemp cleanup 会在短命 GitHub runner 上触发已证实的 chmod EINVAL；
-// 发布验收必须保留 buildpath，并输出 Homebrew 操作，便于保留现场诊断。
+// 仅 Linux 发布验收保留 buildpath，macOS 继续使用其原本的安装命令。
 func TestWorkflowRetainsLinuxHomebrewStagingBuildPath(t *testing.T) {
 	t.Parallel()
 
@@ -60,10 +60,14 @@ func TestWorkflowRetainsLinuxHomebrewStagingBuildPath(t *testing.T) {
 	run := requireMappingValue(t, step, "run").Value
 	for _, command := range []string{
 		`eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"`,
-		`brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"`,
+		`if [ '${{ matrix.os }}' = linux ]; then
+  brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+else
+  brew install --formula "$staging_tap/$formula_name"
+fi`,
 	} {
 		if !strings.Contains(run, command) {
-			t.Fatalf("Homebrew install gate must retain the Linux staging buildpath and show operations; missing %q", command)
+			t.Fatalf("Homebrew install gate must retain only the Linux staging buildpath and preserve the macOS install command; missing %q", command)
 		}
 	}
 	for _, forbidden := range []string{"HOMEBREW_TEMP", "homebrew_temp=", "mkdir -p \"$homebrew_temp\""} {
@@ -179,6 +183,17 @@ func TestCheckWorkflowRejectsHomebrewReleaseGateMutations(t *testing.T) {
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
 				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --keep-tmp --formula \"$staging_tap/$formula_name\"")
+			},
+		},
+		{
+			name: "Linux Homebrew retention flags leave the Linux conditional",
+			want: "Homebrew native install gate must use the required direct command sequence",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), `if [ '${{ matrix.os }}' = linux ]; then
+  brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+else
+  brew install --formula "$staging_tap/$formula_name"
+fi`, `brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"`)
 			},
 		},
 		{

--- a/scripts/releaseworkflow/homebrew_policy_test.go
+++ b/scripts/releaseworkflow/homebrew_policy_test.go
@@ -29,7 +29,7 @@ func TestCheckWorkflowRequiresTapQualifiedStagingFormulaInstall(t *testing.T) {
 
 	root := releaseWorkflowRoot(t)
 	step := stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install")
-	replaceRunFragment(t, step, "brew install --formula \"$staging_tap/$formula_name\"", "brew install --formula \"staging-formula/$formula_name.rb\"")
+	replaceRunFragment(t, step, "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --keep-tmp --verbose --formula \"staging-formula/$formula_name.rb\"")
 	err := checkWorkflow(mustMarshalYAML(t, root))
 	if err == nil || !strings.Contains(err.Error(), "Homebrew native install gate must use the required direct command sequence") {
 		t.Fatalf("policy error = %v, want workspace-path Homebrew formula install rejection", err)
@@ -50,9 +50,9 @@ func TestCheckWorkflowRequiresStagingTapTrust(t *testing.T) {
 	}
 }
 
-// Linux Homebrew 的 formula buildpath 必须和 Cellar 位于同一 Homebrew prefix
-// filesystem；runner 临时目录及裸 /var/tmp 都可能跨设备，从而令 FileUtils mv 返回 EINVAL。
-func TestWorkflowUsesHomebrewPrefixTemporaryDirectoryForLinuxHomebrew(t *testing.T) {
+// Linuxbrew 的 Mktemp cleanup 会在短命 GitHub runner 上触发已证实的 chmod EINVAL；
+// 发布验收必须保留 buildpath，并输出 Homebrew 操作，便于保留现场诊断。
+func TestWorkflowRetainsLinuxHomebrewStagingBuildPath(t *testing.T) {
 	t.Parallel()
 
 	root := releaseWorkflowRoot(t)
@@ -60,16 +60,16 @@ func TestWorkflowUsesHomebrewPrefixTemporaryDirectoryForLinuxHomebrew(t *testing
 	run := requireMappingValue(t, step, "run").Value
 	for _, command := range []string{
 		`eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"`,
-		`homebrew_temp="$(brew --prefix)/var/tmp"`,
-		`mkdir -p "$homebrew_temp"`,
-		`export HOMEBREW_TEMP="$homebrew_temp"`,
+		`brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"`,
 	} {
 		if !strings.Contains(run, command) {
-			t.Fatalf("Homebrew install gate must create and export a Linux-only Homebrew prefix temporary directory; missing %q", command)
+			t.Fatalf("Homebrew install gate must retain the Linux staging buildpath and show operations; missing %q", command)
 		}
 	}
-	if strings.Contains(run, "$RUNNER_TEMP/homebrew-tmp") || strings.Contains(run, `export HOMEBREW_TEMP="/var/tmp"`) {
-		t.Fatal("Homebrew install gate must not use a runner temporary directory or a bare /var/tmp")
+	for _, forbidden := range []string{"HOMEBREW_TEMP", "homebrew_temp=", "mkdir -p \"$homebrew_temp\""} {
+		if strings.Contains(run, forbidden) {
+			t.Fatalf("Homebrew install gate must not override Homebrew's temporary directory; found %q", forbidden)
+		}
 	}
 }
 
@@ -168,24 +168,24 @@ func TestCheckWorkflowRejectsHomebrewReleaseGateMutations(t *testing.T) {
 			},
 		},
 		{
-			name: "Linux Homebrew temporary directory leaves the Homebrew prefix",
+			name: "Linux Homebrew staging buildpath is not retained",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "HOMEBREW_TEMP"), "homebrew_temp=\"$(brew --prefix)/var/tmp\"", "homebrew_temp=\"$RUNNER_TEMP/homebrew-tmp\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --verbose --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{
-			name: "Linux Homebrew temporary directory uses bare var tmp",
+			name: "Linux Homebrew staging install is not verbose",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "HOMEBREW_TEMP"), "homebrew_temp=\"$(brew --prefix)/var/tmp\"", "homebrew_temp=\"/var/tmp\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --keep-tmp --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{
 			name: "staging formula install is not tap qualified",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --formula"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --formula \"staging-formula/$formula_name.rb\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --keep-tmp --verbose --formula \"staging-formula/$formula_name.rb\"")
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- use Homebrew `--keep-tmp --verbose` only for Linux staging validation
- bypass the proven Mktemp cleanup chmod EINVAL on hosted Linux runners
- preserve macOS install behavior and all formula/archive/tap safety gates

## Validation
- `go test ./... -count=1`
- `go test -race ./scripts/releaseworkflow -count=1`
- `sh scripts/test-release-workflow.sh`
- `sh scripts/test-homebrew-formula.sh`
- pre-commit and `git diff --check`

A new immutable patch release will retain Linuxbrew native installs as the deployment gate.