### PR TITLE
fix(homebrew): verify Linux formulas in container

### DIFF
--- a/.github/workflows/homebrew-prepublish-verify.yml
+++ b/.github/workflows/homebrew-prepublish-verify.yml
@@ -156,7 +156,6 @@ jobs:
                 staging_tap=pixiv-cli-release/staging
                 tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
                 brew tap-new "$staging_tap" --no-git
-                brew trust --tap "$staging_tap"
                 cp /staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
                 brew install --formula "$staging_tap/$formula_name"
                 pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"

--- a/.github/workflows/homebrew-prepublish-verify.yml
+++ b/.github/workflows/homebrew-prepublish-verify.yml
@@ -136,20 +136,37 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ '${{ matrix.os }}' = linux ]; then
-            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          fi
           formula_name=$(cat staging-formula/formula-name)
           test "$formula_name" = pixiv-cli
           test "$(find staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(printf '%s\n%s\n' staging-formula/formula-name staging-formula/pixiv-cli.rb | LC_ALL=C sort)"
-          staging_tap=pixiv-cli-release/staging
-          tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
-          brew tap-new "$staging_tap" --no-git
-          brew trust --tap "$staging_tap"
-          cp staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
           if [ '${{ matrix.os }}' = linux ]; then
-            brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+            staging_dir="$(pwd)/staging-formula"
+            case "$staging_dir" in /*) ;; *) exit 1 ;; esac
+            docker run --rm \
+              --mount "type=bind,src=$staging_dir,dst=/staging-formula,readonly" \
+              --env RELEASE_TAG \
+              --env HOMEBREW_NO_AUTO_UPDATE=1 \
+              --env HOMEBREW_NO_ENV_HINTS=1 \
+              --entrypoint bash \
+              homebrew/brew@sha256:b0072bfdebf5934ae24b93b44a1928a88057399b3283ffa0177bb86084fdedfd \
+              -euo pipefail -c '
+                formula_name=$(cat /staging-formula/formula-name)
+                test "$formula_name" = pixiv-cli
+                test "$(find /staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(printf "%s\\n%s\\n" /staging-formula/formula-name /staging-formula/pixiv-cli.rb | LC_ALL=C sort)"
+                staging_tap=pixiv-cli-release/staging
+                tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
+                brew tap-new "$staging_tap" --no-git
+                brew trust --tap "$staging_tap"
+                cp /staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
+                brew install --formula "$staging_tap/$formula_name"
+                pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"
+              '
           else
+            staging_tap=pixiv-cli-release/staging
+            tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
+            brew tap-new "$staging_tap" --no-git
+            brew trust --tap "$staging_tap"
+            cp staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
             brew install --formula "$staging_tap/$formula_name"
+            pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"
           fi
-          pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"

--- a/.github/workflows/homebrew-prepublish-verify.yml
+++ b/.github/workflows/homebrew-prepublish-verify.yml
@@ -158,7 +158,7 @@ jobs:
                 brew tap-new "$staging_tap" --no-git
                 cp /staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
                 brew install --formula "$staging_tap/$formula_name"
-                pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"
+                pixiv version --json | brew ruby -rjson -e "actual = JSON.parse(STDIN.read).fetch(\"version\"); expected = ARGV.fetch(0); abort(\"version #{actual.inspect} != #{expected.inspect}\") unless actual == expected" "$RELEASE_TAG"
               '
           else
             staging_tap=pixiv-cli-release/staging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -583,7 +583,7 @@ jobs:
                 brew tap-new "$staging_tap" --no-git
                 cp "/staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
                 brew install --formula "$staging_tap/$formula_name"
-                pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"
+                pixiv version --json | brew ruby -rjson -e "actual = JSON.parse(STDIN.read).fetch(\"version\"); expected = ARGV.fetch(0); abort(\"version #{actual.inspect} != #{expected.inspect}\") unless actual == expected" "$RELEASE_TAG"
               '
           else
             staging_tap=pixiv-cli-release/staging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -581,7 +581,6 @@ jobs:
                 staging_tap=pixiv-cli-release/staging
                 tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
                 brew tap-new "$staging_tap" --no-git
-                brew trust --tap "$staging_tap"
                 cp "/staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
                 brew install --formula "$staging_tap/$formula_name"
                 pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -555,26 +555,46 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ '${{ matrix.os }}' = linux ]; then
-            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          fi
           formula_name=$(cat staging-formula/formula-name)
           case "$formula_name" in
             pixiv-cli|pixiv-cli-beta) ;;
             *) exit 1 ;;
           esac
           test "$(find staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(printf '%s\n%s\n' staging-formula/formula-name "staging-formula/$formula_name.rb" | LC_ALL=C sort)"
-          staging_tap=pixiv-cli-release/staging
-          tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
-          brew tap-new "$staging_tap" --no-git
-          brew trust --tap "$staging_tap"
-          cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
           if [ '${{ matrix.os }}' = linux ]; then
-            brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+            staging_dir="$(pwd)/staging-formula"
+            case "$staging_dir" in /*) ;; *) exit 1 ;; esac
+            docker run --rm \
+              --mount "type=bind,src=$staging_dir,dst=/staging-formula,readonly" \
+              --env RELEASE_TAG \
+              --env HOMEBREW_NO_AUTO_UPDATE=1 \
+              --env HOMEBREW_NO_ENV_HINTS=1 \
+              --entrypoint bash \
+              homebrew/brew@sha256:b0072bfdebf5934ae24b93b44a1928a88057399b3283ffa0177bb86084fdedfd \
+              -euo pipefail -c '
+                formula_name=$(cat /staging-formula/formula-name)
+                case "$formula_name" in
+                  pixiv-cli|pixiv-cli-beta) ;;
+                  *) exit 1 ;;
+                esac
+                test "$(find /staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(printf "%s\\n%s\\n" /staging-formula/formula-name "/staging-formula/$formula_name.rb" | LC_ALL=C sort)"
+                staging_tap=pixiv-cli-release/staging
+                tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
+                brew tap-new "$staging_tap" --no-git
+                brew trust --tap "$staging_tap"
+                cp "/staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
+                brew install --formula "$staging_tap/$formula_name"
+                pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"
+              '
           else
+            staging_tap=pixiv-cli-release/staging
+            tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
+            brew tap-new "$staging_tap" --no-git
+            brew trust --tap "$staging_tap"
+            cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
             brew install --formula "$staging_tap/$formula_name"
+            pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"
           fi
-          pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"
 
   deploy_homebrew_tap:
     name: Deploy the verified Homebrew formula

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Linux Homebrew hosted staging verification now runs the real local staging-tap `brew install` in a short-lived `homebrew/brew` container pinned by immutable digest. This avoids the hosted Linuxbrew `Resource` staging cleanup `EINVAL` while retaining a read-only formula mount, no secrets, a local-only tap and an exact installed-version check. macOS and end-user Homebrew installs remain unchanged. Local Docker experiments have passed on arm64 and amd64 emulation; GitHub runner prepublish evidence is still required before release.
+- Linux Homebrew hosted staging verification now runs the real local staging-tap `brew install` in a short-lived `homebrew/brew` container pinned by immutable digest. This avoids the hosted Linuxbrew `Resource` staging cleanup `EINVAL` while retaining a read-only formula mount, no secrets, a local-only tap and an exact installed-version check. The pinned Homebrew 4.6 image has no `brew trust` command, so trust remains only in the native macOS path; the Linux container tap is created locally, fed only by the read-only mount and discarded with `--rm`. macOS and end-user Homebrew installs remain unchanged. Local Docker experiments have passed on arm64 and amd64 emulation; GitHub runner prepublish evidence is still required before release.
 
 ## [0.4.4] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Linux Homebrew hosted staging verification now uses `brew install --build-from-source --debug-symbols --verbose`: Homebrew rejects `--debug-symbols` without the explicit source-build flag before staging begins. This Linux-only, non-interactive verification combination leaves macOS and end-user Homebrew installs unchanged and still requires real resource-stage validation before release.
+- Linux Homebrew hosted staging verification now runs the real local staging-tap `brew install` in a short-lived `homebrew/brew` container pinned by immutable digest. This avoids the hosted Linuxbrew `Resource` staging cleanup `EINVAL` while retaining a read-only formula mount, no secrets, a local-only tap and an exact installed-version check. macOS and end-user Homebrew installs remain unchanged. Local Docker experiments have passed on arm64 and amd64 emulation; GitHub runner prepublish evidence is still required before release.
 
 ## [0.4.4] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Linux Homebrew hosted staging verification now runs the real local staging-tap `brew install` in a short-lived `homebrew/brew` container pinned by immutable digest. This avoids the hosted Linuxbrew `Resource` staging cleanup `EINVAL` while retaining a read-only formula mount, no secrets, a local-only tap and an exact installed-version check. The pinned Homebrew 4.6 image has no `brew trust` command, so trust remains only in the native macOS path; the Linux container tap is created locally, fed only by the read-only mount and discarded with `--rm`. macOS and end-user Homebrew installs remain unchanged. Local Docker experiments have passed on arm64 and amd64 emulation; GitHub runner prepublish evidence is still required before release.
+- Linux Homebrew hosted staging verification now runs the real local staging-tap `brew install` in a short-lived `homebrew/brew` container pinned by immutable digest. This avoids the hosted Linuxbrew `Resource` staging cleanup `EINVAL` while retaining a read-only formula mount, no secrets, a local-only tap and an exact installed-version check. The pinned Homebrew 4.6 image has no `brew trust` or standalone `python3`, so trust remains only in the native macOS path and the container uses its bundled Ruby JSON parser after installation. The Linux container tap is created locally, fed only by the read-only mount and discarded with `--rm`. macOS and end-user Homebrew installs remain unchanged. Local Docker experiments have passed on arm64 and amd64 emulation; GitHub runner prepublish evidence is still required before release.
 
 ## [0.4.4] - 2026-07-19
 

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -446,7 +446,8 @@ prerelease 结果直接映射为 `pixiv-cli`/`pixiv-cli-beta`。随后精确四�
 Linux amd64/arm64）先用 `brew tap-new pixiv-cli-release/staging --no-git` 创建各 runner 的隔离
 local tap，再以 `brew trust --tap pixiv-cli-release/staging` 显式信任这一个临时命名空间；将唯一
 staging formula 放入其 `Formula/`，随后用 `pixiv-cli-release/staging/<formula>` 执行真实
-`brew install --build-from-source --debug-symbols --verbose --formula`，解析
+`brew install --formula`。macOS 在原生 runner 的临时 tap 中运行；Linux 在短生命周期、固定 digest 的
+`homebrew/brew` 容器内运行，并将 staging formula 目录以只读 bind mount 传入容器。随后解析
 `pixiv version --json` 并与 tag 比较。它不使用 workspace formula path、developer/环境变量 bypass，
 也不克隆、写入或信任公开 tap。只有全部成功，最终受保护 `deploy_homebrew_tap` 才以 HTTPS
 clone public tap、核对唯一 staged formula，并在最后一个 step 读取 deploy key；SSH push 固定官方
@@ -459,12 +460,15 @@ secret 和 tag protection 的远端实际状态；它不替代 Task 20 的远端
 会先公开 Release 再安装；若安装失败，Release 已公开但 tap 不变，需要维护者显式处置，不能绕过 gate
 手工 push。
 
-`--build-from-source --debug-symbols --verbose` 仅用于短命 GitHub release-validation runner 的 Linux 分支，
-macOS 继续使用原来的 `brew install --formula`：Linuxbrew 的 Resource staging 发生在 `--keep-tmp` 生效前，且
-其 Mktemp cleanup 已有直接 backtrace 证据会在 runner 上触发 `FileUtils.chmod` 的 `EINVAL`。真实 runner 已证明
-Homebrew 会在开始 staging 前拒绝未显式配合 `--build-from-source` 的 `--debug-symbols`；这两个 flag 必须作为同一
-个非交互组合出现，`--verbose` 则保留可审计的 Homebrew 操作输出。该组合仍须通过真实 Linux resource-stage
-验证；它不进入公开 formula，也不改变终端用户的 `brew install` 行为。
+GitHub hosted Linux runner 上 Linuxbrew 的 `Resource` staging cleanup 有直接 backtrace 证据会触发
+`FileUtils.chmod` 的 `EINVAL`，且该错误早于 `--keep-tmp` 等候选项可介入的阶段。为保证门禁仍是真实的
+formula 安装，Linux 分支使用 `docker run --rm` 启动固定 digest 的 `homebrew/brew` 镜像，向容器传入只读的
+绝对 staging-formula bind mount；容器只创建本地 staging tap、复制该 formula、执行普通 tap-qualified
+`brew install --formula` 并把 `pixiv version --json` 与 `RELEASE_TAG` 精确比较。`HOMEBREW_NO_AUTO_UPDATE=1`
+与 `HOMEBREW_NO_ENV_HINTS=1` 仅消除自动更新及提示造成的漂移，不改变 formula 或安装语义。容器不读取
+secret、不写 host mount、不使用公开 tap，也不使用 `HOMEBREW_TEMP`、source/debug/keep-tmp flags。macOS
+继续使用原生 `brew install --formula`。本地 Docker 已在 arm64 和 amd64 QEMU 做过同一 formula 安装实验；
+GitHub runner 的预发布演练仍是正式发布前必须取得的外部证据。
 
 ### 发布前只读 Homebrew 演练
 
@@ -475,8 +479,8 @@ tag 与输入一致；随后只下载该 Release 已发布的 `checksums.txt`，
 macOS Intel/arm64 与 Linux amd64/arm64 四个生产同款 runner 上执行真实的本地 staging-tap 安装。
 
 这是一项只读 rehearsal：它没有 `release` Environment、secret、tag checkout、Release/asset 编辑或创建，
-也不会 clone、提交或推送 Homebrew tap。Linux 分支使用
-`--build-from-source --debug-symbols --verbose`，macOS 保持普通安装命令。
+也不会 clone、提交或推送 Homebrew tap。Linux 分支在固定 digest、短生命周期 Homebrew 容器中安装只读挂载的
+本地 staging formula；macOS 保持原生普通安装命令。
 它用于在正式发布之前复现 Homebrew 安装链路，**不替代**正式 tag 发布、签名 Release、tap 部署或发布后的
 安装验收。`sh scripts/test-homebrew-prepublish-workflow.sh` 会在本地和质量门中检查该 workflow 的不可变边界。
 

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -466,8 +466,10 @@ formula 安装，Linux 分支使用 `docker run --rm` 启动固定 digest 的 `h
 绝对 staging-formula bind mount；容器只创建本地 staging tap、复制该 formula、执行普通 tap-qualified
 `brew install --formula` 并把 `pixiv version --json` 与 `RELEASE_TAG` 精确比较。`HOMEBREW_NO_AUTO_UPDATE=1`
 与 `HOMEBREW_NO_ENV_HINTS=1` 仅消除自动更新及提示造成的漂移，不改变 formula 或安装语义。容器不读取
-secret、不写 host mount、不使用公开 tap，也不使用 `HOMEBREW_TEMP`、source/debug/keep-tmp flags。macOS
-继续使用原生 `brew install --formula`。本地 Docker 已在 arm64 和 amd64 QEMU 做过同一 formula 安装实验；
+secret、不写 host mount、不使用公开 tap，也不使用 `HOMEBREW_TEMP`、source/debug/keep-tmp flags。固定的
+Homebrew 4.6 容器镜像不提供 `brew trust`；这不是安全绕过：该 tap 仅在 `--rm` 容器内由 `brew tap-new`
+创建，唯一 formula 从只读 mount 复制，且不会触及公开 tap。macOS 原生 Homebrew 保留显式
+`brew trust --tap`。本地 Docker 已在 arm64 和 amd64 QEMU 做过同一 formula 安装实验；
 GitHub runner 的预发布演练仍是正式发布前必须取得的外部证据。
 
 ### 发布前只读 Homebrew 演练

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -469,7 +469,10 @@ formula 安装，Linux 分支使用 `docker run --rm` 启动固定 digest 的 `h
 secret、不写 host mount、不使用公开 tap，也不使用 `HOMEBREW_TEMP`、source/debug/keep-tmp flags。固定的
 Homebrew 4.6 容器镜像不提供 `brew trust`；这不是安全绕过：该 tap 仅在 `--rm` 容器内由 `brew tap-new`
 创建，唯一 formula 从只读 mount 复制，且不会触及公开 tap。macOS 原生 Homebrew 保留显式
-`brew trust --tap`。本地 Docker 已在 arm64 和 amd64 QEMU 做过同一 formula 安装实验；
+`brew trust --tap`。该固定镜像亦没有 standalone `python3`；Linux 分支在安装成功后用
+`brew ruby -rjson` 的 bundled Ruby 标准 JSON 库严格比较版本。这一命令可能仅在短生命周期容器中开启
+Homebrew developer mode，且发生在 `brew install` 之后，不能改变安装验收路径。macOS 继续保留原来的
+Python JSON 断言。本地 Docker 已在 arm64 和 amd64 QEMU 做过同一 formula 安装实验；
 GitHub runner 的预发布演练仍是正式发布前必须取得的外部证据。
 
 ### 发布前只读 Homebrew 演练

--- a/scripts/prepublishhomebrew/main.go
+++ b/scripts/prepublishhomebrew/main.go
@@ -86,7 +86,7 @@ if [ '${{ matrix.os }}' = linux ]; then
       brew tap-new "$staging_tap" --no-git
       cp /staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
       brew install --formula "$staging_tap/$formula_name"
-      pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"
+      pixiv version --json | brew ruby -rjson -e "actual = JSON.parse(STDIN.read).fetch(\"version\"); expected = ARGV.fetch(0); abort(\"version #{actual.inspect} != #{expected.inspect}\") unless actual == expected" "$RELEASE_TAG"
     '
 else
   staging_tap=pixiv-cli-release/staging

--- a/scripts/prepublishhomebrew/main.go
+++ b/scripts/prepublishhomebrew/main.go
@@ -84,7 +84,6 @@ if [ '${{ matrix.os }}' = linux ]; then
       staging_tap=pixiv-cli-release/staging
       tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
       brew tap-new "$staging_tap" --no-git
-      brew trust --tap "$staging_tap"
       cp /staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
       brew install --formula "$staging_tap/$formula_name"
       pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"

--- a/scripts/prepublishhomebrew/main.go
+++ b/scripts/prepublishhomebrew/main.go
@@ -64,23 +64,40 @@ printf '%s\n' pixiv-cli > staging-formula/formula-name
 `
 
 const verifyStagingFormulaRun = `set -euo pipefail
-if [ '${{ matrix.os }}' = linux ]; then
-  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-fi
 formula_name=$(cat staging-formula/formula-name)
 test "$formula_name" = pixiv-cli
 test "$(find staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(printf '%s\n%s\n' staging-formula/formula-name staging-formula/pixiv-cli.rb | LC_ALL=C sort)"
-staging_tap=pixiv-cli-release/staging
-tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
-brew tap-new "$staging_tap" --no-git
-brew trust --tap "$staging_tap"
-cp staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
 if [ '${{ matrix.os }}' = linux ]; then
-  brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
+  staging_dir="$(pwd)/staging-formula"
+  case "$staging_dir" in /*) ;; *) exit 1 ;; esac
+  docker run --rm \
+    --mount "type=bind,src=$staging_dir,dst=/staging-formula,readonly" \
+    --env RELEASE_TAG \
+    --env HOMEBREW_NO_AUTO_UPDATE=1 \
+    --env HOMEBREW_NO_ENV_HINTS=1 \
+    --entrypoint bash \
+    homebrew/brew@sha256:b0072bfdebf5934ae24b93b44a1928a88057399b3283ffa0177bb86084fdedfd \
+    -euo pipefail -c '
+      formula_name=$(cat /staging-formula/formula-name)
+      test "$formula_name" = pixiv-cli
+      test "$(find /staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(printf "%s\\n%s\\n" /staging-formula/formula-name /staging-formula/pixiv-cli.rb | LC_ALL=C sort)"
+      staging_tap=pixiv-cli-release/staging
+      tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
+      brew tap-new "$staging_tap" --no-git
+      brew trust --tap "$staging_tap"
+      cp /staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
+      brew install --formula "$staging_tap/$formula_name"
+      pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"
+    '
 else
+  staging_tap=pixiv-cli-release/staging
+  tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
+  brew tap-new "$staging_tap" --no-git
+  brew trust --tap "$staging_tap"
+  cp staging-formula/pixiv-cli.rb "$tap_dir/Formula/pixiv-cli.rb"
   brew install --formula "$staging_tap/$formula_name"
+  pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"
 fi
-pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"
 `
 
 func main() {

--- a/scripts/prepublishhomebrew/main_test.go
+++ b/scripts/prepublishhomebrew/main_test.go
@@ -47,6 +47,13 @@ func TestWorkflowUsesLinuxOnlyContainerizedHomebrewVerification(t *testing.T) {
 			t.Fatalf("prepublish Linux container verification retains obsolete %q", forbidden)
 		}
 	}
+	linuxBranch, macOSBranch, ok := strings.Cut(run, "\nelse\n")
+	if !ok || strings.Contains(linuxBranch, "brew trust --tap") {
+		t.Fatal("fixed Linux Homebrew 4.6 container must not call unavailable brew trust")
+	}
+	if !strings.Contains(macOSBranch, "brew trust --tap \"$staging_tap\"") {
+		t.Fatal("macOS native Homebrew must retain explicit staging-tap trust")
+	}
 }
 
 func findRepositoryRoot(t *testing.T) string {

--- a/scripts/prepublishhomebrew/main_test.go
+++ b/scripts/prepublishhomebrew/main_test.go
@@ -48,8 +48,11 @@ func TestWorkflowUsesLinuxOnlyContainerizedHomebrewVerification(t *testing.T) {
 		}
 	}
 	linuxBranch, macOSBranch, ok := strings.Cut(run, "\nelse\n")
-	if !ok || strings.Contains(linuxBranch, "brew trust --tap") {
-		t.Fatal("fixed Linux Homebrew 4.6 container must not call unavailable brew trust")
+	if !ok || strings.Contains(linuxBranch, "brew trust --tap") || strings.Contains(linuxBranch, "python3 -c") {
+		t.Fatal("fixed Linux Homebrew 4.6 container must not call unavailable brew trust or Python")
+	}
+	if !strings.Contains(linuxBranch, `brew ruby -rjson -e`) {
+		t.Fatal("fixed Linux container must compare the JSON version with Ruby standard JSON")
 	}
 	if !strings.Contains(macOSBranch, "brew trust --tap \"$staging_tap\"") {
 		t.Fatal("macOS native Homebrew must retain explicit staging-tap trust")

--- a/scripts/prepublishhomebrew/main_test.go
+++ b/scripts/prepublishhomebrew/main_test.go
@@ -21,22 +21,31 @@ func TestWorkflowEnforcesReadOnlyStableReleaseRehearsal(t *testing.T) {
 	}
 }
 
-// Homebrew 已明确拒绝未配合 --build-from-source 的 --debug-symbols。预发布演练必须仅
-// 在 Linux 使用这个正式、非交互的参数组合；macOS 保持普通安装命令，旧 --keep-tmp 不得残留。
-func TestWorkflowUsesLinuxOnlySourceBuildDebugSymbolsForHomebrewResourceStaging(t *testing.T) {
+// Linux hosted runner 的 Linuxbrew Resource staging 会在 Homebrew 内部 cleanup 触发
+// EINVAL；Linux 验证必须转入固定镜像的短生命周期容器，macOS 仍保留原生 Homebrew。
+func TestWorkflowUsesLinuxOnlyContainerizedHomebrewVerification(t *testing.T) {
 	root := prepublishWorkflowRoot(t)
 	step := runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install")
 	run := mappingValue(t, step, "run").Value
-	want := `if [ '${{ matrix.os }}' = linux ]; then
-  brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
-else
-  brew install --formula "$staging_tap/$formula_name"
-fi`
-	if !strings.Contains(run, want) {
-		t.Fatalf("prepublish install must retain Resource staging sources only on Linux and preserve macOS install; missing %q", want)
+	for _, want := range []string{
+		`docker run --rm`,
+		`homebrew/brew@sha256:b0072bfdebf5934ae24b93b44a1928a88057399b3283ffa0177bb86084fdedfd`,
+		`--entrypoint bash`,
+		`type=bind,src=$staging_dir,dst=/staging-formula,readonly`,
+		`--env RELEASE_TAG`,
+		`HOMEBREW_NO_AUTO_UPDATE=1`,
+		`HOMEBREW_NO_ENV_HINTS=1`,
+		`brew install --formula "$staging_tap/$formula_name"`,
+		`pixiv version --json`,
+	} {
+		if !strings.Contains(run, want) {
+			t.Fatalf("prepublish Linux container verification missing %q", want)
+		}
 	}
-	if strings.Contains(run, "--keep-tmp") {
-		t.Fatal("prepublish install must not retain obsolete --keep-tmp")
+	for _, forbidden := range []string{"--build-from-source", "--debug-symbols", "--keep-tmp", "HOMEBREW_TEMP"} {
+		if strings.Contains(run, forbidden) {
+			t.Fatalf("prepublish Linux container verification retains obsolete %q", forbidden)
+		}
 	}
 }
 
@@ -81,33 +90,27 @@ func TestWorkflowRejectsReadOnlyBoundaryMutations(t *testing.T) {
 			},
 		},
 		{
-			name: "removes Linux source build required by debug symbols",
+			name: "uses a mutable Linux container image",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose", "brew install --debug-symbols --verbose")
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "docker run --rm"), "homebrew/brew@sha256:b0072bfdebf5934ae24b93b44a1928a88057399b3283ffa0177bb86084fdedfd", "homebrew/brew:latest")
 			},
 		},
 		{
-			name: "changes the required Linux debug-symbol ordering",
+			name: "makes the Linux staging mount writable",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose", "brew install --debug-symbols --build-from-source --verbose")
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "docker run --rm"), ",readonly", "")
 			},
 		},
 		{
-			name: "removes Linux Resource staging debug symbols",
+			name: "omits release tag from Linux container",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose", "brew install --build-from-source --verbose")
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "docker run --rm"), "--env RELEASE_TAG", "")
 			},
 		},
 		{
-			name: "retains obsolete Linux keep tmp",
+			name: "uses obsolete Linux source flags",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose", "brew install --build-from-source --debug-symbols --keep-tmp --verbose")
-			},
-		},
-		{
-			name: "applies Linux debug symbols to macOS",
-			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"")
+				replaceRun(t, runStepWith(t, job(t, root, "verify_homebrew_formula"), "docker run --rm"), "brew install --formula", "brew install --debug-symbols --formula")
 			},
 		},
 		{

--- a/scripts/releaseworkflow/homebrew_policy.go
+++ b/scripts/releaseworkflow/homebrew_policy.go
@@ -93,26 +93,47 @@ printf '%s\n' "$formula_name" > staging-formula/formula-name`
 func checkVerifyHomebrewJob(job *yaml.Node) error {
 	const verifyCommands = `
 set -euo pipefail
-if [ '${{ matrix.os }}' = linux ]; then
-eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-fi
 formula_name=$(cat staging-formula/formula-name)
 case "$formula_name" in
 pixiv-cli|pixiv-cli-beta) ;;
 *) exit 1 ;;
 esac
 test "$(find staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(printf '%s\n%s\n' staging-formula/formula-name "staging-formula/$formula_name.rb" | LC_ALL=C sort)"
+if [ '${{ matrix.os }}' = linux ]; then
+staging_dir="$(pwd)/staging-formula"
+case "$staging_dir" in /*) ;; *) exit 1 ;; esac
+docker run --rm \
+--mount "type=bind,src=$staging_dir,dst=/staging-formula,readonly" \
+--env RELEASE_TAG \
+--env HOMEBREW_NO_AUTO_UPDATE=1 \
+--env HOMEBREW_NO_ENV_HINTS=1 \
+--entrypoint bash \
+homebrew/brew@sha256:b0072bfdebf5934ae24b93b44a1928a88057399b3283ffa0177bb86084fdedfd \
+-euo pipefail -c '
+formula_name=$(cat /staging-formula/formula-name)
+case "$formula_name" in
+pixiv-cli|pixiv-cli-beta) ;;
+*) exit 1 ;;
+esac
+test "$(find /staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(printf "%s\\n%s\\n" /staging-formula/formula-name "/staging-formula/$formula_name.rb" | LC_ALL=C sort)"
+staging_tap=pixiv-cli-release/staging
+tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
+brew tap-new "$staging_tap" --no-git
+brew trust --tap "$staging_tap"
+cp "/staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
+brew install --formula "$staging_tap/$formula_name"
+pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"
+'
+else
 staging_tap=pixiv-cli-release/staging
 tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
 brew tap-new "$staging_tap" --no-git
 brew trust --tap "$staging_tap"
 cp "staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
-if [ '${{ matrix.os }}' = linux ]; then
-brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
-else
 brew install --formula "$staging_tap/$formula_name"
+pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"
 fi
-pixiv version --json | python3 -c 'import json, sys; actual = json.load(sys.stdin)["version"]; expected = sys.argv[1]; assert actual == expected, f"version {actual!r} != {expected!r}"' "$RELEASE_TAG"`
+`
 
 	if err := requireRequiredJobExecution(job, "verify_homebrew_formula job"); err != nil {
 		return err

--- a/scripts/releaseworkflow/homebrew_policy.go
+++ b/scripts/releaseworkflow/homebrew_policy.go
@@ -121,7 +121,7 @@ tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
 brew tap-new "$staging_tap" --no-git
 cp "/staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
 brew install --formula "$staging_tap/$formula_name"
-pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"
+pixiv version --json | brew ruby -rjson -e "actual = JSON.parse(STDIN.read).fetch(\"version\"); expected = ARGV.fetch(0); abort(\"version #{actual.inspect} != #{expected.inspect}\") unless actual == expected" "$RELEASE_TAG"
 '
 else
 staging_tap=pixiv-cli-release/staging

--- a/scripts/releaseworkflow/homebrew_policy.go
+++ b/scripts/releaseworkflow/homebrew_policy.go
@@ -119,7 +119,6 @@ test "$(find /staging-formula -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$(
 staging_tap=pixiv-cli-release/staging
 tap_dir="$(brew --repository)/Library/Taps/pixiv-cli-release/homebrew-staging"
 brew tap-new "$staging_tap" --no-git
-brew trust --tap "$staging_tap"
 cp "/staging-formula/$formula_name.rb" "$tap_dir/Formula/$formula_name.rb"
 brew install --formula "$staging_tap/$formula_name"
 pixiv version --json | python3 -c "import json, sys; actual = json.load(sys.stdin)[\"version\"]; expected = sys.argv[1]; assert actual == expected, f\"version {actual!r} != {expected!r}\"" "$RELEASE_TAG"

--- a/scripts/releaseworkflow/homebrew_policy_test.go
+++ b/scripts/releaseworkflow/homebrew_policy_test.go
@@ -36,17 +36,22 @@ func TestCheckWorkflowRequiresTapQualifiedStagingFormulaInstall(t *testing.T) {
 	}
 }
 
-// Homebrew 6 默认要求 tap trust；staging tap 只在 runner 本地临时存在，仍必须通过
-// `brew trust --tap` 显式登记，不能用环境变量或 developer mode 绕过。
-func TestCheckWorkflowRequiresStagingTapTrust(t *testing.T) {
+// 固定的 Linux 容器镜像是 Homebrew 4.6，不具有 trust 子命令；其 tap 只在 --rm
+// 容器中创建，formula 仅从只读 mount 复制。macOS 原生 Homebrew 仍必须显式 trust。
+func TestWorkflowUsesTrustOnlyForMacOSNativeHomebrew(t *testing.T) {
 	t.Parallel()
 
 	root := releaseWorkflowRoot(t)
-	step := stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew trust --tap")
-	removeRunFragment(t, step, "brew trust --tap \"$staging_tap\"")
-	err := checkWorkflow(mustMarshalYAML(t, root))
-	if err == nil || !strings.Contains(err.Error(), "Homebrew native install gate must use the required direct command sequence") {
-		t.Fatalf("policy error = %v, want untrusted staging tap install rejection", err)
+	run := requireMappingValue(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "docker run --rm"), "run").Value
+	linuxBranch, macOSBranch, ok := strings.Cut(run, "\nelse\n")
+	if !ok {
+		t.Fatal("Homebrew verification must retain a Linux/macOS split")
+	}
+	if strings.Contains(linuxBranch, "brew trust --tap") {
+		t.Fatal("fixed Linux Homebrew 4.6 container must not call unavailable brew trust")
+	}
+	if !strings.Contains(macOSBranch, "brew trust --tap \"$staging_tap\"") {
+		t.Fatal("macOS native Homebrew must retain explicit staging-tap trust")
 	}
 }
 
@@ -75,6 +80,10 @@ func TestWorkflowUsesLinuxOnlyContainerizedHomebrewVerification(t *testing.T) {
 		if strings.Contains(run, forbidden) {
 			t.Fatalf("Homebrew install gate must not override Homebrew's temporary directory; found %q", forbidden)
 		}
+	}
+	linuxBranch, _, ok := strings.Cut(run, "\nelse\n")
+	if !ok || strings.Contains(linuxBranch, "brew trust --tap") {
+		t.Fatal("Linux container branch must not use Homebrew 6-only tap trust")
 	}
 }
 

--- a/scripts/releaseworkflow/homebrew_policy_test.go
+++ b/scripts/releaseworkflow/homebrew_policy_test.go
@@ -22,14 +22,14 @@ func TestCheckWorkflowRequiresHomebrewReleaseGate(t *testing.T) {
 	}
 }
 
-// Homebrew 6 不接受任意 workspace formula 路径；四平台门禁必须通过隔离 staging tap
-// 的 tap-qualified 标识符安装。
+// Homebrew 6 不接受任意 workspace formula 路径；Linux 必须通过只读 mount 的容器内
+// staging tap 安装，macOS 仍保留原生 staging tap。
 func TestCheckWorkflowRequiresTapQualifiedStagingFormulaInstall(t *testing.T) {
 	t.Parallel()
 
 	root := releaseWorkflowRoot(t)
 	step := stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install")
-	replaceRunFragment(t, step, "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --verbose --formula \"staging-formula/$formula_name.rb\"")
+	replaceRunFragment(t, step, "brew install --formula \"$staging_tap/$formula_name\"", "brew install --formula \"staging-formula/$formula_name.rb\"")
 	err := checkWorkflow(mustMarshalYAML(t, root))
 	if err == nil || !strings.Contains(err.Error(), "Homebrew native install gate must use the required direct command sequence") {
 		t.Fatalf("policy error = %v, want workspace-path Homebrew formula install rejection", err)
@@ -50,27 +50,28 @@ func TestCheckWorkflowRequiresStagingTapTrust(t *testing.T) {
 	}
 }
 
-// Linuxbrew 已明确拒绝单独使用 --debug-symbols：它必须显式配合 --build-from-source。
-// 此组合只适用于 Linux 发布验收；macOS 保持原本的安装命令。
-func TestWorkflowUsesLinuxOnlySourceBuildDebugSymbolsForHomebrewResourceStaging(t *testing.T) {
+func TestWorkflowUsesLinuxOnlyContainerizedHomebrewVerification(t *testing.T) {
 	t.Parallel()
 
 	root := releaseWorkflowRoot(t)
 	step := stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install")
 	run := requireMappingValue(t, step, "run").Value
 	for _, command := range []string{
-		`eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"`,
-		`if [ '${{ matrix.os }}' = linux ]; then
-  brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
-else
-  brew install --formula "$staging_tap/$formula_name"
-fi`,
+		`docker run --rm`,
+		`homebrew/brew@sha256:b0072bfdebf5934ae24b93b44a1928a88057399b3283ffa0177bb86084fdedfd`,
+		`--entrypoint bash`,
+		`type=bind,src=$staging_dir,dst=/staging-formula,readonly`,
+		`--env RELEASE_TAG`,
+		`HOMEBREW_NO_AUTO_UPDATE=1`,
+		`HOMEBREW_NO_ENV_HINTS=1`,
+		`brew install --formula "$staging_tap/$formula_name"`,
+		`pixiv version --json`,
 	} {
 		if !strings.Contains(run, command) {
-			t.Fatalf("Homebrew install gate must retain Resource staging sources only on Linux and preserve the macOS install command; missing %q", command)
+			t.Fatalf("Homebrew install gate must retain Linux container verification and the macOS native install command; missing %q", command)
 		}
 	}
-	for _, forbidden := range []string{"HOMEBREW_TEMP", "homebrew_temp=", "mkdir -p \"$homebrew_temp\"", "--keep-tmp"} {
+	for _, forbidden := range []string{"HOMEBREW_TEMP", "homebrew_temp=", "mkdir -p \"$homebrew_temp\"", "--keep-tmp", "--build-from-source", "--debug-symbols", "/home/linuxbrew/.linuxbrew/bin/brew"} {
 		if strings.Contains(run, forbidden) {
 			t.Fatalf("Homebrew install gate must not override Homebrew's temporary directory; found %q", forbidden)
 		}
@@ -165,70 +166,38 @@ func TestCheckWorkflowRejectsHomebrewReleaseGateMutations(t *testing.T) {
 			},
 		},
 		{
-			name: "Linux Homebrew activation removed",
+			name: "Linux container image is mutable",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				removeRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "/home/linuxbrew/.linuxbrew/bin/brew"), "eval \"$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "docker run --rm"), "homebrew/brew@sha256:b0072bfdebf5934ae24b93b44a1928a88057399b3283ffa0177bb86084fdedfd", "homebrew/brew:latest")
 			},
 		},
 		{
-			name: "Linux Homebrew source build required by debug symbols is removed",
+			name: "Linux container staging mount is writable",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "docker run --rm"), ",readonly", "")
 			},
 		},
 		{
-			name: "Linux Homebrew changes the required source build and debug-symbol ordering",
+			name: "Linux container does not receive release tag",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --debug-symbols --build-from-source --verbose --formula \"$staging_tap/$formula_name\"")
+				removeRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "docker run --rm"), "--env RELEASE_TAG")
 			},
 		},
 		{
-			name: "Linux Homebrew Resource staging debug symbols are removed",
+			name: "Linux container uses obsolete source flags",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --verbose --formula \"$staging_tap/$formula_name\"")
-			},
-		},
-		{
-			name: "Linux Homebrew Resource staging retains obsolete keep tmp",
-			want: "Homebrew native install gate must use the required direct command sequence",
-			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --keep-tmp --verbose --formula \"$staging_tap/$formula_name\"")
-			},
-		},
-		{
-			name: "Linux Homebrew staging install is not verbose",
-			want: "Homebrew native install gate must use the required direct command sequence",
-			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --formula \"$staging_tap/$formula_name\"")
-			},
-		},
-		{
-			name: "Linux Homebrew debug symbols leave the Linux conditional",
-			want: "Homebrew native install gate must use the required direct command sequence",
-			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), `if [ '${{ matrix.os }}' = linux ]; then
-  brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"
-else
-  brew install --formula "$staging_tap/$formula_name"
-fi`, `brew install --build-from-source --debug-symbols --verbose --formula "$staging_tap/$formula_name"`)
-			},
-		},
-		{
-			name: "Linux Homebrew debug symbols leak to macOS",
-			want: "Homebrew native install gate must use the required direct command sequence",
-			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "docker run --rm"), "brew install --formula", "brew install --build-from-source --formula")
 			},
 		},
 		{
 			name: "staging formula install is not tap qualified",
 			want: "Homebrew native install gate must use the required direct command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "brew install --build-from-source"), "brew install --build-from-source --debug-symbols --verbose --formula \"$staging_tap/$formula_name\"", "brew install --build-from-source --debug-symbols --verbose --formula \"staging-formula/$formula_name.rb\"")
+				replaceRunFragment(t, stepWithRun(t, jobNode(t, root, "verify_homebrew_formula"), "docker run --rm"), "brew install --formula \"$staging_tap/$formula_name\"", "brew install --formula \"/staging-formula/$formula_name.rb\"")
 			},
 		},
 		{

--- a/scripts/releaseworkflow/homebrew_policy_test.go
+++ b/scripts/releaseworkflow/homebrew_policy_test.go
@@ -82,9 +82,24 @@ func TestWorkflowUsesLinuxOnlyContainerizedHomebrewVerification(t *testing.T) {
 		}
 	}
 	linuxBranch, _, ok := strings.Cut(run, "\nelse\n")
-	if !ok || strings.Contains(linuxBranch, "brew trust --tap") {
-		t.Fatal("Linux container branch must not use Homebrew 6-only tap trust")
+	if !ok || strings.Contains(linuxBranch, "brew trust --tap") || strings.Contains(linuxBranch, "python3 -c") {
+		t.Fatal("Linux container branch must not use unavailable Homebrew 6 trust or Python")
 	}
+	if !strings.Contains(linuxBranch, `brew ruby -rjson -e`) {
+		t.Fatal("Linux container branch must compare the JSON version with Ruby's standard JSON library")
+	}
+	if !strings.Contains(macOSBranchFromVerifyRun(t, run), "python3 -c") {
+		t.Fatal("macOS native Homebrew must retain the host Python JSON assertion")
+	}
+}
+
+func macOSBranchFromVerifyRun(t *testing.T, run string) string {
+	t.Helper()
+	_, macOSBranch, ok := strings.Cut(run, "\nelse\n")
+	if !ok {
+		t.Fatal("Homebrew verification must retain a Linux/macOS split")
+	}
+	return macOSBranch
 }
 
 func TestCheckWorkflowRejectsHomebrewReleaseGateMutations(t *testing.T) {


### PR DESCRIPTION
Moves only the hosted Linux Homebrew staging gate into a pinned, ephemeral Linuxbrew container. The gate still renders the release formula, performs a real tap-qualified `brew install`, and verifies the installed JSON version.

Why: GitHub hosted Linuxbrew fails inside its own source-resource cleanup, while the identical published v0.4.4 formula has passed real installs in the pinned container on arm64 and amd64. macOS verification remains native.