### PR TITLE
fix: stabilize proxied downloads and search pagination guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- 修复经显式 HTTP(S) 代理下载静态图或 ugoira 时可能出现的 HTTP/2 资源流中断：资源传输现在单独协商 HTTP/1.1，App API、OAuth 和 Web 元数据请求保持原有协议协商。
+
 ## [0.5.0] - 2026-07-22
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -164,10 +164,6 @@ v0.4.2 では `auth add`/`auth token` を `auth import`/`auth export` に置き�
 
 bug report、文書修正、test、範囲を絞った機能追加を歓迎します。pull request の前に [CONTRIBUTING.md](CONTRIBUTING.md) を読み、大規模または互換性に影響する変更は先に相談してください。
 
-## Views badge について
-
-無料の `hits.sh` badge は一意の訪問者ではなく badge image request を数えます。再訪問、bot、browser cache、中継 cache により数値は変動し、badge の読み込み時には `hits.sh` へ通常の third-party image request が送信されます。3 言語のページは同じ badge URL を使うため、概算の repository view 数を共有します。
-
 ## ライセンス
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -168,10 +168,6 @@ v0.4.2 replaces `auth add`/`auth token` with `auth import`/`auth export`; the re
 
 Bug reports, documentation fixes, tests, and focused features are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request; discuss large or compatibility-sensitive changes first.
 
-## About the views badge
-
-The free `hits.sh` badge counts badge image requests, not unique people. Repeated visits, bots, browser caches, and intermediary caches can change the number, and loading the badge sends a normal third-party image request to `hits.sh`. All language pages use the same badge URL so they share one approximate repository-view count.
-
 ## License
 
 [MIT](LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -168,10 +168,6 @@ v0.4.2 以 `auth import`/`auth export` 取代 `auth add`/`auth token`，已删�
 
 欢迎提交 bug、文档修复、测试和聚焦功能。发起 pull request 前请阅读 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)；较大或影响兼容性的变更请先讨论。
 
-## 关于 views badge
-
-免费的 `hits.sh` badge 统计 badge 图片请求，不代表 unique people。重复访问、机器人、浏览器缓存和中间缓存都会影响数字；加载 badge 也会向第三方 `hits.sh` 发出普通图片请求。所有语言首页使用同一 badge URL，因此共享一个近似的仓库浏览量。
-
 ## 许可证
 
 [MIT](LICENSE)

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -179,6 +179,10 @@ pixiv auth login --proxy http://127.0.0.1:7890
 be used together. `--no-proxy` clears the proxy for this command even if `https_proxy` exists in the environment or
 config.
 
+When an HTTP(S) proxy is configured, media-resource transfers such as `download` (including Ugoira) deliberately use
+HTTP/1.1. App API, OAuth, and Web metadata requests retain their normal protocol negotiation. This avoids
+proxy-specific HTTP/2 stream resets and does not change authentication or the selected download quality.
+
 Real login depends on the Pixiv OAuth web flow being available; automated tests use a fake OAuth server and never
 touch real Pixiv.
 

--- a/docs/en/mcp-tools.md
+++ b/docs/en/mcp-tools.md
@@ -46,6 +46,10 @@ missing-token hint. This legacy tool remains `isError=false`; file-log events ex
 or values above 20 fail validation instead of being clamped. If fewer recommendations exist, the tool downloads the
 available works. Download tools return local file metadata only and never embed image bytes.
 
+When the MCP server is started with an HTTP(S) proxy, its media-resource downloads deliberately use HTTP/1.1. App
+API, OAuth, and Web metadata requests retain normal protocol negotiation; this avoids proxy-specific HTTP/2 stream
+resets without changing authentication or selected download quality.
+
 Both download tools return valid structured output on validation, SDK, recommendation, download, result-building,
 or file-read failure: `delivery` retains the normalized mode (`local_path` when IDs/delivery are invalid), and
 `items`/`files` are empty arrays rather than `null`. Legacy failures keep `isError=false` and the original safe

--- a/docs/ja/cli-reference.md
+++ b/docs/ja/cli-reference.md
@@ -163,6 +163,8 @@ pixiv auth login --proxy http://127.0.0.1:7890
 ```
 
 `--proxy URL` と `--no-proxy` は現在の command だけに適用され、同時使用できず、`config.toml` に保存されません。
+
+HTTP(S) proxy を設定した場合、ugoira を含む `download` などの media resource transfer は意図的に HTTP/1.1 を使います。App API、OAuth、Web metadata request は通常どおり protocol negotiation を維持します。これは proxy 固有の HTTP/2 stream reset を回避するためであり、認証や選択した download quality は変わりません。
 実 Pixiv login は OAuth Web flow に依存し、自動 test は fake OAuth server を使用します。
 
 ### 認証の import

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -293,7 +293,7 @@ PIXIV_E2E_REAL_API=1 PIXIV_E2E_REFRESH_TOKEN="<独立测试 refresh token>" PIXI
 PIXIV_E2E_REAL_API=1 PIXIV_E2E_USE_LOCAL_AUTH=1 PIXIV_E2E_PROXY=http://127.0.0.1:7890 go test ./e2e -run '^TestPixivBinaryAuthenticatedAppAPICanary$' -count=1 -v
 PIXIV_E2E_REAL_API=1 PIXIV_E2E_REFRESH_TOKEN="<独立测试 refresh token>" PIXIV_E2E_PROXY=http://127.0.0.1:7890 go test ./e2e -run '^TestPixivSDKAuthenticatedAppAPICanarySearchFilters$' -count=1 -v
 PIXIV_E2E_REAL_API=1 PIXIV_E2E_USE_LOCAL_AUTH=1 PIXIV_E2E_PROXY=http://127.0.0.1:7890 go test ./e2e -run '^TestPixivSDKAuthenticatedAppAPICanarySearchFilters$' -count=1 -v
-PIXIV_E2E_REAL_API=1 PIXIV_E2E_USE_LOCAL_AUTH=1 PIXIV_E2E_SFW_ILLUST_ID=147502481 PIXIV_E2E_R18_ILLUST_ID=147070125 PIXIV_E2E_R18_UGOIRA_ID=145973617 go test ./e2e -run 'TestPixiv(SDK|Binary)AuthenticatedR18RegressionCanary' -count=1 -v
+PIXIV_E2E_REAL_API=1 PIXIV_E2E_USE_LOCAL_AUTH=1 PIXIV_E2E_PROXY=http://127.0.0.1:7890 PIXIV_E2E_SFW_ILLUST_ID=147502481 PIXIV_E2E_R18_ILLUST_ID=147070125 PIXIV_E2E_R18_UGOIRA_ID=145973617 go test ./e2e -run 'TestPixiv(SDK|Binary)AuthenticatedR18RegressionCanary' -count=1 -v
 ```
 
 `go test ./...` 保持默认离线稳定；真实 Pixiv web API fallback e2e 默认跳过，只有设置 `PIXIV_E2E_WEB_API=1` 时才会联网。未设置 `PIXIV_WEB_API_PROXY` 时会直连。上述 Web canary 被显式调用时，会先从匿名搜索结果逐项读取 detail 取得真实宽高，选择可分类的横纵比候选，再执行带 `--aspect-ratio` 的高级搜索并通过 detail 复核返回作品的横纵比；该说明描述测试覆盖，不表示 canary 已经运行。
@@ -309,6 +309,8 @@ PIXIV_E2E_REAL_API=1 PIXIV_E2E_USE_LOCAL_AUTH=1 PIXIV_E2E_SFW_ILLUST_ID=14750248
 `download_url`、质量和帧；binary canary 从当前源码构建 CLI，验证 SFW/R18 `detail --json` 并将 R18 ugoira 下载到
 `t.TempDir()`，要求至少一个非空文件。若 Pixiv 返回不带有效 `Retry-After` 的 429，该真实 canary 保留诊断并明确失败，
 不会猜测等待或无限重试。
+
+显式 HTTP(S) proxy 下，资源传输固定协商 HTTP/1.1，而 App API、OAuth 与 Web metadata 保持原有协议协商。该 canary 的 ugoira 下载用于回归这一资源传输边界；它不为慢速正常下载增加固定超时。
 
 `PIXIV_E2E_BINARY` 与 `PIXIV_E2E_EXPECTED_VERSION` 供 CI 对已构建、已解压的 release binary 执行离线 e2e；它们不注入 token，也不启用真实 Pixiv API/Web fallback。`platform-smoke.yml` 在六个受支持 runner 上构建、封装、解压并运行这组 CLI/config/MCP stdio 验证。
 

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -159,6 +159,8 @@ pixiv auth login --proxy http://127.0.0.1:7890
 
 `--proxy URL` 与 `--no-proxy` 都只影响当前命令，不写入 `config.toml`；两者不能同时使用。`--no-proxy` 会清空本次命令的代理，即使环境变量或配置里存在 `https_proxy`。
 
+配置 HTTP(S) 代理时，媒体资源传输（如 `download`，包括 ugoira）会刻意使用 HTTP/1.1；App API、OAuth 与 Web 元数据请求仍保留其常规协议协商。此行为规避部分代理特有的 HTTP/2 流重置，不改变认证或所选下载质量。
+
 真实登录依赖 Pixiv OAuth 网页流程可用；自动化测试使用 fake OAuth server，不访问真实 Pixiv。
 
 ### 导入认证

--- a/docs/zh-CN/mcp-tools.md
+++ b/docs/zh-CN/mcp-tools.md
@@ -30,6 +30,8 @@ SDK cursor 不出现在 MCP 参数或输出。列表工具统一使用逻辑 `pa
 
 `download_random_from_recommendation.count` 限制本次请求的作品数，不限制一个作品展开的文件数。显式传入 0、负数或大于 20 的值会返回参数错误，不会改写为默认值或边界值；推荐列表少于请求数时则下载列表中实际可用的作品。该 tool 与 `download` 一样只返回下载结果文本与 structured 本地文件元数据，不内嵌图片内容。
 
+以 HTTP(S) 代理启动 MCP server 时，其媒体资源下载会刻意使用 HTTP/1.1。App API、OAuth 与 Web 元数据请求仍保留常规协议协商；此行为规避部分代理特有的 HTTP/2 流重置，不改变认证或所选下载质量。
+
 两个下载 tool 在参数校验、SDK、推荐获取、下载、结果整理失败时，都会保留原有业务错误文本，并返回有效 structured output：`delivery` 固定为 `local_path`（非法 `delivery` 时同样回落到该值），`items` 与 `files` 是空数组而不是 `null`。这些遗留失败结果继续保持 `isError=false`，不会被 typed output schema 的校验错误替代。成功与失败均不内嵌图片内容。
 
 ## 作品与用户读取

--- a/pixiv/client.go
+++ b/pixiv/client.go
@@ -3,6 +3,7 @@ package pixiv
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -141,13 +142,14 @@ func NewClient(options Options) (*Client, error) {
 		webapi.WithWebBase(options.WebAPIBaseURL),
 		webapi.WithHTTPClient(httpClient),
 	}
+	resourceHTTPClient := resourceHTTPClientForExplicitProxy(httpClient)
 	return &Client{
 		app:                appapi.New(appOptions...),
 		web:                webapi.New(webOptions...),
 		authenticated:      accessToken != "",
 		webFallbackEnabled: options.WebFallbackEnabled,
 		resourcePolicy:     resourcePolicy,
-		resource:           internalresource.NewApp(httpClient),
+		resource:           internalresource.NewApp(resourceHTTPClient),
 		httpClient:         httpClient,
 		authFilePath:       strings.TrimSpace(options.AuthFilePath),
 		configFilePath:     strings.TrimSpace(options.ConfigFilePath),
@@ -156,6 +158,29 @@ func NewClient(options Options) (*Client, error) {
 		authState:          &authTransactionState{},
 		logger:             loggerOrDiscard(options.Logger),
 	}, nil
+}
+
+// resourceHTTPClientForExplicitProxy 为显式代理的资源流单独复制 transport。
+// 一些本地 HTTP(S) 代理会在 HTTP/2 资源流中断开连接；控制面仍保持调用方原有
+// 协议协商，只有媒体传输固定为 HTTP/1.1。
+func resourceHTTPClientForExplicitProxy(httpClient *http.Client) *http.Client {
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok || transport.Proxy == nil {
+		return httpClient
+	}
+	resourceClient := *httpClient
+	resourceTransport := transport.Clone()
+	resourceTransport.ForceAttemptHTTP2 = false
+	// Transport.Clone 会完成源 transport 的协议初始化，可能已把 h2 写入
+	// TLSClientConfig。显式清除该协商并安装空 TLSNextProto，才能确保此副本
+	// 不会因后续 RoundTrip 再次自动启用 HTTP/2。
+	resourceTransport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+	if resourceTransport.TLSClientConfig == nil {
+		resourceTransport.TLSClientConfig = &tls.Config{}
+	}
+	resourceTransport.TLSClientConfig.NextProtos = []string{"http/1.1"}
+	resourceClient.Transport = resourceTransport
+	return &resourceClient
 }
 
 func loggerOrDiscard(logger *slog.Logger) *slog.Logger {

--- a/pixiv/client_resource_transport_test.go
+++ b/pixiv/client_resource_transport_test.go
@@ -1,0 +1,111 @@
+package pixiv_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/FlanChanXwO/pixiv-cli/pixiv"
+)
+
+func TestNewClientUsesHTTP1ForResourcesWithExplicitProxy(t *testing.T) {
+	protocols := make(chan string, 1)
+	resourceServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		protocols <- r.Proto
+		_, _ = io.WriteString(w, "resource")
+	}))
+	resourceServer.EnableHTTP2 = true
+	resourceServer.TLS = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+	resourceServer.StartTLS()
+	defer resourceServer.Close()
+
+	proxyServer := httptest.NewServer(http.HandlerFunc(tunnelProxy))
+	defer proxyServer.Close()
+	proxyURL, err := url.Parse(proxyServer.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	resourceURL, err := url.Parse(resourceServer.URL)
+	if err != nil {
+		t.Fatalf("parse resource URL: %v", err)
+	}
+	trustedTransport := resourceServer.Client().Transport.(*http.Transport)
+	transport := &http.Transport{
+		TLSClientConfig:   trustedTransport.TLSClientConfig.Clone(),
+		Proxy:             http.ProxyURL(proxyURL),
+		ForceAttemptHTTP2: true,
+	}
+
+	client, err := pixiv.NewClient(pixiv.Options{
+		HTTPClient: transportClient(transport),
+		ResourcePolicy: pixiv.ResourcePolicy{Mirrors: []pixiv.ResourceMirrorPolicy{{
+			Host:         resourceURL.Host,
+			PathPrefixes: []string{"/resource"},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	ref, err := client.ParseResourceRef(resourceServer.URL + "/resource/image.jpg")
+	if err != nil {
+		t.Fatalf("parse resource ref: %v", err)
+	}
+	response, err := client.OpenResource(context.Background(), pixiv.OpenResourceRequest{Ref: ref})
+	if err != nil {
+		t.Fatalf("open resource: %v", err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatalf("close resource response: %v", err)
+	}
+
+	protocol := <-protocols
+	if protocol != "HTTP/1.1" {
+		t.Fatalf("resource protocol = %s, want HTTP/1.1 when an explicit proxy is configured", protocol)
+	}
+}
+
+func transportClient(transport *http.Transport) *http.Client {
+	return &http.Client{Transport: transport}
+}
+
+func tunnelProxy(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodConnect {
+		http.Error(w, "CONNECT required", http.StatusMethodNotAllowed)
+		return
+	}
+	upstream, err := net.Dial("tcp", r.Host)
+	if err != nil {
+		http.Error(w, "cannot connect upstream", http.StatusBadGateway)
+		return
+	}
+	defer upstream.Close()
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking unsupported", http.StatusInternalServerError)
+		return
+	}
+	client, buffered, err := hijacker.Hijack()
+	if err != nil {
+		return
+	}
+	defer client.Close()
+	_, _ = fmt.Fprint(client, "HTTP/1.1 200 Connection Established\r\n\r\n")
+	if pending := buffered.Reader.Buffered(); pending != 0 {
+		_, _ = io.CopyN(upstream, buffered.Reader, int64(pending))
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(upstream, client)
+		close(done)
+	}()
+	_, _ = io.Copy(client, upstream)
+	<-done
+}

--- a/skills/pixiv-cli/SKILL.md
+++ b/skills/pixiv-cli/SKILL.md
@@ -76,7 +76,9 @@ the installed binary's `pixiv <cmd> --help` output.
    `user following`. Add `--page`, `--type`, `--rating`, or other flags only
    when that specific command's help exposes them.
    `--limit 0` requests all results, so never use it unless the user explicitly
-   asks for everything.
+   asks for everything. A result that reaches `--limit N` is not proof that
+   only N matches exist; follow the pagination and completeness contract in
+   [`references/discover.md`](references/discover.md#pagination-and-completeness).
 2. **Small result, display only:** use the default human-readable output and
    relay it. JSON carries field names and metadata — it is *larger* than the
    table for display purposes.
@@ -170,7 +172,9 @@ assuming its effective value.
    emits JSON.
 10. **Proxy is per-command.** The browser's system proxy is NOT inherited.
    Persist with `pixiv config set https_proxy URL`; override per command with
-   `--proxy` / `--no-proxy` (mutually exclusive).
+   `--proxy` / `--no-proxy` (mutually exclusive). With an HTTP(S) proxy,
+   resource downloads deliberately use HTTP/1.1; App API, OAuth, and Web
+   metadata requests retain normal protocol negotiation.
 11. **Long downloads may legitimately take time.** Do not impose an arbitrary
    timeout or kill the process merely because it is slow; wait for completion,
    user cancellation, or a real error.

--- a/skills/pixiv-cli/references/discover.md
+++ b/skills/pixiv-cli/references/discover.md
@@ -35,6 +35,24 @@ pixiv search "初音ミク" --limit 10 --json
 - Artwork JSON/text include the stable page URL
   `https://www.pixiv.net/artworks/{id}` as the first field/line.
 
+## Pagination and completeness
+
+- A search without an explicit `--limit` returns one logical upstream batch. It
+  is a sample, never evidence that no further matches exist.
+- `--limit N` continues across upstream batches until it has N filtered results
+  or reaches the current end. If it returns exactly N, say “found N matching
+  works” or “first N matches”; never say “only N matches exist”. If it returns
+  fewer than N, the current query reached its end and that fact may be stated.
+- When the user asks for a specific number of candidates, request that number
+  with `--limit N`; do not stop at a smaller first batch. To continue a prior
+  bounded search, keep WORD, search fields, filters, and sort identical, then
+  increment `--page N` (1-based). `--page` always requires a positive
+  `--limit`.
+- Only use `--limit 0` for an explicit request to enumerate every result the
+  current search can return. State that this is an exhaustive traversal of the
+  current API search result, not an unsupported claim about a permanent global
+  corpus.
+
 ## From a search hit to full detail
 
 Extract `id` fields from the search JSON, then:


### PR DESCRIPTION
## Summary
- Force Pixiv media-resource transfers through explicit proxies to negotiate HTTP/1.1 while preserving control-plane protocol negotiation.
- Add a TLS CONNECT-proxy regression test and update CLI, MCP, maintainer, and product-skill documentation.
- Teach the distributed product skill to distinguish a bounded search result from an exhaustive result and to paginate when users need more candidates.

## Verification
- `go test ./...`
- `sh scripts/build.sh`
- `pre-commit run --all-files`
- Authenticated real SDK and binary R18 regression canaries with a local proxy
- `go test ./scripts/documentation -count=1`
- `git diff --check`