### PR TITLE
fix(homebrew): retain Linux resource staging

### DIFF
--- a/.github/workflows/homebrew-prepublish-verify.yml
+++ b/.github/workflows/homebrew-prepublish-verify.yml
@@ -148,7 +148,7 @@ jobs:
           brew trust --tap "$staging_tap"
           cp staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
           if [ '${{ matrix.os }}' = linux ]; then
-            brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+            brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
           else
             brew install --formula "$staging_tap/$formula_name"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -570,7 +570,7 @@ jobs:
           brew trust --tap "$staging_tap"
           cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
           if [ '${{ matrix.os }}' = linux ]; then
-            brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+            brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
           else
             brew install --formula "$staging_tap/$formula_name"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Linux Homebrew release validation now retains its staging buildpath with `brew install --keep-tmp --verbose` to bypass the documented GitHub runner cleanup `chmod` `EINVAL`; this affects only the short-lived release-validation runner, not end-user Homebrew installs.
+- Linux Homebrew hosted staging verification now uses `brew install --debug-symbols --verbose`: Homebrew Resource staging happens before `--keep-tmp` can affect its Mktemp cleanup, while `--debug-symbols` retains the source-cache staging path. This is limited to short-lived Linux verification runners, leaves macOS and end-user Homebrew installs unchanged, and still requires real-runner validation before release.
 
 ## [0.4.4] - 2026-07-19
 

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -446,7 +446,7 @@ prerelease 结果直接映射为 `pixiv-cli`/`pixiv-cli-beta`。随后精确四�
 Linux amd64/arm64）先用 `brew tap-new pixiv-cli-release/staging --no-git` 创建各 runner 的隔离
 local tap，再以 `brew trust --tap pixiv-cli-release/staging` 显式信任这一个临时命名空间；将唯一
 staging formula 放入其 `Formula/`，随后用 `pixiv-cli-release/staging/<formula>` 执行真实
-`brew install --keep-tmp --verbose --formula`，解析
+`brew install --debug-symbols --verbose --formula`，解析
 `pixiv version --json` 并与 tag 比较。它不使用 workspace formula path、developer/环境变量 bypass，
 也不克隆、写入或信任公开 tap。只有全部成功，最终受保护 `deploy_homebrew_tap` 才以 HTTPS
 clone public tap、核对唯一 staged formula，并在最后一个 step 读取 deploy key；SSH push 固定官方
@@ -459,11 +459,11 @@ secret 和 tag protection 的远端实际状态；它不替代 Task 20 的远端
 会先公开 Release 再安装；若安装失败，Release 已公开但 tap 不变，需要维护者显式处置，不能绕过 gate
 手工 push。
 
-`--keep-tmp --verbose` 仅用于短命 GitHub release-validation runner 的 Linux 分支，macOS 继续使用
-原来的 `brew install --formula`：Linuxbrew 的 Resource/Mktemp cleanup 已有
-直接 backtrace 证据会在 runner 上触发 `FileUtils.chmod` 的 `EINVAL`，而保留 buildpath 能让该 cleanup
-不执行；`--verbose` 则保留可审计的 Homebrew 操作输出。二者不进入公开 formula，也不改变终端用户的
-`brew install` 行为。
+`--debug-symbols --verbose` 仅用于短命 GitHub release-validation runner 的 Linux 分支，macOS 继续使用
+原来的 `brew install --formula`：Linuxbrew 的 Resource staging 发生在 `--keep-tmp` 生效前，且其
+Mktemp cleanup 已有直接 backtrace 证据会在 runner 上触发 `FileUtils.chmod` 的 `EINVAL`。`--debug-symbols`
+使 Resource 的 source-cache staging 保留，以避免该 cleanup；`--verbose` 则保留可审计的 Homebrew 操作
+输出。此方案尚须真实 Linux runner 验证；二者不进入公开 formula，也不改变终端用户的 `brew install` 行为。
 
 ### 发布前只读 Homebrew 演练
 
@@ -474,7 +474,7 @@ tag 与输入一致；随后只下载该 Release 已发布的 `checksums.txt`，
 macOS Intel/arm64 与 Linux amd64/arm64 四个生产同款 runner 上执行真实的本地 staging-tap 安装。
 
 这是一项只读 rehearsal：它没有 `release` Environment、secret、tag checkout、Release/asset 编辑或创建，
-也不会 clone、提交或推送 Homebrew tap。Linux 分支保留 `--keep-tmp --verbose`，macOS 保持普通安装命令。
+也不会 clone、提交或推送 Homebrew tap。Linux 分支使用 `--debug-symbols --verbose`，macOS 保持普通安装命令。
 它用于在正式发布之前复现 Homebrew 安装链路，**不替代**正式 tag 发布、签名 Release、tap 部署或发布后的
 安装验收。`sh scripts/test-homebrew-prepublish-workflow.sh` 会在本地和质量门中检查该 workflow 的不可变边界。
 

--- a/scripts/prepublishhomebrew/main.go
+++ b/scripts/prepublishhomebrew/main.go
@@ -76,7 +76,7 @@ brew tap-new "$staging_tap" --no-git
 brew trust --tap "$staging_tap"
 cp staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
 if [ '${{ matrix.os }}' = linux ]; then
-  brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+  brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
 else
   brew install --formula "$staging_tap/$formula_name"
 fi

--- a/scripts/prepublishhomebrew/main_test.go
+++ b/scripts/prepublishhomebrew/main_test.go
@@ -21,6 +21,26 @@ func TestWorkflowEnforcesReadOnlyStableReleaseRehearsal(t *testing.T) {
 	}
 }
 
+// Linuxbrew 的 Resource staging 在 --keep-tmp 生效前会清理 Mktemp 并可能在 hosted
+// runner 上失败。预发布演练必须只在 Linux 传入 --debug-symbols，让 source cache staging
+// 保留；macOS 仍使用普通安装命令，且旧 --keep-tmp 不得残留。
+func TestWorkflowUsesLinuxOnlyDebugSymbolsForHomebrewResourceStaging(t *testing.T) {
+	root := prepublishWorkflowRoot(t)
+	step := runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install")
+	run := mappingValue(t, step, "run").Value
+	want := `if [ '${{ matrix.os }}' = linux ]; then
+  brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+else
+  brew install --formula "$staging_tap/$formula_name"
+fi`
+	if !strings.Contains(run, want) {
+		t.Fatalf("prepublish install must retain Resource staging sources only on Linux and preserve macOS install; missing %q", want)
+	}
+	if strings.Contains(run, "--keep-tmp") {
+		t.Fatal("prepublish install must not retain obsolete --keep-tmp")
+	}
+}
+
 func findRepositoryRoot(t *testing.T) string {
 	t.Helper()
 	root, err := filepath.Abs(filepath.Join("..", ".."))
@@ -62,15 +82,21 @@ func TestWorkflowRejectsReadOnlyBoundaryMutations(t *testing.T) {
 			},
 		},
 		{
-			name: "removes Linux staging retention",
+			name: "removes Linux Resource staging debug symbols",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --keep-tmp --verbose", "brew install --verbose")
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose", "brew install --verbose")
 			},
 		},
 		{
-			name: "applies Linux flags to macOS",
+			name: "retains obsolete Linux keep tmp",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"")
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose", "brew install --debug-symbols --keep-tmp --verbose")
+			},
+		},
+		{
+			name: "applies Linux debug symbols to macOS",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{

--- a/scripts/releaseworkflow/homebrew_policy.go
+++ b/scripts/releaseworkflow/homebrew_policy.go
@@ -108,7 +108,7 @@ brew tap-new "$staging_tap" --no-git
 brew trust --tap "$staging_tap"
 cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
 if [ '${{ matrix.os }}' = linux ]; then
-brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
 else
 brew install --formula "$staging_tap/$formula_name"
 fi

--- a/scripts/releaseworkflow/homebrew_policy_test.go
+++ b/scripts/releaseworkflow/homebrew_policy_test.go
@@ -29,7 +29,7 @@ func TestCheckWorkflowRequiresTapQualifiedStagingFormulaInstall(t *testing.T) {
 
 	root := releaseWorkflowRoot(t)
 	step := stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install")
-	replaceRunFragment(t, step, "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --keep-tmp --verbose --formula \"staging-formula/$formula_name.rb\"")
+	replaceRunFragment(t, step, "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --verbose --formula \"staging-formula/$formula_name.rb\"")
 	err := checkWorkflow(mustMarshalYAML(t, root))
 	if err == nil || !strings.Contains(err.Error(), "Homebrew native install gate must use the required direct command sequence") {
 		t.Fatalf("policy error = %v, want workspace-path Homebrew formula install rejection", err)
@@ -50,9 +50,10 @@ func TestCheckWorkflowRequiresStagingTapTrust(t *testing.T) {
 	}
 }
 
-// Linuxbrew 的 Mktemp cleanup 会在短命 GitHub runner 上触发已证实的 chmod EINVAL；
-// 仅 Linux 发布验收保留 buildpath，macOS 继续使用其原本的安装命令。
-func TestWorkflowRetainsLinuxHomebrewStagingBuildPath(t *testing.T) {
+// Linuxbrew 的 Resource staging 在 --keep-tmp 生效前会触发 Mktemp cleanup，且已在
+// 短命 GitHub runner 上报出 chmod EINVAL。--debug-symbols 会让 Resource staging 的
+// source cache 保留；它只适用于 Linux 发布验收，macOS 保持原本的安装命令。
+func TestWorkflowUsesLinuxOnlyDebugSymbolsForHomebrewResourceStaging(t *testing.T) {
 	t.Parallel()
 
 	root := releaseWorkflowRoot(t)
@@ -61,16 +62,16 @@ func TestWorkflowRetainsLinuxHomebrewStagingBuildPath(t *testing.T) {
 	for _, command := range []string{
 		`eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"`,
 		`if [ '${{ matrix.os }}' = linux ]; then
-  brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+  brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
 else
   brew install --formula "$staging_tap/$formula_name"
 fi`,
 	} {
 		if !strings.Contains(run, command) {
-			t.Fatalf("Homebrew install gate must retain only the Linux staging buildpath and preserve the macOS install command; missing %q", command)
+			t.Fatalf("Homebrew install gate must retain Resource staging sources only on Linux and preserve the macOS install command; missing %q", command)
 		}
 	}
-	for _, forbidden := range []string{"HOMEBREW_TEMP", "homebrew_temp=", "mkdir -p \"$homebrew_temp\""} {
+	for _, forbidden := range []string{"HOMEBREW_TEMP", "homebrew_temp=", "mkdir -p \"$homebrew_temp\"", "--keep-tmp"} {
 		if strings.Contains(run, forbidden) {
 			t.Fatalf("Homebrew install gate must not override Homebrew's temporary directory; found %q", forbidden)
 		}
@@ -172,35 +173,49 @@ func TestCheckWorkflowRejectsHomebrewReleaseGateMutations(t *testing.T) {
 			},
 		},
 		{
-			name: "Linux Homebrew staging buildpath is not retained",
+			name: "Linux Homebrew Resource staging debug symbols are removed",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --verbose --formula \"$staging_tap/$formula_name\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --verbose --formula \"$staging_tap/$formula_name\"")
+			},
+		},
+		{
+			name: "Linux Homebrew Resource staging retains obsolete keep tmp",
+			want: "Homebrew native install gate must use the required direct command sequence",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{
 			name: "Linux Homebrew staging install is not verbose",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --keep-tmp --formula \"$staging_tap/$formula_name\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{
-			name: "Linux Homebrew retention flags leave the Linux conditional",
+			name: "Linux Homebrew debug symbols leave the Linux conditional",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), `if [ '${{ matrix.os }}' = linux ]; then
-  brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), `if [ '${{ matrix.os }}' = linux ]; then
+  brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
 else
   brew install --formula "$staging_tap/$formula_name"
-fi`, `brew install --keep-tmp --verbose --formula "$staging_tap/$formula_name"`)
+fi`, `brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"`)
+			},
+		},
+		{
+			name: "Linux Homebrew debug symbols leak to macOS",
+			want: "Homebrew native install gate must use the required direct command sequence",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{
 			name: "staging formula install is not tap qualified",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --keep-tmp"), "brew install --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"", "brew install --keep-tmp --verbose --formula \"staging-formula/$formula_name.rb\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --verbose --formula \"staging-formula/$formula_name.rb\"")
 			},
 		},
 		{


### PR DESCRIPTION
Replaces the disproven Linux-only `--keep-tmp` workaround with Homebrew's earlier `--debug-symbols` source-staging retention.

The change is constrained to hosted Linux staging verification; macOS and public formulas remain unchanged. It is guarded by the release and prepublish workflow policies, but still requires the non-publishing v0.4.4 four-platform rehearsal after merge.