### PR TITLE
docs(release): prepare v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-07-20
+
 ### Fixed
 
-- Linux Homebrew hosted staging verification now runs the real local staging-tap `brew install` in a short-lived `homebrew/brew` container pinned by immutable digest. This avoids the hosted Linuxbrew `Resource` staging cleanup `EINVAL` while retaining a read-only formula mount, no secrets, a local-only tap and an exact installed-version check. The pinned Homebrew 4.6 image has no `brew trust` or standalone `python3`, so trust remains only in the native macOS path and the container uses its bundled Ruby JSON parser after installation. The Linux container tap is created locally, fed only by the read-only mount and discarded with `--rm`. macOS and end-user Homebrew installs remain unchanged. Local Docker experiments have passed on arm64 and amd64 emulation; GitHub runner prepublish evidence is still required before release.
+- Linux Homebrew hosted staging verification now runs the real local staging-tap `brew install` in a short-lived `homebrew/brew` container pinned by immutable digest. This avoids the hosted Linuxbrew `Resource` staging cleanup `EINVAL` while retaining a read-only formula mount, no secrets, a local-only tap and an exact installed-version check. The pinned Homebrew 4.6 image has no `brew trust` or standalone `python3`, so trust remains only in the native macOS path and the container uses its bundled Ruby JSON parser after installation. The Linux container tap is created locally, fed only by the read-only mount and discarded with `--rm`. macOS and end-user Homebrew installs remain unchanged. The GitHub prepublish workflow has passed this verification on all four Homebrew platform/architecture combinations using the published v0.4.4 assets.
 
 ## [0.4.4] - 2026-07-19
 
@@ -223,7 +225,8 @@
 
 [Keep a Changelog 1.1.0]: https://keepachangelog.com/zh-CN/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
-[Unreleased]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.4...HEAD
+[Unreleased]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.5...HEAD
+[0.4.5]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.2

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -8,15 +8,17 @@ those interfaces are linked under [Related documentation](#related-documentation
 
 User-visible changes are recorded in [CHANGELOG.md](../../CHANGELOG.md).
 
+[GitHub Releases page]: https://github.com/FlanChanXwO/pixiv-cli/releases
+
 ## Installation
 
 > **Release status**: the Ed25519 public key, key ID, and fingerprint for supported binaries are committed in
 > [`internal/bootstrap/release_trust.go`](../../internal/bootstrap/release_trust.go); the public source/tap repositories,
-> the protected `release` Environment, and isolated credentials are configured. v0.4.3 has been published as a
-> public GitHub Release with six platform archives, checksums, and a signed manifest. The stable Homebrew formula in
-> the public tap remains v0.3.0 pending v0.4.4 Linuxbrew installation validation; v0.4.4 is not published. Future
-> versions must still pass the same tag, signing, asset, and Homebrew gates before they can be treated as trusted
-> download sources.
+> the protected `release` Environment, and isolated credentials are configured. v0.4.4 is a published public GitHub
+> Release with six platform archives, checksums, and a signed manifest. Use the official [GitHub Releases page]
+> and `brew info FlanChanXwO/tap/pixiv-cli` for the current Release and tap state: they are independently published
+> artifacts. Every future version must pass the same tag, signing, asset, and Homebrew gates before it is treated as
+> a trusted download source.
 
 ### Official installer scripts
 
@@ -76,13 +78,12 @@ go install github.com/FlanChanXwO/pixiv-cli/cmd/pixiv@vX.Y.Z
 ```
 
 This still uses the local Go toolchain, cgo, a C linker, and the committed staticlib for the target. The six target
-libraries and manifest are complete — for example, the current official release can be installed with `@v0.4.3`;
-always use the exact tag for later versions, never a branch name.
+libraries and manifest are complete — for example, the published v0.4.4 release can be installed with `@v0.4.4`;
+always use the exact published tag, never a branch name.
 
 ### Homebrew
 
-Once the official stable Release and the real tap have both passed audit/install verification, macOS/Linux users can
-install:
+macOS/Linux users install the stable formula with:
 
 ```bash
 brew install FlanChanXwO/tap/pixiv-cli
@@ -95,16 +96,16 @@ brew install FlanChanXwO/tap/pixiv-cli-beta
 ```
 
 Both formulas install the same `pixiv` binary and therefore conflict with each other; they only download verified
-macOS/Linux Release assets and introduce no `ffmpeg` dependency. The public tap's current stable `pixiv-cli` formula
-remains v0.3.0; v0.4.3 is available from GitHub Release only while v0.4.4 Linuxbrew installation validation is
-pending. The beta formula will only ship with future pre-releases.
+macOS/Linux Release assets and introduce no `ffmpeg` dependency. The GitHub Release and public tap are separate
+publication channels, so use `brew info FlanChanXwO/tap/pixiv-cli` and the [GitHub Releases page] rather than a
+version hard-coded in this reference. The beta formula only ships with pre-releases.
 
 ### Direct download
 
 The release process produces six fixed-name archives for darwin, linux, and windows on amd64/arm64:
 `pixiv-cli_<version>_<os>_<arch>.tar.gz` (`.zip` on Windows), plus `checksums.txt` and an Ed25519-signed
-`checksums.json`. v0.4.3 ships the complete asset set; later versions should only be trusted as direct download
-sources after passing the same release gates.
+`checksums.json`. Published v0.4.4 ships the complete asset set; later versions should only be trusted as direct
+download sources after passing the same release gates.
 
 Current Releases do not include Apple notarization or Windows Authenticode. Even when downloading from a verified
 Release, macOS Gatekeeper or Windows SmartScreen may still show a system reputation prompt; only obtain assets from
@@ -503,9 +504,9 @@ Update checks only select canonical SemVer tags. Stable checks first exclude Git
 non-SemVer tag, the check reports that tag and fails closed instead of skipping it for an older version.
 
 Supported binaries embed the production Ed25519 public key/key ID/fingerprint; the private key exists only in the
-protected `release` Environment and a controlled macOS Keychain recovery copy. v0.4.3 is the current signed
-Release; `pixiv update --check` remains a read-only check and is not a substitute for verifying the selected
-version's assets, checksums, and signatures at install time.
+protected `release` Environment and a controlled macOS Keychain recovery copy. Select the currently published signed
+Release from the [GitHub Releases page]; `pixiv update --check` remains a read-only check and is not a substitute for
+verifying the selected version's assets, checksums, and signatures at install time.
 
 Successful regular CLI commands make a best-effort stable-update check. It skips MCP, help, `version`, `update`, every `auth export`, `auth import --file`,
 and development builds, queries at most once per 24 hours per user cache, and caps the automatic check at 3

--- a/docs/ja/cli-reference.md
+++ b/docs/ja/cli-reference.md
@@ -8,15 +8,17 @@ fallback、更新を扱います。SDK と MCP の詳細は重複させず、[�
 
 ユーザーに影響する変更は [CHANGELOG.md](../../CHANGELOG.md) に記録されます。
 
+[GitHub Releases ページ]: https://github.com/FlanChanXwO/pixiv-cli/releases
+
 ## インストール
 
 > **Release の状態**：対応 binary の Ed25519 public key、key ID、fingerprint は
 > [`internal/bootstrap/release_trust.go`](../../internal/bootstrap/release_trust.go) に commit されています。
 > public source/tap repository、保護された `release` Environment、分離された credential は設定済みです。
-> v0.4.3 は 6 platform archive、checksum、署名付き manifest を含む公開 GitHub Release として公開されています。
-> public tap の stable Homebrew formula は v0.3.0 のままで、v0.4.4 の Linuxbrew install validation 待ちです。
-> v0.4.4 はまだ公開されていません。将来の version も同じ tag、署名、asset、Homebrew gate を通過するまでは
-> 信頼済み download source とみなしません。
+> v0.4.4 は 6 platform archive、checksum、署名付き manifest を含む公開 GitHub Release として公開されています。
+> GitHub Release と tap は独立した公開物です。現在の状態は公式の [GitHub Releases ページ]と
+> `brew info FlanChanXwO/tap/pixiv-cli` で確認してください。将来の version も同じ tag、署名、asset、
+> Homebrew gate を通過するまでは信頼済み download source とみなしません。
 
 ### 公式インストールスクリプト
 
@@ -92,14 +94,15 @@ brew install FlanChanXwO/tap/pixiv-cli-beta
 両 formula は同じ `pixiv` binary を配置するため競合します。macOS/Linux の検証済み Release asset だけを
 取得し、runtime の `ffmpeg` dependency は追加しません。
 
-public tap の現在の stable `pixiv-cli` formula は v0.3.0 のままです。v0.4.3 は現在 GitHub Release からのみ
-取得でき、tap の更新は v0.4.4 の Linuxbrew install validation 完了後です。
+GitHub Release と public tap は別々の公開 channel です。現在の状態は
+`brew info FlanChanXwO/tap/pixiv-cli` と [GitHub Releases ページ]で確認し、この reference の固定 version に
+依存しないでください。
 
 ### 直接ダウンロード
 
 Release は darwin、linux、windows の amd64/arm64 向けに
 `pixiv-cli_<version>_<os>_<arch>.tar.gz`（Windows は `.zip`）を生成し、`checksums.txt` と Ed25519 署名付き
-`checksums.json` を添付します。v0.4.3 は 6 種類すべてを含みます。
+`checksums.json` を添付します。公開済みの v0.4.4 は 6 種類すべてを含みます。
 
 現在 Apple notarization と Windows Authenticode はありません。macOS Gatekeeper や Windows SmartScreen が
 警告する場合があります。公式 GitHub Release からだけ取得し、version、checksum、signature note を確認し、

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -7,14 +7,16 @@ SDK 与 MCP 细节不在此重复，入口见[相关文档](#相关文档)。
 
 用户可感知变化记录在 [CHANGELOG.md](../../CHANGELOG.md)。
 
+[GitHub Releases 页面]: https://github.com/FlanChanXwO/pixiv-cli/releases
+
 ## 安装与构建
 
 > **发布状态**：受支持 binary 的 Ed25519 公钥、key ID 与 fingerprint 已提交到
 > [`internal/bootstrap/release_trust.go`](../../internal/bootstrap/release_trust.go)；公开 source/tap repositories、
-> 受保护 `release` Environment 与隔离 credentials 已配置。v0.4.3 已作为公开 GitHub Release 发布，包含六个
-> 平台 archive、checksum 与签名清单。公开 tap 中的 stable Homebrew formula 仍为 v0.3.0，待 v0.4.4 的
-> Linuxbrew 安装验证完成后才会更新；v0.4.4 尚未发布。后续版本仍必须通过同一套 tag、签名、资产与 Homebrew
-> 门禁后才可作为可用下载来源。
+> 受保护 `release` Environment 与隔离 credentials 已配置。v0.4.4 已作为公开 GitHub Release 发布，包含六个
+> 平台 archive、checksum 与签名清单。GitHub Release 与 tap 是相互独立的发布物；当前状态请以官方
+> [GitHub Releases 页面]和 `brew info FlanChanXwO/tap/pixiv-cli` 为准。后续版本仍必须通过同一套 tag、签名、
+> 资产与 Homebrew 门禁后才可作为可信下载来源。
 
 ### 官方安装脚本
 
@@ -71,11 +73,11 @@ go install github.com/FlanChanXwO/pixiv-cli/cmd/pixiv@vX.Y.Z
 ```
 
 它仍使用本机 Go、cgo、C linker 和该 target 的 committed staticlib。六目标库与 manifest 已完整，
-例如当前正式版本可使用 `@v0.4.3`；后续版本始终使用其精确 tag，而不是分支名。
+例如已发布的 v0.4.4 可使用 `@v0.4.4`；始终使用已发布的精确 tag，而不是分支名。
 
 ### Homebrew
 
-正式 stable Release 和真实 tap 均通过 audit/安装验证后，macOS/Linux 用户可安装：
+macOS/Linux 用户可通过 stable formula 安装：
 
 ```bash
 brew install FlanChanXwO/tap/pixiv-cli
@@ -88,15 +90,15 @@ brew install FlanChanXwO/tap/pixiv-cli-beta
 ```
 
 两个 formula 都安装同名 `pixiv`，因此相互冲突；它们只下载已验证的 macOS/Linux Release
-资产，不引入 `ffmpeg` 依赖。公开 tap 中当前 stable `pixiv-cli` formula 仍为 v0.3.0；v0.4.3 目前仅可通过
-GitHub Release 获取，待 v0.4.4 的 Linuxbrew 安装验证完成后才会更新 tap。beta formula 只随后续 pre-release
-发布。
+资产，不引入 `ffmpeg` 依赖。GitHub Release 与公开 tap 属于独立发布通道，请用
+`brew info FlanChanXwO/tap/pixiv-cli` 和 [GitHub Releases 页面]查询当前状态，不要依赖本手册中硬编码的
+版本。beta formula 只随 pre-release 发布。
 
 ### 直接下载
 
 发布流程会为 darwin、linux、windows 的 amd64/arm64 生成六个固定名称的 archive：
 `pixiv-cli_<version>_<os>_<arch>.tar.gz`（Windows 为 `.zip`），以及 `checksums.txt` 与
-Ed25519 签名的 `checksums.json`。v0.4.3 已提供完整资产；后续版本只有在同一发布门禁完成后才应作为
+Ed25519 签名的 `checksums.json`。已发布的 v0.4.4 提供完整资产；后续版本只有在同一发布门禁完成后才应作为
 可供信任的直接下载来源。
 
 当前 Release 不包含 Apple notarization 或 Windows Authenticode。即使从已验证 Release
@@ -422,8 +424,9 @@ tag；Release binary 在下载前校验 Ed25519 签名的 checksum 清单和 arc
 SemVer tag，检查会报告该 tag 并 fail-closed，不会跳过它而选择较旧版本。
 
 受支持 binary 已内置 production Ed25519 public key/key ID/fingerprint；私钥只保存在受保护的
-`release` Environment 与受控 macOS Keychain 恢复副本。v0.4.3 是当前已发布的受签名 Release；
-`pixiv update --check` 仍只是只读检查，不能替代对选中版本资产、checksum 与签名的安装验证。
+`release` Environment 与受控 macOS Keychain 恢复副本。当前已发布的受签名 Release 请以
+[GitHub Releases 页面]为准；`pixiv update --check` 仍只是只读检查，不能替代对选中版本资产、checksum 与
+签名的安装验证。
 
 普通 CLI 命令成功后会尽力检查 stable 更新。它跳过 MCP、help、`version`、`update`、全部 `auth export`、`auth import --file` 与开发构建，
 对同一用户 cache 最多每 24 小时查询一次，并为自动检查设定最多 3 秒的等待时间。发现新版本或


### PR DESCRIPTION
Prepares the single formal v0.4.5 candidate after the Homebrew gate passed.

- moves the verified Linux Homebrew container fix into the v0.4.5 changelog section
- corrects stale EN/ZH/JA release-status prose without claiming v0.4.5 is already published
- leaves source, public formula, release assets, tags and tap untouched