### PR TITLE
fix(homebrew): require source build for debug symbols

### DIFF
--- a/.github/workflows/homebrew-prepublish-verify.yml
+++ b/.github/workflows/homebrew-prepublish-verify.yml
@@ -148,7 +148,7 @@ jobs:
           brew trust --tap "$staging_tap"
           cp staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
           if [ '${{ matrix.os }}' = linux ]; then
-            brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+            brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
           else
             brew install --formula "$staging_tap/$formula_name"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -570,7 +570,7 @@ jobs:
           brew trust --tap "$staging_tap"
           cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
           if [ '${{ matrix.os }}' = linux ]; then
-            brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+            brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
           else
             brew install --formula "$staging_tap/$formula_name"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Linux Homebrew hosted staging verification now uses `brew install --debug-symbols --verbose`: Homebrew Resource staging happens before `--keep-tmp` can affect its Mktemp cleanup, while `--debug-symbols` retains the source-cache staging path. This is limited to short-lived Linux verification runners, leaves macOS and end-user Homebrew installs unchanged, and still requires real-runner validation before release.
+- Linux Homebrew hosted staging verification now uses `brew install --build-from-source --debug-symbols --verbose`: Homebrew rejects `--debug-symbols` without the explicit source-build flag before staging begins. This Linux-only, non-interactive verification combination leaves macOS and end-user Homebrew installs unchanged and still requires real resource-stage validation before release.
 
 ## [0.4.4] - 2026-07-19
 

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -446,7 +446,7 @@ prerelease 结果直接映射为 `pixiv-cli`/`pixiv-cli-beta`。随后精确四�
 Linux amd64/arm64）先用 `brew tap-new pixiv-cli-release/staging --no-git` 创建各 runner 的隔离
 local tap，再以 `brew trust --tap pixiv-cli-release/staging` 显式信任这一个临时命名空间；将唯一
 staging formula 放入其 `Formula/`，随后用 `pixiv-cli-release/staging/<formula>` 执行真实
-`brew install --debug-symbols --verbose --formula`，解析
+`brew install --build-from-source --debug-symbols --verbose --formula`，解析
 `pixiv version --json` 并与 tag 比较。它不使用 workspace formula path、developer/环境变量 bypass，
 也不克隆、写入或信任公开 tap。只有全部成功，最终受保护 `deploy_homebrew_tap` 才以 HTTPS
 clone public tap、核对唯一 staged formula，并在最后一个 step 读取 deploy key；SSH push 固定官方
@@ -459,11 +459,12 @@ secret 和 tag protection 的远端实际状态；它不替代 Task 20 的远端
 会先公开 Release 再安装；若安装失败，Release 已公开但 tap 不变，需要维护者显式处置，不能绕过 gate
 手工 push。
 
-`--debug-symbols --verbose` 仅用于短命 GitHub release-validation runner 的 Linux 分支，macOS 继续使用
-原来的 `brew install --formula`：Linuxbrew 的 Resource staging 发生在 `--keep-tmp` 生效前，且其
-Mktemp cleanup 已有直接 backtrace 证据会在 runner 上触发 `FileUtils.chmod` 的 `EINVAL`。`--debug-symbols`
-使 Resource 的 source-cache staging 保留，以避免该 cleanup；`--verbose` 则保留可审计的 Homebrew 操作
-输出。此方案尚须真实 Linux runner 验证；二者不进入公开 formula，也不改变终端用户的 `brew install` 行为。
+`--build-from-source --debug-symbols --verbose` 仅用于短命 GitHub release-validation runner 的 Linux 分支，
+macOS 继续使用原来的 `brew install --formula`：Linuxbrew 的 Resource staging 发生在 `--keep-tmp` 生效前，且
+其 Mktemp cleanup 已有直接 backtrace 证据会在 runner 上触发 `FileUtils.chmod` 的 `EINVAL`。真实 runner 已证明
+Homebrew 会在开始 staging 前拒绝未显式配合 `--build-from-source` 的 `--debug-symbols`；这两个 flag 必须作为同一
+个非交互组合出现，`--verbose` 则保留可审计的 Homebrew 操作输出。该组合仍须通过真实 Linux resource-stage
+验证；它不进入公开 formula，也不改变终端用户的 `brew install` 行为。
 
 ### 发布前只读 Homebrew 演练
 
@@ -474,7 +475,8 @@ tag 与输入一致；随后只下载该 Release 已发布的 `checksums.txt`，
 macOS Intel/arm64 与 Linux amd64/arm64 四个生产同款 runner 上执行真实的本地 staging-tap 安装。
 
 这是一项只读 rehearsal：它没有 `release` Environment、secret、tag checkout、Release/asset 编辑或创建，
-也不会 clone、提交或推送 Homebrew tap。Linux 分支使用 `--debug-symbols --verbose`，macOS 保持普通安装命令。
+也不会 clone、提交或推送 Homebrew tap。Linux 分支使用
+`--build-from-source --debug-symbols --verbose`，macOS 保持普通安装命令。
 它用于在正式发布之前复现 Homebrew 安装链路，**不替代**正式 tag 发布、签名 Release、tap 部署或发布后的
 安装验收。`sh scripts/test-homebrew-prepublish-workflow.sh` 会在本地和质量门中检查该 workflow 的不可变边界。
 

--- a/scripts/prepublishhomebrew/main.go
+++ b/scripts/prepublishhomebrew/main.go
@@ -76,7 +76,7 @@ brew tap-new "$staging_tap" --no-git
 brew trust --tap "$staging_tap"
 cp staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
 if [ '${{ matrix.os }}' = linux ]; then
-  brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+  brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
 else
   brew install --formula "$staging_tap/$formula_name"
 fi

--- a/scripts/prepublishhomebrew/main_test.go
+++ b/scripts/prepublishhomebrew/main_test.go
@@ -21,15 +21,14 @@ func TestWorkflowEnforcesReadOnlyStableReleaseRehearsal(t *testing.T) {
 	}
 }
 
-// Linuxbrew 的 Resource staging 在 --keep-tmp 生效前会清理 Mktemp 并可能在 hosted
-// runner 上失败。预发布演练必须只在 Linux 传入 --debug-symbols，让 source cache staging
-// 保留；macOS 仍使用普通安装命令，且旧 --keep-tmp 不得残留。
-func TestWorkflowUsesLinuxOnlyDebugSymbolsForHomebrewResourceStaging(t *testing.T) {
+// Homebrew 已明确拒绝未配合 --build-from-source 的 --debug-symbols。预发布演练必须仅
+// 在 Linux 使用这个正式、非交互的参数组合；macOS 保持普通安装命令，旧 --keep-tmp 不得残留。
+func TestWorkflowUsesLinuxOnlySourceBuildDebugSymbolsForHomebrewResourceStaging(t *testing.T) {
 	root := prepublishWorkflowRoot(t)
 	step := runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install")
 	run := mappingValue(t, step, "run").Value
 	want := `if [ '${{ matrix.os }}' = linux ]; then
-  brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+  brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
 else
   brew install --formula "$staging_tap/$formula_name"
 fi`
@@ -82,21 +81,33 @@ func TestWorkflowRejectsReadOnlyBoundaryMutations(t *testing.T) {
 			},
 		},
 		{
+			name: "removes Linux source build required by debug symbols",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose", "brew install --debug-symbols --verbose")
+			},
+		},
+		{
+			name: "changes the required Linux debug-symbol ordering",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose", "brew install --debug-symbols --build-from-source --verbose")
+			},
+		},
+		{
 			name: "removes Linux Resource staging debug symbols",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose", "brew install --verbose")
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose", "brew install --build-from-source --verbose")
 			},
 		},
 		{
 			name: "retains obsolete Linux keep tmp",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose", "brew install --debug-symbols --keep-tmp --verbose")
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose", "brew install --build-from-source --debug-symbols --keep-tmp --verbose")
 			},
 		},
 		{
 			name: "applies Linux debug symbols to macOS",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"")
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{

--- a/scripts/releaseworkflow/homebrew_policy.go
+++ b/scripts/releaseworkflow/homebrew_policy.go
@@ -108,7 +108,7 @@ brew tap-new "$staging_tap" --no-git
 brew trust --tap "$staging_tap"
 cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
 if [ '${{ matrix.os }}' = linux ]; then
-brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
 else
 brew install --formula "$staging_tap/$formula_name"
 fi

--- a/scripts/releaseworkflow/homebrew_policy_test.go
+++ b/scripts/releaseworkflow/homebrew_policy_test.go
@@ -29,7 +29,7 @@ func TestCheckWorkflowRequiresTapQualifiedStagingFormulaInstall(t *testing.T) {
 
 	root := releaseWorkflowRoot(t)
 	step := stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install")
-	replaceRunFragment(t, step, "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --verbose --formula \"staging-formula/$formula_name.rb\"")
+	replaceRunFragment(t, step, "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --verbose --formula \"staging-formula/$formula_name.rb\"")
 	err := checkWorkflow(mustMarshalYAML(t, root))
 	if err == nil || !strings.Contains(err.Error(), "Homebrew native install gate must use the required direct command sequence") {
 		t.Fatalf("policy error = %v, want workspace-path Homebrew formula install rejection", err)
@@ -50,10 +50,9 @@ func TestCheckWorkflowRequiresStagingTapTrust(t *testing.T) {
 	}
 }
 
-// Linuxbrew 的 Resource staging 在 --keep-tmp 生效前会触发 Mktemp cleanup，且已在
-// 短命 GitHub runner 上报出 chmod EINVAL。--debug-symbols 会让 Resource staging 的
-// source cache 保留；它只适用于 Linux 发布验收，macOS 保持原本的安装命令。
-func TestWorkflowUsesLinuxOnlyDebugSymbolsForHomebrewResourceStaging(t *testing.T) {
+// Linuxbrew 已明确拒绝单独使用 --debug-symbols：它必须显式配合 --build-from-source。
+// 此组合只适用于 Linux 发布验收；macOS 保持原本的安装命令。
+func TestWorkflowUsesLinuxOnlySourceBuildDebugSymbolsForHomebrewResourceStaging(t *testing.T) {
 	t.Parallel()
 
 	root := releaseWorkflowRoot(t)
@@ -62,7 +61,7 @@ func TestWorkflowUsesLinuxOnlyDebugSymbolsForHomebrewResourceStaging(t *testing.
 	for _, command := range []string{
 		`eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"`,
 		`if [ '${{ matrix.os }}' = linux ]; then
-  brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+  brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
 else
   brew install --formula "$staging_tap/$formula_name"
 fi`,
@@ -173,49 +172,63 @@ func TestCheckWorkflowRejectsHomebrewReleaseGateMutations(t *testing.T) {
 			},
 		},
 		{
+			name: "Linux Homebrew source build required by debug symbols is removed",
+			want: "Homebrew native install gate must use the required direct command sequence",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"")
+			},
+		},
+		{
+			name: "Linux Homebrew changes the required source build and debug-symbol ordering",
+			want: "Homebrew native install gate must use the required direct command sequence",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --build-from-source --verbose --formula \"$staging_tap/$formula_name\"")
+			},
+		},
+		{
 			name: "Linux Homebrew Resource staging debug symbols are removed",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --verbose --formula \"$staging_tap/$formula_name\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --verbose --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{
 			name: "Linux Homebrew Resource staging retains obsolete keep tmp",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{
 			name: "Linux Homebrew staging install is not verbose",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --formula \"$staging_tap/$formula_name\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{
 			name: "Linux Homebrew debug symbols leave the Linux conditional",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), `if [ '${{ matrix.os }}' = linux ]; then
-  brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), `if [ '${{ matrix.os }}' = linux ]; then
+  brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
 else
   brew install --formula "$staging_tap/$formula_name"
-fi`, `brew install --debug-symbols --verbose --formula "$staging_tap/$formula_name"`)
+fi`, `brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"`)
 			},
 		},
 		{
 			name: "Linux Homebrew debug symbols leak to macOS",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"")
 			},
 		},
 		{
 			name: "staging formula install is not tap qualified",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --debug-symbols"), "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --verbose --formula \"staging-formula/$formula_name.rb\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --verbose --formula \"staging-formula/$formula_name.rb\"")
 			},
 		},
 		{


### PR DESCRIPTION
Homebrew rejects `--debug-symbols` unless `--build-from-source` is explicit. Linux staging already has no bottle and follows the source path; this makes that required relationship explicit so Resource staging can retain its source cache.

The change is Linux-only and requires the existing non-publishing v0.4.4 four-platform rehearsal after merge.