### PR TITLE
test(homebrew): verify releases before publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           sh scripts/test-package-release.sh
           sh scripts/test-release-workflow.sh
+          sh scripts/test-homebrew-prepublish-workflow.sh
           go test ./scripts/platformsmokeworkflow -count=1
       - name: Install pinned pre-commit
         shell: bash

--- a/.github/workflows/homebrew-prepublish-verify.yml
+++ b/.github/workflows/homebrew-prepublish-verify.yml
@@ -1,0 +1,155 @@
+name: Homebrew prepublish verification
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing public stable Release tag to verify
+        required: true
+        type: string
+
+# 手动演练只从执行所在的默认分支读取受审 workflow；输入 tag 仅绑定已公开的 Release 资产。
+env:
+  RELEASE_TAG: ${{ inputs.release_tag }}
+
+permissions:
+  contents: read
+
+jobs:
+  validate_existing_release:
+    name: Validate an existing public stable Release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version: '1.26.3'
+      - name: Validate the manual tag and the public Release
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"
+          go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"
+          case "$RELEASE_TAG" in
+            v[0-9]*) ;;
+            *) printf '%s\n' 'release tag must start with v and a digit' >&2; exit 1 ;;
+          esac
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" > release.json
+          python3 - "$RELEASE_TAG" release.json <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          tag = sys.argv[1]
+          release = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+          if release.get("tag_name") != tag:
+              raise SystemExit("release tag does not match the requested tag")
+          if release.get("draft") or release.get("prerelease") or not release.get("published_at"):
+              raise SystemExit("requested release must already be public and stable")
+          PY
+
+  render_stable_formula:
+    name: Render a stable formula from Release checksums
+    needs: validate_existing_release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version: '1.26.3'
+      - name: Download only the public Release checksums
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p verified-release
+          gh release download "$RELEASE_TAG" --pattern checksums.txt --dir verified-release
+          test "$(find verified-release -maxdepth 1 -type f -print | LC_ALL=C sort)" = "verified-release/checksums.txt"
+      - name: Render exactly the stable formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          test "$(go run ./scripts/releaseassets channel --version "$version")" = stable
+          mkdir -p staging-formula
+          go run ./scripts/homebrewformula render \
+            --formula pixiv-cli \
+            --version "$version" \
+            --checksums verified-release/checksums.txt \
+            --output staging-formula/pixiv-cli.rb
+          printf '%s\n' pixiv-cli > staging-formula/formula-name
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: staging-homebrew-formula
+          path: staging-formula
+          if-no-files-found: error
+          retention-days: 1
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: verified-release-checksums
+          path: verified-release/checksums.txt
+          if-no-files-found: error
+          retention-days: 1
+
+  verify_homebrew_formula:
+    name: Verify Homebrew on ${{ matrix.os }}/${{ matrix.arch }}
+    needs: render_stable_formula
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-intel
+            os: darwin
+            arch: amd64
+          - runner: macos-15
+            os: darwin
+            arch: arm64
+          - runner: ubuntu-22.04
+            os: linux
+            arch: amd64
+          - runner: ubuntu-22.04-arm
+            os: linux
+            arch: arm64
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: staging-homebrew-formula
+          path: staging-formula
+      - name: Install the local staging formula and verify its version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ '${{ matrix.os }}' = linux ]; then
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          fi
+          formula_name=$(cat staging-formula/formula-name)
+          test "$formula_name" = pixiv-cli
+          test "$(find staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(printf '%s\n%s\n' staging-formula/formula-name staging-formula/pixiv-cli.rb | LC_ALL=C sort)"
+          staging_tap=pixiv-cli-release/staging
+          tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
+          brew tap-new "$staging_tap" --no-git
+          brew trust --tap "$staging_tap"
+          cp staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
+          if [ '${{ matrix.os }}' = linux ]; then
+            brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+          else
+            brew install --formula "$staging_tap/$formula_name"
+          fi
+          pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -465,6 +465,19 @@ secret 和 tag protection 的远端实际状态；它不替代 Task 20 的远端
 不执行；`--verbose` 则保留可审计的 Homebrew 操作输出。二者不进入公开 formula，也不改变终端用户的
 `brew install` 行为。
 
+### 发布前只读 Homebrew 演练
+
+在创建任何新 tag 或 Release 前，维护者可从默认分支手动运行
+`.github/workflows/homebrew-prepublish-verify.yml`，并传入一个**已公开、非 draft、非 prerelease** 的
+stable Release tag。它先验证输入为带 `v` 前缀的 SemVer、执行分支为默认分支，并确认 GitHub Release 的
+tag 与输入一致；随后只下载该 Release 已发布的 `checksums.txt`，渲染 `pixiv-cli` staging formula，最后在
+macOS Intel/arm64 与 Linux amd64/arm64 四个生产同款 runner 上执行真实的本地 staging-tap 安装。
+
+这是一项只读 rehearsal：它没有 `release` Environment、secret、tag checkout、Release/asset 编辑或创建，
+也不会 clone、提交或推送 Homebrew tap。Linux 分支保留 `--keep-tmp --verbose`，macOS 保持普通安装命令。
+它用于在正式发布之前复现 Homebrew 安装链路，**不替代**正式 tag 发布、签名 Release、tap 部署或发布后的
+安装验收。`sh scripts/test-homebrew-prepublish-workflow.sh` 会在本地和质量门中检查该 workflow 的不可变边界。
+
 正式发布目前仍必须被正式 tag、签名 GitHub Release、tap formula 与后续安装验收阻断。完整
 six-target staticlib/manifest 与真实 native artifact 证据已由 run `29192425899` 收集并受控回填；
 受保护 `release` Environment、生产 signing 私钥与公开仓库也已按 Task 20 配置，但这些前置条件本身

--- a/scripts/prepublishhomebrew/main.go
+++ b/scripts/prepublishhomebrew/main.go
@@ -21,6 +21,68 @@ var nativeTargets = map[string]struct{}{
 	"ubuntu-22.04-arm|linux|arm64": {},
 }
 
+// 四段 shell 都是只读演练的完整 allowlist。逐字绑定而不是检查片段，避免通过
+// 在既有步骤尾部追加 Release、tap 或网络写入命令绕过 workflow policy。
+const validateReleaseRun = `set -euo pipefail
+test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"
+go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"
+case "$RELEASE_TAG" in
+  v[0-9]*) ;;
+  *) printf '%s\n' 'release tag must start with v and a digit' >&2; exit 1 ;;
+esac
+gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" > release.json
+python3 - "$RELEASE_TAG" release.json <<'PY'
+import json
+import pathlib
+import sys
+
+tag = sys.argv[1]
+release = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+if release.get("tag_name") != tag:
+    raise SystemExit("release tag does not match the requested tag")
+if release.get("draft") or release.get("prerelease") or not release.get("published_at"):
+    raise SystemExit("requested release must already be public and stable")
+PY
+`
+
+const downloadChecksumsRun = `set -euo pipefail
+mkdir -p verified-release
+gh release download "$RELEASE_TAG" --pattern checksums.txt --dir verified-release
+test "$(find verified-release -maxdepth 1 -type f -print | LC_ALL=C sort)" = "verified-release/checksums.txt"
+`
+
+const renderStableFormulaRun = `set -euo pipefail
+version="${RELEASE_TAG#v}"
+test "$(go run ./scripts/releaseassets channel --version "$version")" = stable
+mkdir -p staging-formula
+go run ./scripts/homebrewformula render \
+  --formula pixiv-cli \
+  --version "$version" \
+  --checksums verified-release/checksums.txt \
+  --output staging-formula/pixiv-cli.rb
+printf '%s\n' pixiv-cli > staging-formula/formula-name
+`
+
+const verifyStagingFormulaRun = `set -euo pipefail
+if [ '${{ matrix.os }}' = linux ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+formula_name=$(cat staging-formula/formula-name)
+test "$formula_name" = pixiv-cli
+test "$(find staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(printf '%s\n%s\n' staging-formula/formula-name staging-formula/pixiv-cli.rb | LC_ALL=C sort)"
+staging_tap=pixiv-cli-release/staging
+tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
+brew tap-new "$staging_tap" --no-git
+brew trust --tap "$staging_tap"
+cp staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
+if [ '${{ matrix.os }}' = linux ]; then
+  brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+else
+  brew install --formula "$staging_tap/$formula_name"
+fi
+pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"
+`
+
 func main() {
 	if len(os.Args) != 3 || os.Args[1] != "--workflow" {
 		fmt.Fprintln(os.Stderr, "prepublish Homebrew workflow policy: usage: prepublishhomebrew --workflow PATH")
@@ -96,16 +158,11 @@ func checkValidate(job *yaml.Node) error {
 	if len(steps) != 3 || !checkoutStep(steps[0]) || !goSetupStep(steps[1]) {
 		return errors.New("validate job must use the fixed checkout and Go setup")
 	}
-	run := runStep(steps[2], "Validate the manual tag and the public Release")
-	for _, required := range []string{
-		"test \"$GITHUB_REF\" = \"refs/heads/$DEFAULT_BRANCH\"", "go run ./scripts/releaseassets validate --version \"${RELEASE_TAG#v}\"", "case \"$RELEASE_TAG\" in", "gh api \"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG\"", "release.get(\"tag_name\")", "release.get(\"draft\")", "release.get(\"prerelease\")", "release.get(\"published_at\")",
-	} {
-		if !strings.Contains(run, required) {
-			return errors.New("validate job must check the main ref, SemVer, and public stable Release metadata")
-		}
-	}
-	if !exactStringMap(value(steps[2], "env"), map[string]string{"DEFAULT_BRANCH": "${{ github.event.repository.default_branch }}", "GH_TOKEN": "${{ github.token }}"}) {
-		return errors.New("validate job has unexpected credentials")
+	if !canonicalRunStep(steps[2], "Validate the manual tag and the public Release", validateReleaseRun, map[string]string{
+		"DEFAULT_BRANCH": "${{ github.event.repository.default_branch }}",
+		"GH_TOKEN":       "${{ github.token }}",
+	}) {
+		return errors.New("validate job must use the canonical read-only release check")
 	}
 	return nil
 }
@@ -118,17 +175,11 @@ func checkRender(job *yaml.Node) error {
 	if len(steps) != 6 || !checkoutStep(steps[0]) || !goSetupStep(steps[1]) {
 		return errors.New("render job must use the fixed checkout and Go setup")
 	}
-	download := runStep(steps[2], "Download only the public Release checksums")
-	render := runStep(steps[3], "Render exactly the stable formula")
-	if !strings.Contains(download, "gh release download \"$RELEASE_TAG\" --pattern checksums.txt --dir verified-release") ||
-		!strings.Contains(render, "go run ./scripts/releaseassets channel --version \"$version\"") ||
-		!strings.Contains(render, "--formula pixiv-cli") || strings.Contains(render, "pixiv-cli-beta") ||
+	if !canonicalRunStep(steps[2], "Download only the public Release checksums", downloadChecksumsRun, map[string]string{"GH_TOKEN": "${{ github.token }}"}) ||
+		!canonicalRunStep(steps[3], "Render exactly the stable formula", renderStableFormulaRun, nil) ||
 		!artifactStep(steps[4], "staging-homebrew-formula", "staging-formula") ||
 		!artifactStep(steps[5], "verified-release-checksums", "verified-release/checksums.txt") {
 		return errors.New("render job must download Release checksums and render only pixiv-cli")
-	}
-	if !exactStringMap(value(steps[2], "env"), map[string]string{"GH_TOKEN": "${{ github.token }}"}) {
-		return errors.New("checksum download has unexpected credentials")
 	}
 	return nil
 }
@@ -147,18 +198,8 @@ func checkVerify(job *yaml.Node) error {
 		scalar(value(steps[0], "with"), "path") != "staging-formula" {
 		return errors.New("verify job must download only the staging formula")
 	}
-	run := runStep(steps[1], "Install the local staging formula and verify its version")
-	for _, required := range []string{
-		"eval \"$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"", "test \"$formula_name\" = pixiv-cli", "brew tap-new \"$staging_tap\" --no-git", "brew trust --tap \"$staging_tap\"", "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --formula \"$staging_tap/$formula_name\"", "pixiv version --json",
-	} {
-		if !strings.Contains(run, required) {
-			return errors.New("verify job must keep the canonical Linux and macOS Homebrew install paths")
-		}
-	}
-	for _, forbidden := range []string{"git clone", "git push", "gh release create", "gh release edit", "brew tap \"FlanChanXwO/tap\""} {
-		if strings.Contains(run, forbidden) {
-			return errors.New("verify job must not publish a tap or Release")
-		}
+	if !canonicalRunStep(steps[1], "Install the local staging formula and verify its version", verifyStagingFormulaRun, nil) {
+		return errors.New("verify job must use the canonical Linux and macOS Homebrew install paths")
 	}
 	return nil
 }
@@ -234,11 +275,15 @@ func artifactStep(step *yaml.Node, name, path string) bool {
 		})
 }
 
-func runStep(step *yaml.Node, name string) string {
-	if step == nil || scalar(step, "name") != name || scalar(step, "shell") != "bash" {
-		return ""
+func canonicalRunStep(step *yaml.Node, name, run string, env map[string]string) bool {
+	keys := []string{"name", "shell", "run"}
+	if env != nil {
+		keys = append(keys, "env")
 	}
-	return scalar(step, "run")
+	if !exactKeys(step, keys...) || scalar(step, "name") != name || scalar(step, "shell") != "bash" || scalar(step, "run") != run {
+		return false
+	}
+	return env == nil || exactStringMap(value(step, "env"), env)
 }
 
 func stepsOf(job *yaml.Node) []*yaml.Node {

--- a/scripts/prepublishhomebrew/main.go
+++ b/scripts/prepublishhomebrew/main.go
@@ -1,0 +1,290 @@
+// Command prepublishhomebrew 检查只读 Homebrew 发布前演练 workflow 的安全边界。
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/FlanChanXwO/pixiv-cli/scripts/internal/workflowpolicy"
+	"gopkg.in/yaml.v3"
+)
+
+var actionReferencePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[0-9a-f]{40}$`)
+
+var nativeTargets = map[string]struct{}{
+	"macos-15-intel|darwin|amd64":  {},
+	"macos-15|darwin|arm64":        {},
+	"ubuntu-22.04|linux|amd64":     {},
+	"ubuntu-22.04-arm|linux|arm64": {},
+}
+
+func main() {
+	if len(os.Args) != 3 || os.Args[1] != "--workflow" {
+		fmt.Fprintln(os.Stderr, "prepublish Homebrew workflow policy: usage: prepublishhomebrew --workflow PATH")
+		os.Exit(1)
+	}
+	body, err := os.ReadFile(os.Args[2])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "prepublish Homebrew workflow policy: read workflow: %v\n", err)
+		os.Exit(1)
+	}
+	if err := checkWorkflow(body); err != nil {
+		fmt.Fprintf(os.Stderr, "prepublish Homebrew workflow policy: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func checkWorkflow(body []byte) error {
+	var document yaml.Node
+	if err := yaml.Unmarshal(body, &document); err != nil {
+		return fmt.Errorf("parse YAML: %w", err)
+	}
+	if err := workflowpolicy.RejectAmbiguousYAML(&document); err != nil {
+		return err
+	}
+	if document.Kind != yaml.DocumentNode || len(document.Content) != 1 {
+		return errors.New("workflow must contain one document")
+	}
+	root := document.Content[0]
+	if !exactKeys(root, "name", "on", "env", "permissions", "jobs") || scalar(root, "name") != "Homebrew prepublish verification" {
+		return errors.New("workflow root is not the fixed read-only prepublish shape")
+	}
+	if err := checkDispatch(root); err != nil {
+		return err
+	}
+	if !exactStringMap(value(root, "env"), map[string]string{"RELEASE_TAG": "${{ inputs.release_tag }}"}) || !contentsRead(root) {
+		return errors.New("workflow must bind only the required release_tag with contents read")
+	}
+	if workflowpolicy.ContainsSecretReference(root) {
+		return errors.New("prepublish workflow must not reference secrets")
+	}
+	if err := checkActions(root); err != nil {
+		return err
+	}
+	jobs := value(root, "jobs")
+	if !exactKeys(jobs, "validate_existing_release", "render_stable_formula", "verify_homebrew_formula") {
+		return errors.New("workflow must contain only validation, render, and native verify jobs")
+	}
+	if err := checkValidate(value(jobs, "validate_existing_release")); err != nil {
+		return err
+	}
+	if err := checkRender(value(jobs, "render_stable_formula")); err != nil {
+		return err
+	}
+	return checkVerify(value(jobs, "verify_homebrew_formula"))
+}
+
+func checkDispatch(root *yaml.Node) error {
+	on := value(root, "on")
+	dispatch := value(on, "workflow_dispatch")
+	input := value(value(dispatch, "inputs"), "release_tag")
+	if !exactKeys(on, "workflow_dispatch") || !exactKeys(dispatch, "inputs") || !exactKeys(value(dispatch, "inputs"), "release_tag") ||
+		!exactKeys(input, "description", "required", "type") || scalar(input, "description") != "Existing public stable Release tag to verify" || scalar(input, "type") != "string" || !boolValue(input, "required", true) {
+		return errors.New("workflow_dispatch must require exactly one release_tag input")
+	}
+	return nil
+}
+
+func checkValidate(job *yaml.Node) error {
+	if !jobShape(job, "Validate an existing public stable Release", "", false) {
+		return errors.New("validate job must be an unprivileged fixed Linux job")
+	}
+	steps := stepsOf(job)
+	if len(steps) != 3 || !checkoutStep(steps[0]) || !goSetupStep(steps[1]) {
+		return errors.New("validate job must use the fixed checkout and Go setup")
+	}
+	run := runStep(steps[2], "Validate the manual tag and the public Release")
+	for _, required := range []string{
+		"test \"$GITHUB_REF\" = \"refs/heads/$DEFAULT_BRANCH\"", "go run ./scripts/releaseassets validate --version \"${RELEASE_TAG#v}\"", "case \"$RELEASE_TAG\" in", "gh api \"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG\"", "release.get(\"tag_name\")", "release.get(\"draft\")", "release.get(\"prerelease\")", "release.get(\"published_at\")",
+	} {
+		if !strings.Contains(run, required) {
+			return errors.New("validate job must check the main ref, SemVer, and public stable Release metadata")
+		}
+	}
+	if !exactStringMap(value(steps[2], "env"), map[string]string{"DEFAULT_BRANCH": "${{ github.event.repository.default_branch }}", "GH_TOKEN": "${{ github.token }}"}) {
+		return errors.New("validate job has unexpected credentials")
+	}
+	return nil
+}
+
+func checkRender(job *yaml.Node) error {
+	if !jobShape(job, "Render a stable formula from Release checksums", "validate_existing_release", true) {
+		return errors.New("render job must be an unprivileged fixed Linux job")
+	}
+	steps := stepsOf(job)
+	if len(steps) != 6 || !checkoutStep(steps[0]) || !goSetupStep(steps[1]) {
+		return errors.New("render job must use the fixed checkout and Go setup")
+	}
+	download := runStep(steps[2], "Download only the public Release checksums")
+	render := runStep(steps[3], "Render exactly the stable formula")
+	if !strings.Contains(download, "gh release download \"$RELEASE_TAG\" --pattern checksums.txt --dir verified-release") ||
+		!strings.Contains(render, "go run ./scripts/releaseassets channel --version \"$version\"") ||
+		!strings.Contains(render, "--formula pixiv-cli") || strings.Contains(render, "pixiv-cli-beta") ||
+		!artifactStep(steps[4], "staging-homebrew-formula", "staging-formula") ||
+		!artifactStep(steps[5], "verified-release-checksums", "verified-release/checksums.txt") {
+		return errors.New("render job must download Release checksums and render only pixiv-cli")
+	}
+	if !exactStringMap(value(steps[2], "env"), map[string]string{"GH_TOKEN": "${{ github.token }}"}) {
+		return errors.New("checksum download has unexpected credentials")
+	}
+	return nil
+}
+
+func checkVerify(job *yaml.Node) error {
+	if !exactKeys(job, "name", "needs", "runs-on", "permissions", "strategy", "steps") ||
+		scalar(job, "name") != "Verify Homebrew on ${{ matrix.os }}/${{ matrix.arch }}" ||
+		scalar(job, "needs") != "render_stable_formula" || scalar(job, "runs-on") != "${{ matrix.runner }}" ||
+		!contentsRead(job) || !nativeMatrix(value(job, "strategy")) {
+		return errors.New("verify job must retain the exact four native targets")
+	}
+	steps := stepsOf(job)
+	if len(steps) != 2 || !exactKeys(steps[0], "uses", "with") ||
+		!strings.HasPrefix(scalar(steps[0], "uses"), "actions/download-artifact@") ||
+		scalar(value(steps[0], "with"), "name") != "staging-homebrew-formula" ||
+		scalar(value(steps[0], "with"), "path") != "staging-formula" {
+		return errors.New("verify job must download only the staging formula")
+	}
+	run := runStep(steps[1], "Install the local staging formula and verify its version")
+	for _, required := range []string{
+		"eval \"$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"", "test \"$formula_name\" = pixiv-cli", "brew tap-new \"$staging_tap\" --no-git", "brew trust --tap \"$staging_tap\"", "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --formula \"$staging_tap/$formula_name\"", "pixiv version --json",
+	} {
+		if !strings.Contains(run, required) {
+			return errors.New("verify job must keep the canonical Linux and macOS Homebrew install paths")
+		}
+	}
+	for _, forbidden := range []string{"git clone", "git push", "gh release create", "gh release edit", "brew tap \"FlanChanXwO/tap\""} {
+		if strings.Contains(run, forbidden) {
+			return errors.New("verify job must not publish a tap or Release")
+		}
+	}
+	return nil
+}
+
+func jobShape(job *yaml.Node, name, needs string, hasNeeds bool) bool {
+	keys := []string{"name", "runs-on", "permissions", "steps"}
+	if hasNeeds {
+		keys = append(keys, "needs")
+	}
+	return exactKeys(job, keys...) && scalar(job, "name") == name && scalar(job, "runs-on") == "ubuntu-24.04" && (!hasNeeds || scalar(job, "needs") == needs) && contentsRead(job)
+}
+
+func nativeMatrix(strategy *yaml.Node) bool {
+	if !exactKeys(strategy, "fail-fast", "matrix") || !boolValue(strategy, "fail-fast", false) {
+		return false
+	}
+	matrix := value(strategy, "matrix")
+	include := value(matrix, "include")
+	if !exactKeys(matrix, "include") || include == nil || include.Kind != yaml.SequenceNode || len(include.Content) != len(nativeTargets) {
+		return false
+	}
+	seen := map[string]struct{}{}
+	for _, target := range include.Content {
+		if !exactKeys(target, "runner", "os", "arch") {
+			return false
+		}
+		identity := strings.Join([]string{scalar(target, "runner"), scalar(target, "os"), scalar(target, "arch")}, "|")
+		if _, ok := nativeTargets[identity]; !ok {
+			return false
+		}
+		if _, duplicate := seen[identity]; duplicate {
+			return false
+		}
+		seen[identity] = struct{}{}
+	}
+	return true
+}
+
+func checkActions(node *yaml.Node) error {
+	if node == nil {
+		return errors.New("workflow contains nil node")
+	}
+	if node.Kind == yaml.MappingNode {
+		if uses := value(node, "uses"); uses != nil && (uses.Kind != yaml.ScalarNode || !actionReferencePattern.MatchString(uses.Value)) {
+			return errors.New("workflow actions must use immutable full SHA references")
+		}
+	}
+	for _, child := range node.Content {
+		if err := checkActions(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkoutStep(step *yaml.Node) bool {
+	return actionStep(step, "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5", "persist-credentials", "false") && scalar(value(step, "with"), "ref") == "${{ github.sha }}"
+}
+
+func goSetupStep(step *yaml.Node) bool {
+	return actionStep(step, "actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff", "go-version", "1.26.3")
+}
+
+func actionStep(step *yaml.Node, action, key, want string) bool {
+	return exactKeys(step, "uses", "with") && scalar(step, "uses") == action && scalar(value(step, "with"), key) == want
+}
+
+func artifactStep(step *yaml.Node, name, path string) bool {
+	return exactKeys(step, "uses", "with") &&
+		scalar(step, "uses") == "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" &&
+		exactStringMap(value(step, "with"), map[string]string{
+			"name": name, "path": path, "if-no-files-found": "error", "retention-days": "1",
+		})
+}
+
+func runStep(step *yaml.Node, name string) string {
+	if step == nil || scalar(step, "name") != name || scalar(step, "shell") != "bash" {
+		return ""
+	}
+	return scalar(step, "run")
+}
+
+func stepsOf(job *yaml.Node) []*yaml.Node {
+	steps := value(job, "steps")
+	if steps == nil || steps.Kind != yaml.SequenceNode {
+		return nil
+	}
+	return steps.Content
+}
+
+func contentsRead(node *yaml.Node) bool {
+	return exactStringMap(value(node, "permissions"), map[string]string{"contents": "read"})
+}
+
+func value(node *yaml.Node, key string) *yaml.Node {
+	value, _ := workflowpolicy.MappingValue(node, key)
+	return value
+}
+
+func scalar(node *yaml.Node, key string) string {
+	value := value(node, key)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return value.Value
+}
+
+func boolValue(node *yaml.Node, key string, want bool) bool {
+	value := value(node, key)
+	return value != nil && value.Kind == yaml.ScalarNode && value.Tag == "!!bool" && value.Value == fmt.Sprint(want)
+}
+
+func exactKeys(node *yaml.Node, keys ...string) bool {
+	return workflowpolicy.HasExactMappingKeys(node, keys...)
+}
+
+func exactStringMap(node *yaml.Node, want map[string]string) bool {
+	if node == nil || node.Kind != yaml.MappingNode || len(node.Content) != len(want)*2 {
+		return false
+	}
+	keys := make([]string, 0, len(want))
+	for key, expected := range want {
+		if scalar(node, key) != expected {
+			return false
+		}
+		keys = append(keys, key)
+	}
+	return exactKeys(node, keys...)
+}

--- a/scripts/prepublishhomebrew/main_test.go
+++ b/scripts/prepublishhomebrew/main_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/FlanChanXwO/pixiv-cli/scripts/internal/workflowpolicy"
+	"gopkg.in/yaml.v3"
+)
+
+// 预发布验收必须是只读的：它只允许手动触发并验证一个已公开的 stable Release。
+func TestWorkflowEnforcesReadOnlyStableReleaseRehearsal(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join(findRepositoryRoot(t), ".github", "workflows", "homebrew-prepublish-verify.yml"))
+	if err != nil {
+		t.Fatalf("read prepublish Homebrew workflow: %v", err)
+	}
+	if err := checkWorkflow(body); err != nil {
+		t.Fatalf("prepublish Homebrew workflow policy rejected the checked-in workflow: %v", err)
+	}
+}
+
+func findRepositoryRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	return root
+}
+
+func TestWorkflowRejectsReadOnlyBoundaryMutations(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name   string
+		mutate func(t *testing.T, root *yaml.Node)
+	}{
+		{
+			name: "adds a push trigger",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				appendMappingValue(t, mappingValue(t, root, "on"), "push", &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"})
+			},
+		},
+		{
+			name: "adds a deploy job",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				appendMappingValue(t, mappingValue(t, root, "jobs"), "deploy", &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"})
+			},
+		},
+		{
+			name: "adds an environment",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				appendMappingValue(t, job(t, root, "render_stable_formula"), "environment", scalarNode("release"))
+			},
+		},
+		{
+			name: "references a secret",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				appendMappingValue(t, job(t, root, "verify_homebrew_formula"), "env", mappingNode("LEAK", scalarNode("${{ secrets.TOKEN }}")))
+			},
+		},
+		{
+			name: "removes Linux staging retention",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --keep-tmp --verbose", "brew install --verbose")
+			},
+		},
+		{
+			name: "applies Linux flags to macOS",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"")
+			},
+		},
+		{
+			name: "downloads an unverified file",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRun(t, runStepWith(t, job(t, root, "render_stable_formula"), "gh release download"), "--pattern checksums.txt", "--pattern checksums.json")
+			},
+		},
+		{
+			name: "uses a mutable action reference",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				mappingValue(t, mappingValue(t, job(t, root, "validate_existing_release"), "steps").Content[0], "uses").Value = "actions/checkout@v4"
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := prepublishWorkflowRoot(t)
+			test.mutate(t, root)
+			if err := checkWorkflow(marshalWorkflow(t, root)); err == nil {
+				t.Fatal("policy accepted an unsafe prepublish workflow mutation")
+			}
+		})
+	}
+}
+
+func TestQualityWorkflowRunsPrepublishPolicy(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join(findRepositoryRoot(t), ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read quality workflow: %v", err)
+	}
+	if !strings.Contains(string(body), "sh scripts/test-homebrew-prepublish-workflow.sh") {
+		t.Fatal("quality workflow does not run the prepublish Homebrew policy")
+	}
+}
+
+func prepublishWorkflowRoot(t *testing.T) *yaml.Node {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(findRepositoryRoot(t), ".github", "workflows", "homebrew-prepublish-verify.yml"))
+	if err != nil {
+		t.Fatalf("read prepublish workflow: %v", err)
+	}
+	var document yaml.Node
+	if err := yaml.Unmarshal(body, &document); err != nil {
+		t.Fatalf("parse prepublish workflow: %v", err)
+	}
+	return document.Content[0]
+}
+
+func marshalWorkflow(t *testing.T, root *yaml.Node) []byte {
+	t.Helper()
+	body, err := yaml.Marshal(root)
+	if err != nil {
+		t.Fatalf("marshal workflow: %v", err)
+	}
+	return body
+}
+
+func job(t *testing.T, root *yaml.Node, name string) *yaml.Node {
+	t.Helper()
+	return mappingValue(t, mappingValue(t, root, "jobs"), name)
+}
+
+func mappingValue(t *testing.T, node *yaml.Node, key string) *yaml.Node {
+	t.Helper()
+	value, ok := workflowpolicy.MappingValue(node, key)
+	if !ok {
+		t.Fatalf("mapping has no %q", key)
+	}
+	return value
+}
+
+func runStepWith(t *testing.T, job *yaml.Node, fragment string) *yaml.Node {
+	t.Helper()
+	for _, step := range mappingValue(t, job, "steps").Content {
+		if run, ok := workflowpolicy.MappingValue(step, "run"); ok && strings.Contains(run.Value, fragment) {
+			return step
+		}
+	}
+	t.Fatalf("job has no run step containing %q", fragment)
+	return nil
+}
+
+func replaceRun(t *testing.T, step *yaml.Node, old, new string) {
+	t.Helper()
+	run := mappingValue(t, step, "run")
+	if !strings.Contains(run.Value, old) {
+		t.Fatalf("run step has no %q", old)
+	}
+	run.Value = strings.Replace(run.Value, old, new, 1)
+}
+
+func appendMappingValue(t *testing.T, node *yaml.Node, key string, value *yaml.Node) {
+	t.Helper()
+	node.Content = append(node.Content, scalarNode(key), value)
+}
+
+func scalarNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}
+
+func mappingNode(entries ...any) *yaml.Node {
+	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	for index := 0; index < len(entries); index += 2 {
+		node.Content = append(node.Content, scalarNode(entries[index].(string)), entries[index+1].(*yaml.Node))
+	}
+	return node
+}

--- a/scripts/prepublishhomebrew/main_test.go
+++ b/scripts/prepublishhomebrew/main_test.go
@@ -85,6 +85,30 @@ func TestWorkflowRejectsReadOnlyBoundaryMutations(t *testing.T) {
 				mappingValue(t, mappingValue(t, job(t, root, "validate_existing_release"), "steps").Content[0], "uses").Value = "actions/checkout@v4"
 			},
 		},
+		{
+			name: "validate creates a Release after checking it",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				appendRun(t, runStepWith(t, job(t, root, "validate_existing_release"), "gh api"), "gh release create \"$RELEASE_TAG\" --title unsafe")
+			},
+		},
+		{
+			name: "checksum download pushes a tap commit",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				appendRun(t, runStepWith(t, job(t, root, "render_stable_formula"), "gh release download"), "git push origin HEAD:main")
+			},
+		},
+		{
+			name: "checksum download trusts the public tap",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				appendRun(t, runStepWith(t, job(t, root, "render_stable_formula"), "gh release download"), "brew tap \"FlanChanXwO/tap\"")
+			},
+		},
+		{
+			name: "native verification creates a Release through the API",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				appendRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "pixiv version --json"), "gh api --method POST \"repos/$GITHUB_REPOSITORY/releases\"")
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -161,6 +185,12 @@ func replaceRun(t *testing.T, step *yaml.Node, old, new string) {
 		t.Fatalf("run step has no %q", old)
 	}
 	run.Value = strings.Replace(run.Value, old, new, 1)
+}
+
+func appendRun(t *testing.T, step *yaml.Node, command string) {
+	t.Helper()
+	run := mappingValue(t, step, "run")
+	run.Value += "\n" + command
 }
 
 func appendMappingValue(t *testing.T, node *yaml.Node, key string, value *yaml.Node) {

--- a/scripts/test-homebrew-prepublish-workflow.sh
+++ b/scripts/test-homebrew-prepublish-workflow.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# 验证只读 Homebrew 发布前演练 workflow 的安全结构；不访问 GitHub 或 Homebrew。
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+exec go run "$repo_root/scripts/prepublishhomebrew" --workflow "$repo_root/.github/workflows/homebrew-prepublish-verify.yml"


### PR DESCRIPTION
Adds a dispatch-only, read-only Homebrew rehearsal for an existing public stable Release.

- renders from the Release checksums without recomputing them
- verifies the production macOS/Linux amd64/arm64 matrix
- keeps Linux-only `--keep-tmp --verbose` staging behavior
- uses fail-closed YAML policy tests for command, permission, and deployment boundaries

No Release, tag, asset, or tap write path is included.