### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/.github/workflows/publish-skillhub.yml
+++ b/.github/workflows/publish-skillhub.yml
@@ -1,0 +1,101 @@
+name: Publish SkillHub skill
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing published immutable SemVer tag to publish to SkillHub
+        required: true
+        type: string
+
+# Release events load this workflow from the default branch. The checkout below is
+# nevertheless pinned to the immutable release tag, so the submitted Skill always
+# matches the GitHub Release rather than a later main commit.
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }}
+  SKILLHUB_HOST: https://api.skillhub.cn
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish pixiv-cli to SkillHub
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ env.RELEASE_TAG }}
+      - name: Verify the published release tag belongs to the default branch
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          case "$RELEASE_TAG" in
+            v[0-9]*) ;;
+            *) printf '%s\n' 'release tag must start with v and a digit' >&2; exit 1 ;;
+          esac
+          git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"
+          tag_commit=$(git rev-parse "$RELEASE_TAG^{commit}")
+          git show-ref --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH"
+          git merge-base --is-ancestor "$tag_commit" "origin/$DEFAULT_BRANCH"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.draft')" = false
+          test -n "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.published_at')"
+          go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"
+      # The vendor installer runs before this workflow makes SKILLHUB_TOKEN available.
+      # Its CLI is only used after the immutable tag and local metadata have passed.
+      - name: Install the official SkillHub CLI without credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          installer="$RUNNER_TEMP/skillhub-install.sh"
+          curl --fail --location --silent --show-error https://skillhub.cn/install/install.sh --output "$installer"
+          bash "$installer" --cli-only
+          "$HOME/.local/bin/skillhub" --skip-self-upgrade --version
+      - name: Dry-run the exact tagged product skill
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$HOME/.local/bin/skillhub" --skip-self-upgrade publish skills/pixiv-cli \
+            --host "$SKILLHUB_HOST" \
+            --version "${RELEASE_TAG#v}" \
+            --dry-run \
+            --json
+      - name: Publish and confirm the SkillHub submission
+        shell: bash
+        env:
+          SKILLHUB_TOKEN: ${{ secrets.SKILLHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$SKILLHUB_TOKEN"
+          response="$RUNNER_TEMP/skillhub-publish.json"
+          "$HOME/.local/bin/skillhub" --skip-self-upgrade publish skills/pixiv-cli \
+            --host "$SKILLHUB_HOST" \
+            --version "${RELEASE_TAG#v}" \
+            --changelog "Synchronized with Pixiv CLI $RELEASE_TAG" \
+            --json | tee "$response"
+          python3 - "$response" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as source:
+              result = json.load(source)
+
+          skill_id = result.get("skillId")
+          status = result.get("status")
+          if not skill_id or not status:
+              raise SystemExit("SkillHub accepted the request without skillId or status")
+
+          print(f"SkillHub submission confirmed: skillId={skill_id} status={status}")
+          public_url = result.get("publicUrl")
+          if public_url:
+              print(f"SkillHub URL: {public_url}")
+          PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -470,6 +470,7 @@ jobs:
             --output-dir release \
             --install-sh scripts/install.sh \
             --install-cmd scripts/install.cmd \
+            --release-sources internal/update/release_sources.txt \
             --key-id "$RELEASE_SIGNING_KEY_ID" \
             --private-key "$key_path" \
             --changelog "changelog/v${RELEASE_TAG#v}/en.md" \

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,6 +22,7 @@
 - **App API 優先** — refresh token が設定されている場合は常に認証済み App 経路を使用し、App の失敗を Web に暗黙フォールバックしません。
 - **認証済み R18 読み取り** — detail、pages、ugoira metadata と全 16 ranking mode は App API を使い、original が得られない場合は検証済み medium ugoira ZIP を正しく使用します。
 - **実用的な検索フィルター** — レーティング、作品種別、AI モード、縦横比、解像度、動的な制作ツール候補に対応します。
+- **Pixiv URL を直接指定** — 対応する作品 URL を detail/download に貼り付けられ、認証済みならユーザープロフィール/作品一覧 URL でそのユーザーの視覚作品をブラウザー Cookie 自動化なしにダウンロードできます。
 - **ローカル複数アカウント OAuth** — ブラウザーの Cookie や profile を読み取らず、ブラウザーログイン、アカウント選択、refresh token rotation を行います。
 - **安全な自動化** — typed SDK error、JSON 出力、クリーンな MCP stdio、署名付き更新を備え、結果を暗黙に切り捨てません。
 - **限定的な匿名アクセス** — token がなく fallback が有効な場合、対応する読み取り操作は Web API を利用できます。
@@ -33,7 +34,7 @@
 Linux/macOS（`sh`）：
 
 ```bash
-curl -fsSLo /tmp/pixiv-install.sh https://raw.githubusercontent.com/FlanChanXwO/pixiv-cli/main/scripts/install.sh && sh /tmp/pixiv-install.sh --add-to-path
+curl -fsSLo /tmp/pixiv-install.sh https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/install.sh && sh /tmp/pixiv-install.sh --add-to-path
 ```
 
 Windows Command Prompt（`cmd.exe`、PowerShell 不要）：
@@ -43,6 +44,8 @@ curl.exe -fsSLo "%TEMP%\pixiv-install.cmd" https://raw.githubusercontent.com/Fla
 ```
 
 どちらのスクリプトも AMD64/ARM64 を検出し、最新の安定版公式 Release archive を選択して公開 SHA-256 を検証します。staging した binary を事前確認してからユーザー単位でインストールし、その後にのみ PATH を変更します。PATH を変更しない場合は `--no-path`、別の保存先には `--install-dir DIR` を使用できます。実行前にダウンロードしたスクリプトを確認できます。
+
+正式版の installer は権威ある `checksums.txt` を常に GitHub HTTPS から直接取得します。内蔵の無料候補は platform archive の probe/download だけに使われ、返す checksum は直取得した内容と一致しなければなりません。download 後も SHA-256 を検証するため、これは転送到達性の改善であり、Release の identity や integrity 判定を変更しません。
 
 ### Coding Agent にインストールさせる
 
@@ -96,9 +99,9 @@ pixiv search "初音ミク" --type illust --ai-mode exclude --resolution high
 pixiv novel search "初音ミク" --rating sfw --min-text-length 1000
 
 # 詳細、おすすめ、ダウンロードを利用します。
-pixiv detail 123456
+pixiv detail https://www.pixiv.net/artworks/123456
 pixiv recommended all --limit 10
-pixiv download 123456 --pages 1,3-5 --quality regular
+pixiv download https://www.pixiv.net/artworks/123456 --pages 1,3-5 --quality regular
 ```
 
 すべての command、flag、設定キー、環境変数、fallback、更新動作は `pixiv --help` または[完全な CLI リファレンス](docs/ja/cli-reference.md)で確認できます。

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Maintainers: release tags are blocked by a protected authenticated E2E gate. Its
 - **App API first** — a configured refresh token always uses the authenticated App path; App failures never silently fall back to Web.
 - **Authenticated R18 reads** — details, pages, ugoira metadata, and all 16 ranking modes use the App API; a verified medium ugoira ZIP is reported honestly when original is unavailable.
 - **Useful search filters** — rating, content type, AI mode, aspect ratio, resolution, and dynamic drawing tools.
+- **Direct Pixiv references** — paste supported artwork URLs into detail or download, or an authenticated user profile/artworks URL to download that user's visual works without browser-cookie automation.
 - **Local multi-account OAuth** — browser login, account selection, and refresh-token rotation without reading browser cookies or profiles.
 - **Safe automation** — typed SDK errors, JSON output, clean MCP stdio, signed release updates, and no hidden result truncation.
 - **Limited anonymous access** — supported read operations can use the Web API when no token exists and fallback is enabled.
@@ -33,7 +34,7 @@ Maintainers: release tags are blocked by a protected authenticated E2E gate. Its
 Linux/macOS (`sh`):
 
 ```bash
-curl -fsSLo /tmp/pixiv-install.sh https://raw.githubusercontent.com/FlanChanXwO/pixiv-cli/main/scripts/install.sh && sh /tmp/pixiv-install.sh --add-to-path
+curl -fsSLo /tmp/pixiv-install.sh https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/install.sh && sh /tmp/pixiv-install.sh --add-to-path
 ```
 
 Windows Command Prompt (`cmd.exe`, no PowerShell):
@@ -45,6 +46,10 @@ curl.exe -fsSLo "%TEMP%\pixiv-install.cmd" https://raw.githubusercontent.com/Fla
 Both scripts detect AMD64/ARM64, select the latest stable official Release archive, verify its published SHA-256,
 preflight the staged binary, and install per-user before changing PATH. Use `--no-path` to leave PATH untouched or
 `--install-dir DIR` to choose another destination. You can inspect the downloaded script before running it.
+
+Versioned installers keep `checksums.txt` on the official GitHub HTTPS path. Embedded free source candidates are
+probed only for the platform archive, must return the same checksum content, and the downloaded archive still has to
+pass SHA-256 verification. This changes transport availability, never Release identity or integrity.
 
 ### Install with a coding agent
 
@@ -98,9 +103,9 @@ pixiv search "初音ミク" --type illust --ai-mode exclude --resolution high
 pixiv novel search "初音ミク" --rating sfw --min-text-length 1000
 
 # Inspect, discover recommendations, and download.
-pixiv detail 123456
+pixiv detail https://www.pixiv.net/artworks/123456
 pixiv recommended all --limit 10
-pixiv download 123456 --pages 1,3-5 --quality regular
+pixiv download https://www.pixiv.net/artworks/123456 --pages 1,3-5 --quality regular
 ```
 
 Run `pixiv --help` or open the [complete CLI reference](docs/en/cli-reference.md) for every command, flag, configuration key, environment variable, fallback rule, and update behavior.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@
 - **App API 优先**——配置 refresh token 后始终走已认证 App 路径；App 失败不会静默回落 Web。
 - **认证 R18 读取**——详情、分页、ugoira metadata 和全部 16 种排行榜都走 App API；无法取得 original 时会诚实使用已验证的 medium ugoira ZIP。
 - **实用搜索筛选**——支持分级、作品类型、AI 模式、横纵比、分辨率和动态绘图工具。
+- **直达 Pixiv 引用**——可把受支持作品 URL 直接粘贴给详情或下载；已认证时也可使用作者主页/作品页 URL 下载该作者的视觉作品，无需浏览器 Cookie 自动化。
 - **本地多账号 OAuth**——支持浏览器登录、账号选择和 refresh token rotation，不读取浏览器 Cookie 或 profile。
 - **适合自动化**——typed SDK error、JSON 输出、纯净 MCP stdio、签名更新且不隐藏截断结果。
 - **有限匿名访问**——没有 token 且启用 fallback 时，受支持的只读操作可以使用 Web API。
@@ -33,7 +34,7 @@
 Linux/macOS（`sh`）：
 
 ```bash
-curl -fsSLo /tmp/pixiv-install.sh https://raw.githubusercontent.com/FlanChanXwO/pixiv-cli/main/scripts/install.sh && sh /tmp/pixiv-install.sh --add-to-path
+curl -fsSLo /tmp/pixiv-install.sh https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/install.sh && sh /tmp/pixiv-install.sh --add-to-path
 ```
 
 Windows 命令提示符（`cmd.exe`，不依赖 PowerShell）：
@@ -45,6 +46,8 @@ curl.exe -fsSLo "%TEMP%\pixiv-install.cmd" https://raw.githubusercontent.com/Fla
 两个脚本都会检测 AMD64/ARM64、选择最新 stable 官方 Release archive、校验发布的 SHA-256、预检暂存
 binary，并在修改 PATH 前完成用户级安装。可用 `--no-path` 保持 PATH 不变，或用 `--install-dir DIR`
 选择其他目录；执行前也可以先审阅下载的脚本。
+
+随正式版本发布的安装器始终从 GitHub HTTPS 直连取得权威 `checksums.txt`。内置免费候选源只用于探测和下载平台压缩包，候选返回的 checksum 必须与直连内容一致，下载结果仍必须通过 SHA-256 校验。它只改善传输可达性，不改变 Release 身份或完整性判断。
 
 ### 让 Coding Agent 安装
 
@@ -98,9 +101,9 @@ pixiv search "初音ミク" --type illust --ai-mode exclude --resolution high
 pixiv novel search "初音ミク" --rating sfw --min-text-length 1000
 
 # 查看详情、获取推荐并下载。
-pixiv detail 123456
+pixiv detail https://www.pixiv.net/artworks/123456
 pixiv recommended all --limit 10
-pixiv download 123456 --pages 1,3-5 --quality regular
+pixiv download https://www.pixiv.net/artworks/123456 --pages 1,3-5 --quality regular
 ```
 
 运行 `pixiv --help`，或打开[完整 CLI 参考手册](docs/zh-CN/cli-reference.md)，查看全部命令、flag、配置键、环境变量、fallback 规则和更新行为。

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,7 @@ GitHub Release bodies present the two versions together, with English first and 
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.7.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.6.0...v0.7.0) | 2026-07-25 | [English](v0.7.0/en.md) · [简体中文](v0.7.0/zh-CN.md) |
 | [v0.6.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.5.0...v0.6.0) | 2026-07-24 | [English](v0.6.0/en.md) · [简体中文](v0.6.0/zh-CN.md) |
 | [v0.5.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.5...v0.5.0) | 2026-07-22 | [English](v0.5.0/en.md) · [简体中文](v0.5.0/zh-CN.md) |
 | [v0.4.5](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.4...v0.4.5) | 2026-07-20 | [English](v0.4.5/en.md) · [简体中文](v0.4.5/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,6 +5,8 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | 未发布 | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.7.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.6.0...v0.7.0) | 2026-07-25 | [English](v0.7.0/en.md) · [简体中文](v0.7.0/zh-CN.md) |
+| [v0.6.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.5.0...v0.6.0) | 2026-07-24 | [English](v0.6.0/en.md) · [简体中文](v0.6.0/zh-CN.md) |
 | [v0.5.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.5...v0.5.0) | 2026-07-22 | [English](v0.5.0/en.md) · [简体中文](v0.5.0/zh-CN.md) |
 | [v0.4.5](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.4...v0.4.5) | 2026-07-20 | [English](v0.4.5/en.md) · [简体中文](v0.4.5/zh-CN.md) |
 | [v0.4.4](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.3...v0.4.4) | 2026-07-19 | [English](v0.4.4/en.md) · [简体中文](v0.4.4/zh-CN.md) |

--- a/changelog/v0.7.0/en.md
+++ b/changelog/v0.7.0/en.md
@@ -1,0 +1,14 @@
+# v0.7.0 — 2026-07-25
+
+## Added
+
+- Release-binary updates and versioned installer assets now carry a static, tested free GitHub Release-source list. They probe viable routes locally, support path and query-parameter proxy templates, and never fetch a remote mirror list.
+- Existing `detail` and `download` inputs now accept strict official Pixiv artwork URLs; `download` also accepts authenticated user profile and artworks URLs to walk every illustration, manga, and ugoira without downloading novels.
+- MCP `illust_detail` accepts exactly one of an ID or URL, and `download` accepts URLs. Illustration query tools now return typed structured results alongside compact text summaries.
+- Illustration `search` and MCP `search_illust` now support official App `keyword` search (tags, titles, and captions), inclusive explicit date bounds, public bookmark-count bounds, and the `half-year` / `year` quick date ranges. App-only filters fail explicitly without App OAuth; no cookie fallback is introduced.
+- Each published GitHub Release now submits the matching tagged `pixiv-cli` product skill to SkillHub. The submission is validated locally first and the workflow requires the returned SkillHub `skillId` and review status before succeeding.
+
+## Changed
+
+- A configured `--proxy`, `https_proxy`, or `HTTPS_PROXY` keeps precedence over public Release sources. The updater preserves canonical GitHub release identity and Ed25519/SHA-256 verification; installers retain a direct GitHub checksum before accepting a proxied archive.
+- Download JSON now reports `{items, failures}` with canonical artwork URLs, IDs, types, pages, and local paths. Partial downloads report every completed outcome and exit non-zero; no download history, cache, or cross-run de-duplication is created.

--- a/changelog/v0.7.0/zh-CN.md
+++ b/changelog/v0.7.0/zh-CN.md
@@ -1,0 +1,14 @@
+# v0.7.0 — 2026-07-25
+
+## 新增
+
+- Release binary 更新与版本化安装器资产现在携带静态、已测试的免费 GitHub Release-source 列表；它们在本机探测可用路由，支持路径式和查询参数式代理模板，且绝不远程拉取镜像列表。
+- 现有 `detail` 与 `download` 输入现在接受严格的官方 Pixiv 作品 URL；`download` 也接受已认证作者主页和作品页 URL，以遍历全部插画、漫画和 ugoira，但不下载小说。
+- MCP `illust_detail` 现在恰好接受 ID 或 URL 之一，`download` 接受 URL；插画查询 tool 会在紧凑文本摘要之外返回 typed structured result。
+- 插画 `search` 与 MCP `search_illust` 现支持官方 App 的 `keyword` 搜索（标签、标题、说明文字）、包含边界的显式日期、公开收藏数边界，以及 `half-year` / `year` 快捷日期范围。没有 App OAuth 时，App 专属筛选会明确失败；未引入 Cookie fallback。
+- 每个已公开 GitHub Release 现在都会向 SkillHub 提交同一 tag 对应的 `pixiv-cli` 产品 skill。提交前会先在本地校验，工作流必须取得 SkillHub 返回的 `skillId` 与审核状态才会成功。
+
+## 变更
+
+- 已配置的 `--proxy`、`https_proxy` 或 `HTTPS_PROXY` 继续优先于公共 Release 源。更新器保持规范 GitHub Release 身份和 Ed25519/SHA-256 验证；安装器在接受经代理下载的 archive 前仍直连 GitHub 取得 checksum。
+- 下载 JSON 现在以 `{items, failures}` 报告规范作品 URL、ID、类型、页码和本地路径。部分失败会报告全部已完成结果并以非零退出；不会创建下载历史、缓存或跨次去重。

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -26,7 +26,7 @@ The repository provides two per-user bootstrap scripts for the latest stable Rel
 
 ```bash
 # Linux/macOS
-curl -fsSLo /tmp/pixiv-install.sh https://raw.githubusercontent.com/FlanChanXwO/pixiv-cli/main/scripts/install.sh
+curl -fsSLo /tmp/pixiv-install.sh https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/install.sh
 sh /tmp/pixiv-install.sh --add-to-path
 ```
 
@@ -52,6 +52,11 @@ This is an initial-bootstrap boundary: before `pixiv` exists, the scripts have n
 SHA-256 check detects corruption or a mismatched archive, while authenticity still depends on HTTPS and the official
 GitHub repository/Release account. Inspect the installer before execution. Once installed, `pixiv update` uses the
 binary's embedded Ed25519 trust root for subsequent Release updates.
+
+The versioned installers embed a static Release-source list. They always download the authoritative `checksums.txt`
+directly from GitHub HTTPS, then probe free candidates only for the matching platform archive; a candidate is usable
+only when its checksum response is byte-for-byte identical to the direct file. The archive still requires the direct
+SHA-256 match before installation. The list is never fetched remotely and changes only with a signed Release.
 
 ### Build from source
 
@@ -333,7 +338,7 @@ The CLI uses Cobra/pflag, so options may appear before or after positional argum
 | `search` | `pixiv search [options] WORD` | Searches illustrations. |
 | `novel search` | `pixiv novel search [options] WORD` | Searches novels through the authenticated App API. |
 | `search-options` | `pixiv search-options [options] WORD` | Lists the App API drawing-tool choices for a word; requires authentication and supports the common account/token/proxy flags and `--json`. |
-| `detail` | `pixiv detail [options] ILLUST_ID` | Shows details for a single artwork. |
+| `detail` | `pixiv detail [options] ILLUST_ID_OR_URL` | Shows details for a single artwork ID or supported Pixiv artwork URL. |
 | `ranking` | `pixiv ranking [options]` | Shows Pixiv illustration rankings. |
 | `recommended` | `pixiv recommended all\|illust\|manga\|novel\|user [--page N --limit N --json]` | Shows personalized recommendations for the given kind; `all` returns illustrations, manga, novels, and users in full, in order, and requires authentication. |
 | `user search` | `pixiv user search WORD [--page N --limit N --json]` | Searches users. JSON and text label whether results came from official App user search or anonymous related-illustration-author fallback. |
@@ -345,7 +350,7 @@ The CLI uses Cobra/pflag, so options may appear before or after positional argum
 | `bookmark remove` | `pixiv bookmark remove ILLUST_ID` | Removes an artwork bookmark; it does not accept visibility or tag flags. |
 | `follow add` | `pixiv follow add USER_ID [--restrict public\|private]` | Follows a user with the selected visibility. |
 | `follow remove` | `pixiv follow remove USER_ID` | Unfollows a user; it does not accept a visibility flag. |
-| `download` | `pixiv download [options] ILLUST_ID...` | Downloads one or more artworks; without a token, uses the anonymous web fallback by default. |
+| `download` | `pixiv download [options] TARGET...` | Downloads artwork IDs/URLs, or all visual works from a supported user URL. |
 | `mcp` | `pixiv mcp [--proxy URL\|--no-proxy]` | Starts the MCP stdio server; the proxy override applies only to this launch. |
 
 Downloaded filenames normalize cross-platform-invalid characters in both the filename template and URL-derived
@@ -368,15 +373,19 @@ used.
 
 | Command | Flag | Default | Description |
 | --- | --- | --- | --- |
-| `search`, `novel search` | `--search-by` | `tag-partial` | Search field: `tag-partial`, `tag-exact`, or `title-caption`. |
+| `search` | `--search-by` | `tag-partial` | Search field: `tag-partial`, `tag-exact`, `title-caption`, or App-only `tag-title-caption` (tags, titles, and captions). |
+| `novel search` | `--search-by` | `tag-partial` | Search field: `tag-partial`, `tag-exact`, or `title-caption`. |
 | `search`, `novel search` | `--sort` | `date_desc` | Sort order: `date_desc` or `date_asc`. |
-| `search`, `novel search` | `--period` | empty | Time range: `day`, `week`, or `month`; omit for no range. |
+| `search` | `--period` | empty | Quick time range: `day`, `week`, `month`, `half-year`, or `year`; omit for no range. Cannot be combined with `--start-date` or `--end-date`. |
+| `novel search` | `--period` | empty | Time range: `day`, `week`, or `month`; omit for no range. |
+| `search` | `--start-date` / `--end-date` | empty | Inclusive `YYYY-MM-DD` date bounds. Either may be supplied; when both are present, start cannot be later than end. Mutually exclusive with `--period`. |
 | `search`, `novel search` | `--rating` | `all` | Rating filter: `sfw`, `r18`, `r18g`, `mature`, or `all`. |
 | `search` | `--type` | `all` | Content type: `all`, `illust-and-ugoira`, `illust`, `manga`, or `ugoira`. |
 | `search` | `--ai-mode` | `all` | AI filter: `all`, `exclude`, or `only`; Pixiv `AIType==2` is AI-generated. |
 | `search` | `--aspect-ratio` | `all` | Aspect ratio: `all`, `landscape`, `portrait`, or `square`. |
 | `search` | `--resolution` | `all` | Resolution: `all`, `high`, `medium`, or `low`; both dimensions are respectively `>=3000`, `1000..2999`, or `<=999`. |
 | `search` | `--draw-tool` | empty | Exact upstream drawing-tool name; obtain current values with authenticated `search-options`. |
+| `search` | `--bookmark-min` / `--bookmark-max` | empty | Inclusive non-negative public bookmark-count bounds. Require App OAuth; `min` cannot exceed `max`. |
 | `novel search` | `--min-text-length` | `0` | Minimum text length in characters; `0` disables the bound. |
 | `novel search` | `--max-text-length` | `0` | Maximum text length in characters; `0` disables the bound; it cannot be lower than a non-zero minimum. |
 | `novel search` | `--original-only` | `false` | Keeps only novels marked original by Pixiv. |
@@ -396,8 +405,8 @@ used.
 | `bookmark add` | `--restrict` | `public` | Visibility of the new bookmark: `public` or `private`. |
 | `bookmark add` | `--tag` | empty | Bookmark tag; may be repeated. |
 | `follow add` | `--restrict` | `public` | Visibility of the new follow: `public` or `private`. |
-| `detail` | `ILLUST_ID` | required | Pixiv artwork ID. |
-| `download` | `ILLUST_ID...` | required | One or more Pixiv artwork IDs. |
+| `detail` | `ILLUST_ID_OR_URL` | required | A positive artwork ID or a supported Pixiv artwork URL. |
+| `download` | `TARGET...` | required | Artwork IDs, artwork URLs, or supported user profile/artworks URLs. |
 
 With a refresh token, `search` always uses App API. App applies resolution, aspect-ratio, tool, content-type, and
 `ai-mode=exclude` filters, while rating and `ai-mode=only` are applied to each App result batch. App
@@ -406,8 +415,22 @@ different filter set. When local filters skip leading empty upstream batches, CL
 non-empty logical batch or the upstream ends. With a positive `--limit` or `--page`, the CLI fills logical
 results across batches until it collects enough matching works, the upstream has no next batch, or a repeated
 cursor is detected; `--limit 0` walks the entire filtered stream; omitting `--limit` reads one upstream batch while
-still skipping leading empty batches. Bookmark-count filtering and like-count fields are not provided.
+still skipping leading empty batches. App also applies explicit date and bookmark-count bounds. Bookmark count is not a
+like-count field and must not be labeled as likes.
 Artwork JSON/text include a stable page URL `https://www.pixiv.net/artworks/{id}` as the first field/line.
+
+### Illustration tag-query syntax
+
+The authenticated App API has been verified for illustration `search` when `--search-by` selects a tag mode. Use
+`tag-exact` for boolean tag filtering: `tagA tagB` means both complete tags are required (AND), and
+`tagA OR tagB` means either complete tag is accepted (OR). `OR` must be uppercase. The literal word `AND` is not a
+verified operator; write the two tags with a space instead.
+
+`tag-partial` (the default) also accepts the tested uppercase `OR` syntax, but each term is a fuzzy tag condition.
+Its results must not be described as a strict exact-tag AND: a result may match a partial, alias, or translated tag
+without visibly listing the supplied complete label. `title-caption` and App-only `tag-title-caption` have no documented boolean-tag contract. No
+escape syntax for a literal uppercase `OR` tag/keyword is verified, so use exact tags without that token when a
+strict query is required.
 
 `novel search` is App-only. Its App request supports keyword target, date order, and duration; rating, text-length,
 and original-only conditions are verified against stable fields in every returned batch. Missing those fields is a
@@ -422,6 +445,17 @@ idempotent App JSON reads, a first 429 with a valid `Retry-After` waits and retr
 invalid/missing headers, a second 429, writes, and resource downloads are never replayed.
 `detail --json` preserves Pixiv's raw HTML `caption`; ordinary `detail` output renders it as safe plain text and
 never includes captions in artwork list output.
+
+`detail` accepts a positive artwork ID or a canonical HTTPS `pixiv.net`/`www.pixiv.net` artwork URL in the form
+`/artworks/{id}` (an optional locale segment, query, and fragment are allowed). It does not accept user, novel,
+short-link, FANBOX, Pixivision, Sketch, legacy, or arbitrary URLs.
+
+`download` accepts the same artwork references plus `/users/{id}` and `/users/{id}/artworks` URLs. A user URL follows
+all pagination for `illust`, `manga`, and `ugoira`, but never novels, and requires App OAuth; it has no anonymous Web
+fallback. URL parsing is local only: it does not fetch HTML or follow redirects. Downloads continue after individual
+artwork failures and report every outcome; cancellation stops immediately. `download --json` emits
+`{"items":[...],"failures":[...]}`. Each successful item contains its canonical artwork `url`, ID, type, and local
+file paths/pages; any failure makes the command exit non-zero. No download history or cross-run deduplication is kept.
 
 ### Common flags
 
@@ -478,8 +512,8 @@ Differences in the anonymous fallback:
 
 - Anonymous `search` only applies filters that Web API can express reliably. Resolution, aspect ratio, drawing
   tool, and content type are translated to Web parameters; AI filtering uses returned artwork fields.
-- `rating=r18`, `r18g`, or `mature` fails before an anonymous request with an authentication requirement rather
-  than pretending the result is empty. `rating=all` means only content visible anonymously.
+- `rating=r18`, `r18g`, `mature`, `--search-by tag-title-caption`, or bookmark-count bounds fail before an anonymous
+  request with an authentication requirement rather than pretending the result is empty. `rating=all` means only content visible anonymously.
 - `search-options` is App-only and explicitly unsupported without a refresh token. Search does not read or store
   browser cookies such as `PHPSESSID`, and never converts a refresh token into a Web session.
 - `novel search` is App-only and returns an authentication requirement without a refresh token.
@@ -532,6 +566,14 @@ to `--prerelease`; if the switch install fails, it explicitly attempts to restor
 both the original error and the recovery result. `go install` uses the exact Release tag; Release binaries verify
 the Ed25519-signed checksum manifest and the archive SHA-256 before downloading, then preflight
 `pixiv version --json` and atomically replace the executable.
+
+Unless an explicit `--proxy`, configured `https_proxy`, or `HTTPS_PROXY` is in effect, Release-binary updates probe
+the embedded source list concurrently. API-capable candidates are used for the GitHub Releases API; archive-capable
+candidates are used for the signed manifest, checksum, and platform archive. The first valid response becomes the
+preferred route, and an asset download may silently try each remaining declared route once; if all fail, the reported
+error names every failed route. Candidates never alter canonical Release URLs, SemVer selection, Ed25519 verification,
+or SHA-256 verification. The automatic notification uses only API-capable candidates and retains its existing shared
+three-second limit and 24-hour cache.
 
 Update checks only select canonical SemVer tags. Stable checks first exclude GitHub Releases marked as prerelease;
 `--prerelease` includes them in the current channel. If any non-draft published Release in that channel uses a

--- a/docs/en/mcp-tools.md
+++ b/docs/en/mcp-tools.md
@@ -9,8 +9,9 @@ retention 7 days); the terminal stays free of log traces by default. MCP exposes
 With a refresh token, App API is the primary path and failures never fall back to Web automatically. Without a
 token and with `web_fallback_enabled=true`, only allowlisted anonymous read tools may use Web API. SDK-based user
 detail/list and bookmark/follow write tools return text plus structured output; classified failures set
-`isError=true`. Text-form MCP tool failures retain their documented Content, structured output, text, and
-`isError=false` wire behavior, while the file log records an error-level operation event with `result=error`. Events contain only
+`isError=true`. Query tools likewise keep a compact text summary and return typed structured content; their failures
+set `isError=true`. Legacy session/auth tool failures retain their documented `isError=false` wire behavior, while the
+file log records an error-level operation event with `result=error`. Events contain only
 the operation, stable SDK classification, backend/status, and safe IDs; they never include raw errors, inputs,
 queries, tokens, cookies, URLs, paths, or response bodies. Unknown public SDK codes are omitted and unknown
 backends normalize to `local`. A normal empty result remains a success.
@@ -32,7 +33,7 @@ SDK cursors never appear in MCP input or output. List tools use the logical `pag
 | `set_download_path` | `path` | Text status. |
 | `refresh_token` | none | Current authenticated-account summary. |
 | `set_refresh_token` | raw App API `refresh_token` | Current-session authentication result; does not write `auth.json`; rejects cookies. |
-| `download` | `illust_id` or `illust_ids`, optional `pages`/`quality`; `delivery` is `local_path` only | Local file path/file_uri/mime_type/page/size; never embeds image bytes. |
+| `download` | `illust_id`, `illust_ids`, and/or `urls`; optional `pages`/`quality`; `delivery` is `local_path` only | `{items, failures, files, text}` with canonical artwork URLs and local file metadata; never embeds image bytes. |
 | `download_random_from_recommendation` | optional `count` (omitted/`null` defaults to 5; explicit value must be 1..20), optional `pages`/`quality`; `delivery` is `local_path` only | Text plus structured local file metadata; never embeds image bytes. |
 
 `refresh_token` does not misreport SDK/config/proxy initialization failures as a missing token. Context cancellation
@@ -48,25 +49,32 @@ When the MCP server is started with an HTTP(S) proxy, its media-resource downloa
 API, OAuth, and Web metadata requests retain normal protocol negotiation; this avoids proxy-specific HTTP/2 stream
 resets without changing authentication or selected download quality.
 
+`download.urls` accepts only local-parsed HTTPS `pixiv.net`/`www.pixiv.net` artwork URLs (`/artworks/{id}`, optional
+locale/query/fragment) and user URLs (`/users/{id}` or `/users/{id}/artworks`). Artwork URLs behave like IDs. A user
+URL follows all `illust`, `manga`, and `ugoira` pages, excludes novels, and requires App OAuth; it never falls back to
+anonymous Web access. It does not fetch HTML or follow redirects. Partial artwork failures remain in `failures` while
+other works continue; a partial report has `isError=true`. `illust_id`/`illust_ids` retain their legacy input order,
+then `urls` follow their array order; MCP cannot represent interleaving across these separate fields.
+
 Both download tools return valid structured output on validation, SDK, recommendation, download, result-building,
 or file-read failure: `delivery` retains the normalized mode (`local_path` when IDs/delivery are invalid), and
-`items`/`files` are empty arrays rather than `null`. These failures return `isError=false` and the original safe
-business error text.
+`items`, `failures`, and `files` are empty arrays rather than `null`. Validation and all-or-nothing failures retain
+the safe business-error text; `download` partial failures set `isError=true`.
 
 ## Work and user reads
 
 | Tool | Input | Structured output |
 | --- | --- | --- |
-| `search_illust` | `word`, `search_target`, `sort`, `duration`, `page`, `limit`, `rating`, `content_type`, `ai_mode`, `aspect_ratio`, `resolution`, `tool` | `{text}`; works remain in text. |
+| `search_illust` | `word`, `search_target`, `sort`, `duration`, `start_date`, `end_date`, `page`, `limit`, `rating`, `content_type`, `ai_mode`, `aspect_ratio`, `resolution`, `tool`, `bookmark_min`, `bookmark_max` | `{items, pagination, text}`. |
 | `search_novel` | `word`, `search_target`, `sort`, `duration`, `page`, `limit`, `rating`, `min_text_length`, `max_text_length`, `original_only` | App-only `{novels, pagination, text}`. A classified failure has `isError=true`. |
 | `search_illust_options` | required `word` | `{tools,text}` for the word; authenticated App only. |
-| `illust_detail` | `illust_id` | Work detail, including raw HTML `caption` when Pixiv provides it. |
-| `illust_related` | `illust_id`, `page`, `limit` | Related works. |
-| `illust_ranking` | `mode`, `date`, `page`, `limit` | Ranked works. |
-| `illust_recommended` | `page`, `limit` | Illustration recommendation text through the public SDK path. |
+| `illust_detail` | exactly one of `illust_id` or `url` | `{illust, text}`; the complete work detail includes raw HTML `caption` when Pixiv provides it. |
+| `illust_related` | `illust_id`, `page`, `limit` | `{items, pagination, text}`. |
+| `illust_ranking` | `mode`, `date`, `page`, `limit` | `{items, pagination, text}`. |
+| `illust_recommended` | `page`, `limit` | `{items, pagination, text}` through the public SDK path. |
 | `recommended` | required `kind` (`all`, `illust`, `manga`, `novel`, `user`), optional `page`, `limit` | `{kind, illusts, manga, novels, user_previews, pagination}`; `all` reads four authenticated streams in order. |
-| `trending_tags_illust` | none | Trending tags. |
-| `illust_follow` | `restrict`, `page`, `limit` | Followed works; authentication required. |
+| `trending_tags_illust` | none | `{tags, text}`. |
+| `illust_follow` | `restrict`, `page`, `limit` | `{items, pagination, text}`; authentication required. |
 | `search_user` | `word`, `page`, `limit` | `{source, user_previews, pagination, text}`. `source` is `app_search` for official authenticated App search or `related_illust_authors` for anonymous fallback; the latter is not a username search. |
 | `user_detail` | required `user_id` | Stable `{user, profile, profile_publicity, workspace}`; authenticated App only. |
 | `user_artworks` | optional `user_id`, `type`, `page`, `limit` | `{user_id, items, pagination}`; omitted UID uses the authenticated user. |
@@ -81,11 +89,22 @@ business error text.
 - `aspect_ratio`: `all|landscape|portrait|square`;
 - `resolution`: `all|high|medium|low`, with both dimensions respectively `>=3000`, `1000..2999`, or `<=999`;
 - `tool`: exact upstream drawing-tool value, without fuzzy matching.
+- `search_target`: `partial_match_for_tags|exact_match_for_tags|title_and_caption|keyword`; `keyword` searches tags, titles, and captions and requires App OAuth.
+- `duration`: `within_last_day|within_last_week|within_last_month|within_half_year|within_year`; it cannot be combined with date bounds. The two long values are expanded locally into an inclusive Tokyo date range.
+- `start_date` / `end_date`: inclusive `YYYY-MM-DD` bounds. Either is allowed, but a supplied start cannot be later than end.
+- `bookmark_min` / `bookmark_max`: inclusive non-negative public bookmark-count bounds; the minimum cannot exceed the maximum and both require App OAuth.
 
 With a refresh token, App performs resolution, aspect ratio, tool, content type, and AI exclusion filtering;
 rating and AI-only filtering use public SDK normalized App fields. App failures never fall back to Web. Anonymous
-Web applies only verified filters; `r18|r18g|mature` fails before the request with an authentication requirement.
-`search_illust_options` is App-only. None of the search tools accepts cookies or bookmark-count filters.
+Web applies only verified filters; `r18|r18g|mature`, `search_target=keyword`, and bookmark-count bounds fail before
+the request with an authentication requirement.
+
+For authenticated `search_illust`, tag `search_target` values preserve the verified Pixiv App query grammar in
+`word`: with `exact_match_for_tags`, `tagA tagB` requires both complete tags and uppercase `tagA OR tagB` accepts
+either one. Literal `AND` is not an operator. `partial_match_for_tags` also accepts the tested uppercase `OR`, but
+uses fuzzy tag terms and must not be treated as strict exact-tag AND. `title_and_caption` and `keyword` have no boolean-tag
+contract. No escape syntax for a literal uppercase `OR` tag/keyword is verified.
+`search_illust_options` is App-only. None of the search tools accepts cookies.
 
 `search_novel.rating` uses `all|sfw|r18|r18g|mature`. `min_text_length` and `max_text_length` are non-negative
 character bounds where `0` disables the corresponding bound; a non-zero maximum below the minimum fails validation.

--- a/docs/en/sdk.md
+++ b/docs/en/sdk.md
@@ -70,6 +70,17 @@ expose a like-count field; bookmark totals must not be labeled as likes.
 `DownloadQuality` (`original|regular|small|thumb|mini`); ugoira rejects page selection
 or non-original quality as unsupported.
 
+### Local Pixiv references
+
+`ParseReference(raw)` performs no I/O and accepts either a positive artwork ID or a
+strict official Pixiv HTTPS URL. It returns `Reference{Kind, ID}`, where `Kind` is
+`artwork` for an ID or `/artworks/{id}`, and `user` for `/users/{id}` or
+`/users/{id}/artworks`. The URL host must be `pixiv.net` or `www.pixiv.net`; an
+optional locale, query, and fragment are allowed. `ParseArtworkReference(raw)` is the
+artwork-only variant, and `Reference.URL()` returns the canonical artwork or user page
+URL. The parser neither follows redirects nor fetches HTML, rejects all other Pixiv
+properties and URL forms, and its validation errors do not reproduce the supplied URL.
+
 SDK user IDs such as `UserArtworksRequest.UserID` are required. Omitting a UID to mean “the current user” is a
 CLI/MCP adapter feature; Go callers should call `CurrentUserID(ctx)` and then build the request.
 
@@ -134,10 +145,15 @@ manage their own PKCE and state. Use `StartLogin` when the SDK should manage the
 | `AspectRatio` | `all`, `landscape`, `portrait`, `square` |
 | `Resolution` | `all`, `high`, `medium`, `low`; both dimensions must respectively be `>=3000`, `1000..2999`, or `<=999` |
 | `Tool` | Exact upstream drawing-tool value; no fuzzy matching |
+| `BookmarkMin` / `BookmarkMax` | Optional inclusive non-negative public bookmark-count bounds; `Min` cannot exceed `Max` |
 
 Zero enum values normalize to `all`; `Tool` is trimmed. Unknown values return `invalid_argument` before any
-upstream request. The authenticated adapter maps resolution, aspect ratio, tool, content type, and AI exclusion to
-App server parameters. Rating and AI-only filtering use normalized fields from the current App batch.
+upstream request. `SearchIllustRequest.Target` also accepts `keyword` for tags, titles, and captions; `Duration`
+accepts `within_last_day|within_last_week|within_last_month`; `StartDate` and `EndDate`
+are optional inclusive `YYYY-MM-DD` bounds. A date range cannot be combined with `Duration`, and a supplied start
+cannot be later than end. The authenticated adapter maps resolution, aspect ratio, tool, content type, AI exclusion,
+date bounds, and bookmark bounds to App server parameters. Rating and AI-only filtering use normalized fields from
+the current App batch.
 `Illust.Tools []string` preserves upstream order and values and is unrelated to bookmark-count filtering.
 
 `SearchIllustOptions(ctx, SearchIllustOptionsRequest{Word: word})` requires a non-empty word and App
@@ -185,7 +201,7 @@ _ = next
 ```
 
 Cursors are versioned and bound to the operation and complete normalized query. An illustration-search cursor also
-binds `Rating`, `ContentType`, `AIMode`, `AspectRatio`, `Resolution`, and `Tool`; a novel-search cursor binds its
+binds target, duration, date bounds, `Rating`, `ContentType`, `AIMode`, `AspectRatio`, `Resolution`, `Tool`, and bookmark bounds; a novel-search cursor binds its
 target, sort, duration, rating, text-length bounds, and original-only condition. Changing a filter and reusing the
 old cursor returns `invalid_argument`. Never parse, edit, reuse across requests, or replace a cursor with an upstream
 offset/page. The SDK does not accept `page`; CLI/MCP translate logical pages and limits at their boundaries.
@@ -195,8 +211,8 @@ offset/page. The SDK does not accept `page`; CLI/MCP translate logical pages and
 With a refresh token, illustration search uses only App API. Authentication, network, and server failures never
 fall back to Web automatically. Without a token, `NewClient` can use the anonymous Web allowlist when
 `WebFallbackEnabled=true`; `OpenDefault` reads local `web_fallback_enabled` for each snapshot. Anonymous search
-uses only filters Web can express reliably. `r18`, `r18g`, and `mature` fail with `unauthorized` before networking;
-they are never disguised as empty results. Anonymous `SearchIllustOptions` returns `unsupported`. The SDK never
+uses only filters Web can express reliably. `r18`, `r18g`, `mature`, `Target=keyword`, and bookmark bounds fail
+with `unauthorized` before networking; they are never disguised as empty results. Anonymous `SearchIllustOptions` returns `unsupported`. The SDK never
 reads/injects cookies or converts a refresh token into a Web session.
 
 `SearchNovel` requires App authentication and never falls back to Web. `SearchUser` uses App search when

--- a/docs/ja/cli-reference.md
+++ b/docs/ja/cli-reference.md
@@ -26,7 +26,7 @@ fallback、更新を扱います。SDK と MCP の詳細は重複させず、[�
 
 ```bash
 # Linux/macOS
-curl -fsSLo /tmp/pixiv-install.sh https://raw.githubusercontent.com/FlanChanXwO/pixiv-cli/main/scripts/install.sh
+curl -fsSLo /tmp/pixiv-install.sh https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/install.sh
 sh /tmp/pixiv-install.sh --add-to-path
 ```
 
@@ -52,6 +52,8 @@ Linux Release asset は glibc 2.35 以降を必要とします。release、nativ
 初回 bootstrap の script には Ed25519 verifier を埋め込めません。SHA-256 は破損・取り違えを検出しますが、
 真正性は HTTPS と公式 GitHub repository/Release account に依存します。実行前に script を確認してください。
 導入後の `pixiv update` は binary に埋め込まれた Ed25519 trust root を使用します。
+
+正式版の installer には静的な Release-source list が埋め込まれます。権威ある `checksums.txt` は常に GitHub HTTPS から直接取得し、無料候補は対応する platform archive の probe にだけ使用します。候補の checksum は直取得した内容と byte 単位で一致する必要があり、install 前にも archive の SHA-256 を検証します。list を remote から取得することはなく、署名済み Release とともにだけ更新されます。
 
 ### source から build
 
@@ -258,7 +260,7 @@ option は positional argument の前後どちらでも指定できます。
 | `search` | `pixiv search [options] WORD` | イラストを検索します。 |
 | `novel search` | `pixiv novel search [options] WORD` | 認証済み App API で小説を検索します。 |
 | `search-options` | `pixiv search-options [options] WORD` | keyword に対する App API 制作ツール候補を表示します。認証が必要です。 |
-| `detail` | `pixiv detail [options] ILLUST_ID` | 作品詳細を表示します。 |
+| `detail` | `pixiv detail [options] ILLUST_ID_OR_URL` | 作品 ID または対応 Pixiv 作品 URL の詳細を表示します。 |
 | `ranking` | `pixiv ranking [options]` | イラストランキングを表示します。 |
 | `recommended` | `pixiv recommended all\|illust\|manga\|novel\|user [--page N --limit N --json]` | 指定 kind の認証済みおすすめを表示します。`all` は 4 種類を順に返します。 |
 | `user search` | `pixiv user search WORD [--page N --limit N --json]` | ユーザーを検索します。JSON/text は公式 App 検索か匿名の関連作品作者 fallback かを示します。 |
@@ -270,7 +272,7 @@ option は positional argument の前後どちらでも指定できます。
 | `bookmark remove` | `pixiv bookmark remove ILLUST_ID` | bookmark を削除します。visibility/tag flag はありません。 |
 | `follow add` | `pixiv follow add USER_ID [--restrict public\|private]` | 指定 visibility で follow します。 |
 | `follow remove` | `pixiv follow remove USER_ID` | unfollow します。visibility flag はありません。 |
-| `download` | `pixiv download [options] ILLUST_ID...` | 1 件以上の作品を download します。token なしでは既定で匿名 Web fallback を使います。 |
+| `download` | `pixiv download [options] TARGET...` | 作品 ID/URL、または対応 user URL の全 visual works を download します。 |
 | `mcp` | `pixiv mcp [--proxy URL\|--no-proxy]` | MCP stdio server を起動します。 |
 
 download filename は template と URL 由来 extension の cross-platform 不正文字を正規化します。ASCII control
@@ -292,15 +294,19 @@ allowlist、MIME 推測、暗黙置換は行いません。
 
 | Command | Flag | Default | 説明 |
 | --- | --- | --- | --- |
-| `search`、`novel search` | `--search-by` | `tag-partial` | 検索フィールド: `tag-partial`、`tag-exact`、`title-caption`。 |
+| `search` | `--search-by` | `tag-partial` | 検索フィールド: `tag-partial`、`tag-exact`、`title-caption`、または App OAuth 専用の `tag-title-caption`（タグ、タイトル、キャプション）。 |
+| `novel search` | `--search-by` | `tag-partial` | 検索フィールド: `tag-partial`、`tag-exact`、`title-caption`。 |
 | `search`、`novel search` | `--sort` | `date_desc` | sort order: `date_desc` または `date_asc`。 |
-| `search`、`novel search` | `--period` | empty | time range: `day`、`week`、`month`。省略時は期間指定なし。 |
+| `search` | `--period` | empty | quick time range: `day`、`week`、`month`、`half-year`、`year`。省略時は期間指定なし。`--start-date` / `--end-date` と併用不可。 |
+| `novel search` | `--period` | empty | time range: `day`、`week`、`month`。省略時は期間指定なし。 |
+| `search` | `--start-date` / `--end-date` | empty | 包含境界の `YYYY-MM-DD` date。どちらか一方でも指定でき、両方ある場合 start は end より後にできません。`--period` と併用不可。 |
 | `search`、`novel search` | `--rating` | `all` | `sfw`, `r18`, `r18g`, `mature`, `all`。 |
 | `search` | `--type` | `all` | `all`, `illust-and-ugoira`, `illust`, `manga`, `ugoira`。 |
 | `search` | `--ai-mode` | `all` | `all`, `exclude`, `only`。Pixiv `AIType==2` が AI 生成です。 |
 | `search` | `--aspect-ratio` | `all` | `all`, `landscape`, `portrait`, `square`。 |
 | `search` | `--resolution` | `all` | `all`, `high`, `medium`, `low`。両辺がそれぞれ `>=3000`, `1000..2999`, `<=999`。 |
 | `search` | `--draw-tool` | empty | upstream の正確な制作ツール名。認証済み `search-options` で取得します。 |
+| `search` | `--bookmark-min` / `--bookmark-max` | empty | 包含境界の非負 public bookmark 数。App OAuth が必要で、`min` は `max` を超えられません。 |
 | `novel search` | `--min-text-length` | `0` | 本文の最小文字数。`0` は下限を無効にします。 |
 | `novel search` | `--max-text-length` | `0` | 本文の最大文字数。`0` は上限を無効にし、非ゼロの下限より小さくできません。 |
 | `novel search` | `--original-only` | `false` | Pixiv がオリジナルと表示した小説だけを残します。 |
@@ -320,16 +326,29 @@ allowlist、MIME 推測、暗黙置換は行いません。
 | `bookmark add` | `--restrict` | `public` | 新規 bookmark visibility。 |
 | `bookmark add` | `--tag` | empty | 反復可能な bookmark tag。 |
 | `follow add` | `--restrict` | `public` | 新規 follow visibility。 |
-| `detail` | `ILLUST_ID` | required | Pixiv artwork ID。 |
-| `download` | `ILLUST_ID...` | required | 1 件以上の artwork ID。 |
+| `detail` | `ILLUST_ID_OR_URL` | required | 正の artwork ID または対応 Pixiv artwork URL。 |
+| `download` | `TARGET...` | required | artwork ID、artwork URL、または対応 user profile/artworks URL。 |
 
 refresh token がある `search` は常に App API を使います。App は解像度、縦横比、tool、content type、
 `ai-mode=exclude` を処理し、rating と `ai-mode=only` は App result batch ごとに適用されます。App failure は
 Web に fallback しません。filter は opaque cursor に binding され、別条件へ再利用できません。ローカル filter が
 連続 empty upstream batch を飛ばす場合、CLI/MCP は最初の非 empty 論理 batch か upstream 終端まで続けます。
 正数 `--limit`/`--page` は filter 後の論理結果を跨 batch で埋め、`--limit 0` は全件走査、`--limit` なしでも
-先頭 empty batch は skip します。bookmark-count filter も like-count フィールドもありません。作品 JSON/text は
+先頭 empty batch は skip します。App は明示 date と bookmark-count の境界も処理します。bookmark count は like-count
+フィールドではなく、like と表記してはいけません。作品 JSON/text は
 `https://www.pixiv.net/artworks/{id}` を先頭フィールド/先頭行として含めます。
+
+### イラストタグ検索の構文
+
+認証済み App API で、イラスト `search` がタグ mode を選んだ場合に検証済みです。boolean tag filter には
+`tag-exact` を使用します。`tagA tagB` は両方の完全な tag が必要な AND、`tagA OR tagB` はどちらかの完全な
+tag でよい OR です。`OR` は大文字で指定します。文字列 `AND` は検証済みの演算子ではないため、二つの tag は
+空白で区切ります。
+
+既定の `tag-partial` も検証済みの大文字 `OR` 構文を受け付けますが、各語は曖昧な tag 条件です。結果を厳密な
+exact-tag AND と説明してはいけません。部分 tag、alias、翻訳 tag に一致し、入力した完全な label が表示されない
+場合があります。`title-caption` と App OAuth 専用の `tag-title-caption` には boolean tag の契約がありません。大文字の literal `OR` tag/keyword を
+escape する構文は未検証なので、厳密な query ではその token を避けて exact tag を使用してください。
 
 `novel search` は App 専用です。App request が表すのは keyword target、日付順、期間だけで、rating、本文長、
 original-only は各 batch の安定した response field で検証されます。必須 field がなければ無言の非一致ではなく
@@ -339,6 +358,10 @@ typed upstream-response failure になります。filter が batch を飛ばす�
 
 認証済みの `detail`、pages、ugoira metadata は App API のみを使います。App のページ数不一致またはページ資源不足は明示的に失敗し、匿名 Web request は行いません。認証済み ugoira は original ZIP が得られないとき、検証済み App medium ZIP を直接 download します。冪等 App JSON read だけは、最初の 429 に有効な `Retry-After` がある場合に command context 配下で一度だけ待機・再試行します。header 不正/欠落、二度目の 429、write、resource download は replay しません。
 `detail --json` は Pixiv の raw HTML `caption` を保持し、通常の `detail` 出力は安全な plain text に変換します。作品 list output には caption を含めません。
+
+`detail` は正の artwork ID、または HTTPS の `pixiv.net`/`www.pixiv.net` にある `/artworks/{id}` URL を受け付けます。locale、query、fragment は許可されます。user、novel、short-link、FANBOX、Pixivision、Sketch、legacy、そのほかの URL は受け付けません。
+
+`download` はこれに加えて `/users/{id}` と `/users/{id}/artworks` を受け付けます。user URL は `illust`、`manga`、`ugoira` を全 page にわたり download し、novel は対象外です。App OAuth が必須で、匿名 Web fallback は使いません。URL はローカルでのみ parse され、HTML 取得や redirect follow は行いません。1 件の失敗後も他の作品を続行し、cancel は直ちに停止します。`download --json` は `{"items":[...],"failures":[...]}` を出力し、成功 item は canonical artwork `url`、ID、type、local file path/page を含みます。失敗が 1 件でもあれば非ゼロ終了です。download history や cross-run deduplication はありません。
 
 ### 共通 flag
 
@@ -387,7 +410,7 @@ token source がなく `web_fallback_enabled=true` の場合、CLI の `search`�
 server error を自動 fallback しません。
 
 - 匿名 `search` は Web が確実に表現できる filter だけを使用します。AI は返却 field で判定します。
-- `rating=r18|r18g|mature` は request 前に認証要求として失敗し、空結果に見せません。`all` は匿名で見える範囲です。
+- `rating=r18|r18g|mature`、`--search-by tag-title-caption`、または bookmark-count filter は request 前に認証要求として失敗し、空結果に見せません。`all` は匿名で見える範囲です。
 - `search-options` は App 専用です。Cookie を読み取らず、refresh token を Web session に変換しません。
 - `novel search` は App 専用で、refresh token がなければ認証要求として失敗します。
 - 拡張 ranking mode（`day_manga`、`week_manga`、`month_manga`、`week_rookie_manga`、`day_r18`、
@@ -420,6 +443,8 @@ development build は `dev` と表示し self-update を拒否します。公式
 `go install`、Release binary を検出します。Homebrew channel 切替失敗時は元 formula の復元を明示的に試み、
 両方の結果を報告します。`go install` は正確な Release tag、Release binary は Ed25519 署名 checksum manifest
 と archive SHA-256 を検証し、`pixiv version --json` preflight 後に atomic replace します。
+
+明示的な `--proxy`、設定済み `https_proxy`、または `HTTPS_PROXY` がない場合、Release binary update は内蔵 source list を並行 probe します。API 対応候補は GitHub Releases API に、archive 対応候補は署名 manifest、checksum、platform archive に使用されます。最初の有効 response が優先 route となり、asset download が失敗すると残る宣言済み route を各一回だけ静かに試します。全て失敗した場合だけ error に各 route を表示します。候補は canonical Release URL、SemVer 選択、Ed25519 verification、SHA-256 verification を変更しません。自動 update notification は API 対応候補だけを使い、既存の 3 秒総制限と 24 時間 cache を維持します。
 
 update check は canonical SemVer tag だけを選びます。対象 channel に non-SemVer published Release があれば、
 古い version へ暗黙に戻らず fail closed します。private key は保護された `release` Environment と管理された

--- a/docs/maintainers/adr/0008-ed25519-signed-multi-channel-release-trust.md
+++ b/docs/maintainers/adr/0008-ed25519-signed-multi-channel-release-trust.md
@@ -16,7 +16,8 @@ repository secret，或复用同一 SSH key，会让任意 tag/workflow 或公�
 
 ## Decision
 
-- GitHub Releases API 是更新查询的唯一后端。draft 不可选；自动检查只选 stable，显式
+- GitHub Releases API 是更新查询的唯一规范后端。内置公共源只能改写传输 URL，不能改写 API
+  路径、分页、缓存 URL、Release 身份或版本选择；draft 不可选；自动检查只选 stable，显式
   `--prerelease` 才可选择预发布版本。
 - 当前受信发布入口只有 `.github/workflows/release.yml` 的 tag push 与必填 `release_tag` 的
   `workflow_dispatch`，两者共用 `RELEASE_TAG`；validate、test build 与 production build 均以该值执行
@@ -30,7 +31,9 @@ repository secret，或复用同一 SSH key，会让任意 tag/workflow 或公�
   更不能把网络、HTTP、cache、签名或安装失败解释成“无更新”。
 - 每个正式 Release 使用固定六目标 asset 名，发布 `checksums.txt` 以及对其原始 bytes 签名、含 key
   ID 的 Ed25519 `checksums.json`。Release installer 先验证签名和 SHA-256，再解包、版本预检并原子
-  替换。
+  替换。版本化公共源列表随 Release installer asset 生成并进入同一份 checksum/signature 集合；它只允许
+  在无显式 HTTP(S) proxy 时选择更快的传输路径。installer bootstrap 仍直连取得权威 `checksums.txt`，
+  公共源下载的平台 archive 必须匹配该值。
 - Release binary 只信任随受支持 binary 提交的 Ed25519 public key/key ID。私钥只允许存在于受保护
   `release` Environment secret；恢复副本只可存在于受控 macOS Keychain。私钥不能进入 CLI、源码、
   GitHub Release、formula、日志或测试 fixture。

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -549,6 +549,13 @@ workflow artifact 读取、生成或记录 deploy key。
 当前 Release 不会进行 Apple notarization 或 Windows Authenticode。直接下载仍可能被 Gatekeeper
 或 SmartScreen 拦截/提示；这是需要在用户文档中保留的系统信誉边界，不能通过文档或脚本绕过。
 
+已公开的 GitHub Release 还会触发 `.github/workflows/publish-skillhub.yml`。该工作流只 checkout
+不可变 release tag，并确认该 tag 属于默认分支、对应 GitHub Release 已公开且版本满足 SemVer 后，才对
+`skills/pixiv-cli/` 运行 SkillHub CLI 的 dry-run 和提交。`SKILLHUB_TOKEN` 仅进入最后的提交步骤，CLI
+必须返回 `skillId` 和审核状态；这证明 SkillHub 已接收提交，但平台审核完成前公开详情页可能仍不可见。
+若该独立发布失败，可通过同一 workflow 的 `workflow_dispatch` 输入既有发布 tag 恢复，不能用 main 的
+后续内容替代该 tag。
+
 ## Git 与本地产物
 
 `.gitignore` 已排除：

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -24,7 +24,7 @@ SDK 与 MCP 细节不在此重复，入口见[相关文档](#相关文档)。
 
 ```bash
 # Linux/macOS
-curl -fsSLo /tmp/pixiv-install.sh https://raw.githubusercontent.com/FlanChanXwO/pixiv-cli/main/scripts/install.sh
+curl -fsSLo /tmp/pixiv-install.sh https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/install.sh
 sh /tmp/pixiv-install.sh --add-to-path
 ```
 
@@ -48,6 +48,8 @@ binary 预检会在替换现有安装前显露 loader 失败。
 这是首次 bootstrap 的信任边界：`pixiv` 尚不存在时，脚本没有内置 Ed25519 verifier。SHA-256 校验可以
 发现传输损坏或 archive 不匹配，但来源真实性仍依赖 HTTPS 与官方 GitHub repository/Release 账号；执行前
 应审阅安装脚本。安装完成后，后续 `pixiv update` 会使用 binary 内置的 Ed25519 trust root 验证 Release 更新。
+
+随正式版本发布的安装器内嵌静态 Release-source 列表。它始终从 GitHub HTTPS 直连获取权威 `checksums.txt`，再仅对匹配的平台 archive 探测免费候选；候选返回的 checksum 必须与直连文件逐字一致。安装前 archive 仍必须匹配该直连 SHA-256。列表不会从远端拉取，只会随签名 Release 更新。
 
 ### 从源码构建
 
@@ -264,7 +266,7 @@ CLI 使用 Cobra/pflag，选项可以写在位置参数前后，例如 `pixiv au
 | `search` | `pixiv search [options] WORD` | 搜索插画。 |
 | `novel search` | `pixiv novel search [options] WORD` | 通过认证 App API 搜索小说。 |
 | `search-options` | `pixiv search-options [options] WORD` | 查询该关键词在 App API 中可用的绘图工具；需要认证，支持通用账号/token/代理参数和 `--json`。 |
-| `detail` | `pixiv detail [options] ILLUST_ID` | 查看单个作品详情。 |
+| `detail` | `pixiv detail [options] ILLUST_ID_OR_URL` | 查看单个作品 ID 或受支持 Pixiv 作品 URL 的详情。 |
 | `ranking` | `pixiv ranking [options]` | 查看 Pixiv 插画排行榜。 |
 | `recommended` | `pixiv recommended all\|illust\|manga\|novel\|user [--page N --limit N --json]` | 查看指定类个性化推荐；`all` 按插画、漫画、小说、作者顺序完整返回，需要认证。 |
 | `user search` | `pixiv user search WORD [--page N --limit N --json]` | 搜索用户；JSON 和文本会标明结果来自官方 App 用户搜索，还是匿名“相关插画作者”fallback。 |
@@ -276,7 +278,7 @@ CLI 使用 Cobra/pflag，选项可以写在位置参数前后，例如 `pixiv au
 | `bookmark remove` | `pixiv bookmark remove ILLUST_ID` | 取消收藏作品；不接受可见性或 tag 参数。 |
 | `follow add` | `pixiv follow add USER_ID [--restrict public\|private]` | 按选定可见性关注用户。 |
 | `follow remove` | `pixiv follow remove USER_ID` | 取消关注用户；不接受可见性参数。 |
-| `download` | `pixiv download [options] ILLUST_ID...` | 下载一个或多个作品；无 token 时默认走匿名 web fallback。 |
+| `download` | `pixiv download [options] TARGET...` | 下载作品 ID/URL，或从受支持的用户 URL 下载全部视觉作品。 |
 | `mcp` | `pixiv mcp [--proxy URL\|--no-proxy]` | 启动 MCP stdio server；代理覆盖只在本次启动时生效。 |
 
 下载文件名会规范化文件名模板以及 URL 推导扩展名中的跨平台非法字符；扩展名还会替换 ASCII 控制字符并移除 Windows 不接受的尾随点或空格。扩展名仍来自上游 URL，不使用 allowlist、MIME 猜测或静默替代。
@@ -296,15 +298,19 @@ CLI 使用 Cobra/pflag，选项可以写在位置参数前后，例如 `pixiv au
 
 | 命令 | 参数 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `search`、`novel search` | `--search-by` | `tag-partial` | 搜索字段：`tag-partial`、`tag-exact` 或 `title-caption`。 |
+| `search` | `--search-by` | `tag-partial` | 搜索字段：`tag-partial`、`tag-exact`、`title-caption`，或仅 App OAuth 可用的 `tag-title-caption`（标签、标题、说明文字）。 |
+| `novel search` | `--search-by` | `tag-partial` | 搜索字段：`tag-partial`、`tag-exact` 或 `title-caption`。 |
 | `search`、`novel search` | `--sort` | `date_desc` | 排序方式：`date_desc` 或 `date_asc`。 |
-| `search`、`novel search` | `--period` | 空 | 时间范围：`day`、`week` 或 `month`；省略则不限制时间。 |
+| `search` | `--period` | 空 | 快捷时间范围：`day`、`week`、`month`、`half-year` 或 `year`；省略则不限制时间。不能和 `--start-date`、`--end-date` 同用。 |
+| `novel search` | `--period` | 空 | 时间范围：`day`、`week` 或 `month`；省略则不限制时间。 |
+| `search` | `--start-date` / `--end-date` | 空 | 包含边界的 `YYYY-MM-DD` 日期；可只给一端，两端都给时起始不得晚于结束；不能和 `--period` 同用。 |
 | `search`、`novel search` | `--rating` | `all` | 分级筛选：`sfw`、`r18`、`r18g`、`mature` 或 `all`。 |
 | `search` | `--type` | `all` | 作品类型：`all`、`illust-and-ugoira`、`illust`、`manga` 或 `ugoira`。 |
 | `search` | `--ai-mode` | `all` | AI 筛选：`all`、`exclude` 或 `only`；Pixiv `AIType==2` 表示 AI 生成。 |
 | `search` | `--aspect-ratio` | `all` | 横纵比：`all`、`landscape`、`portrait` 或 `square`。 |
 | `search` | `--resolution` | `all` | 分辨率：`all`、`high`、`medium` 或 `low`；宽高两个维度分别都需满足 `>=3000`、`1000..2999` 或 `<=999`。 |
 | `search` | `--draw-tool` | 空 | 上游绘图工具的精确名称；用已认证的 `search-options` 查询当前值。 |
+| `search` | `--bookmark-min` / `--bookmark-max` | 空 | 包含边界的非负公开收藏数；需要 App OAuth，且最小值不能大于最大值。 |
 | `novel search` | `--min-text-length` | `0` | 正文最少字符数；`0` 关闭下界。 |
 | `novel search` | `--max-text-length` | `0` | 正文最多字符数；`0` 关闭上界，且不能小于非零下界。 |
 | `novel search` | `--original-only` | `false` | 仅保留 Pixiv 标记为原创的小说。 |
@@ -324,10 +330,20 @@ CLI 使用 Cobra/pflag，选项可以写在位置参数前后，例如 `pixiv au
 | `bookmark add` | `--restrict` | `public` | 新收藏的可见性：`public` 或 `private`。 |
 | `bookmark add` | `--tag` | 空 | 收藏 tag；可重复使用。 |
 | `follow add` | `--restrict` | `public` | 新关注的可见性：`public` 或 `private`。 |
-| `detail` | `ILLUST_ID` | 必填 | Pixiv 作品 ID。 |
-| `download` | `ILLUST_ID...` | 必填 | 一个或多个 Pixiv 作品 ID。 |
+| `detail` | `ILLUST_ID_OR_URL` | 必填 | 正整数作品 ID，或受支持的 Pixiv 作品 URL。 |
+| `download` | `TARGET...` | 必填 | 作品 ID、作品 URL，或受支持的用户主页/作品页 URL。 |
 
-有 refresh token 时，`search` 始终使用 App API。分辨率、横纵比、工具、作品类型和 `ai-mode=exclude` 由 App 筛选，分级和 `ai-mode=only` 对 App 返回批次筛选；App 失败不会回落 Web。全部筛选都会绑定 opaque cursor，cursor 不能用于不同筛选组合。本地筛选跳过连续空上游批次时，CLI/MCP 会补拉到首个非空逻辑批次或真正结束。指定正数 `--limit` 或 `--page` 时，按过滤后的逻辑结果跨批填满；`--limit 0` 遍历全部过滤结果；未指定 `--limit` 时读取一个上游批次，但会跳过前导空批。不提供收藏数筛选，也不提供点赞数字段。作品 JSON/文本包含稳定作品页 URL `https://www.pixiv.net/artworks/{id}`，作为首字段/每件作品第一行。
+有 refresh token 时，`search` 始终使用 App API。分辨率、横纵比、工具、作品类型和 `ai-mode=exclude` 由 App 筛选，分级和 `ai-mode=only` 对 App 返回批次筛选；App 失败不会回落 Web。全部筛选都会绑定 opaque cursor，cursor 不能用于不同筛选组合。本地筛选跳过连续空上游批次时，CLI/MCP 会补拉到首个非空逻辑批次或真正结束。指定正数 `--limit` 或 `--page` 时，按过滤后的逻辑结果跨批填满；`--limit 0` 遍历全部过滤结果；未指定 `--limit` 时读取一个上游批次，但会跳过前导空批。App 还会执行显式日期与收藏数边界；收藏数不是点赞字段，不得文案为点赞。作品 JSON/文本包含稳定作品页 URL `https://www.pixiv.net/artworks/{id}`，作为首字段/每件作品第一行。
+
+### 插画标签查询语法
+
+已在认证 App API 上验证：插画 `search` 选择标签模式时，`tag-exact` 适合布尔标签筛选。`tagA tagB`
+表示同时要求两个完整标签（AND），`tagA OR tagB` 表示任一完整标签即可（OR）；`OR` 必须大写。字面量
+`AND` 不是已验证的运算符，应以空格分隔两个标签。
+
+默认的 `tag-partial` 也接受已验证的大写 `OR` 语法，但每个词都是模糊标签条件，不能把结果描述成严格的
+精确标签 AND：它可能匹配部分标签、别名或翻译标签，而作品未必显式列出输入的完整标签。`title-caption` 和仅 App OAuth 可用的 `tag-title-caption`
+都没有已记录的布尔标签契约。尚未验证对字面量大写 `OR` 标签/关键词的转义语法；需要严格查询时请避免该 token 并使用精确标签。
 
 `novel search` 仅走 App API。App 请求只表达关键词匹配、日期排序和时间范围；分级、正文长度与原创条件逐批依据稳定返回字段验证。字段缺失会明确返回上游响应错误，不会静默视为不匹配。筛选跳过上游批次时，逻辑 `--page`/`--limit` 语义不变。小说 JSON 包含稳定作品页 URL `https://www.pixiv.net/novel/show.php?id={id}`、`x_restrict`、`text_length` 与 `is_original`。
 
@@ -336,6 +352,10 @@ CLI 使用 Cobra/pflag，选项可以写在位置参数前后，例如 `pixiv au
 App JSON 读取在首次 429 且 `Retry-After` 有效时按命令 context 等待并重试一次；header 缺失/非法、第二次 429、
 写操作和资源下载绝不重放。
 `detail --json` 保留 Pixiv 原始 HTML `caption`；普通 `detail` 输出将其安全转为纯文本，作品列表不会输出 caption。
+
+`detail` 接受正整数作品 ID，或规范 HTTPS `pixiv.net`/`www.pixiv.net` 作品 URL：`/artworks/{id}`；可带 locale、query 和 fragment。不接受用户页、小说、短链、FANBOX、Pixivision、Sketch、旧式或任意其他 URL。
+
+`download` 还接受 `/users/{id}` 与 `/users/{id}/artworks`。用户 URL 会完整遍历并下载 `illust`、`manga`、`ugoira`，不下载小说，且必须使用 App OAuth；不会走匿名 Web fallback。URL 只在本地解析，不抓取 HTML，也不跟随重定向。单个作品失败不会阻止其余作品，取消会立即停止。`download --json` 输出 `{"items":[...],"failures":[...]}`；成功项含规范作品 `url`、ID、类型和本地文件 path/page，任何失败都会令命令以非零码退出。不会保存下载历史，也不做跨次去重。
 
 ### 通用参数
 
@@ -385,7 +405,7 @@ App JSON 读取在首次 429 且 `Retry-After` 有效时按命令 context 等待
 匿名 fallback 的差异：
 
 - 匿名 `search` 只执行 Web API 能可靠表达的筛选。分辨率、横纵比、绘图工具和作品类型会转译为 Web 参数；AI 筛选使用返回的作品字段。
-- `rating=r18`、`r18g` 或 `mature` 会在匿名请求前明确返回需要认证，而不会伪装成空结果；`rating=all` 只表示匿名可见范围。
+- `rating=r18`、`r18g`、`mature`、`--search-by tag-title-caption` 或收藏数边界会在匿名请求前明确返回需要认证，而不会伪装成空结果；`rating=all` 只表示匿名可见范围。
 - `search-options` 仅支持 App API，无 refresh token 时明确返回 unsupported。搜索不会读取或保存 `PHPSESSID` 等浏览器 Cookie，也不会把 refresh token 转换成 Web session。
 - `novel search` 仅支持 App API；无 refresh token 时明确返回需要认证。
 - 九个扩展排行榜 mode（`day_manga`、`week_manga`、`month_manga`、`week_rookie_manga`、`day_r18`、
@@ -428,6 +448,8 @@ pixiv update --proxy http://127.0.0.1:7890
 安装失败，会显式尝试恢复原 formula 并报告原错误和恢复结果。`go install` 使用精确 Release
 tag；Release binary 在下载前校验 Ed25519 签名的 checksum 清单和 archive SHA-256，再预检
 `pixiv version --json` 并原子替换可执行文件。
+
+未显式使用 `--proxy`、已配置的 `https_proxy` 或 `HTTPS_PROXY` 时，Release binary 更新会并发探测内嵌 source 列表。支持 API 的候选用于 GitHub Releases API；支持 archive 的候选用于签名 manifest、checksum 与平台 archive。首个有效响应成为首选路由；某个 asset 下载失败时会静默依次尝试其余已声明路由各一次，全部失败才会在错误中列出每条失败路由。候选不会改变规范 Release URL、SemVer 选择、Ed25519 验证或 SHA-256 验证。自动更新通知只使用支持 API 的候选，并保持原有的三秒总时限和 24 小时缓存。
 
 更新检查只选择 canonical SemVer tag。stable 检查先排除 GitHub 已标记的 prerelease；
 `--prerelease` 则将其纳入当前通道。若当前通道的任一非 draft published Release 使用非

--- a/docs/zh-CN/mcp-tools.md
+++ b/docs/zh-CN/mcp-tools.md
@@ -4,7 +4,7 @@
 
 以 `pixiv mcp` 启动 stdio server。stdout 仅用于 JSON-RPC；操作日志写入用户主目录 `~/.pixiv-cli/logs`（Windows 为 `%USERPROFILE%\.pixiv-cli\logs`）下的按日纯文本文件 `YYYY-MM-DD.txt`（默认保留 7 天），终端默认无日志痕迹。MCP 不提供 HTTP endpoint。
 
-有 refresh token 时 App API 为主路径，失败不自动回落 Web；无 refresh token 且 `web_fallback_enabled=true` 时，仅匿名白名单读 tool 可用 Web API。SDK 路径的用户详情、用户列表和收藏/关注写操作同时返回文本内容与 structured output；其可分类失败会令 result `isError=true`，保留安全错误文本和对应 structured output。文本型 MCP tool 的失败保留既有 Content、structured output、文本和 `isError=false` wire 形式，但对应文件日志 operation event 会使用 error level 和 `result=error`；事件只保留 operation、稳定 SDK 分类、backend/status 及安全 ID，不记录原始错误文本、tool 输入、query、token、Cookie、URL、path 或 response body。公开可写的未知 SDK error code 不进入事件，未知 backend 归类为 `local`，不会回显原值。正常空结果仍记录为成功。
+有 refresh token 时 App API 为主路径，失败不自动回落 Web；无 refresh token 且 `web_fallback_enabled=true` 时，仅匿名白名单读 tool 可用 Web API。查询型 tool（包括作品查询）同时返回紧凑文本摘要与对应的 typed structured output；其可分类失败会令 result `isError=true`，保留安全错误文本和对应 structured output。其他文本型 MCP tool 的失败保留既有 Content、structured output、文本和 `isError=false` wire 形式，但对应文件日志 operation event 会使用 error level 和 `result=error`；事件只保留 operation、稳定 SDK 分类、backend/status 及安全 ID，不记录原始错误文本、tool 输入、query、token、Cookie、URL、path 或 response body。公开可写的未知 SDK error code 不进入事件，未知 backend 归类为 `local`，不会回显原值。正常空结果仍记录为成功。
 
 ## 分页
 
@@ -23,7 +23,7 @@ SDK cursor 不出现在 MCP 参数或输出。列表工具统一使用逻辑 `pa
 | `set_download_path` | `path` | 文本状态。 |
 | `refresh_token` | 无 | 当前认证账号摘要。 |
 | `set_refresh_token` | 原始 App API `refresh_token` | 当前会话认证结果；不写 `auth.json`；Cookie 输入会被拒绝。 |
-| `download` | `illust_id` 或 `illust_ids`，可选 `pages`/`quality`；`delivery` 仅 `local_path` | 本地文件 path/file_uri/mime_type/页号/大小；不内嵌图片内容。 |
+| `download` | `illust_id`、`illust_ids` 和/或 `urls`，可选 `pages`/`quality`；`delivery` 仅 `local_path` | `{items, failures}` 下载报告；每个成功项含规范作品 URL、ID、类型和本地文件页号/路径；不内嵌图片内容。 |
 | `download_random_from_recommendation` | 可选 `count`（省略或 `null` 时默认 5；显式值须为 1..20），可选 `pages`/`quality`；`delivery` 仅 `local_path` | 下载结果文本与 structured 本地文件元数据；不内嵌图片内容。 |
 
 `refresh_token` 在 SDK/config/proxy 初始化失败时不会误报“未设置 refresh token”：context 取消与 deadline 保留明确文案，公开 `*pixiv.Error` 保留安全 code/operation/backend 分类，其他未知初始化错误不回显原始细节。真正执行 refresh 时，仅 `unauthorized` 保留缺少 token 提示；未知执行错误同样返回脱敏排查提示。该 tool 的 wire 返回 `isError=false`，真实失败通过前述文件日志 event 可观测。
@@ -32,22 +32,26 @@ SDK cursor 不出现在 MCP 参数或输出。列表工具统一使用逻辑 `pa
 
 以 HTTP(S) 代理启动 MCP server 时，其媒体资源下载会刻意使用 HTTP/1.1。App API、OAuth 与 Web 元数据请求仍保留常规协议协商；此行为规避部分代理特有的 HTTP/2 流重置，不改变认证或所选下载质量。
 
-两个下载 tool 在参数校验、SDK、推荐获取、下载、结果整理失败时，都会保留原有业务错误文本，并返回有效 structured output：`delivery` 固定为 `local_path`（非法 `delivery` 时同样回落到该值），`items` 与 `files` 是空数组而不是 `null`。这些失败结果返回 `isError=false`，不会被 typed output schema 的校验错误替代。成功与失败均不内嵌图片内容。
+`download.urls` 只在本地识别稳定的官方 Pixiv HTTPS 页面：`pixiv.net` 或 `www.pixiv.net` 的 `/artworks/{id}`、`/users/{id}`、`/users/{id}/artworks`，可带 locale、query 和 fragment。解析不跟随跳转、不抓取 HTML；短链、旧式 URL、小说、FANBOX、Pixivision、Sketch、其他 host 或路径都会在联网和打开下载器前被拒绝，安全错误文本不会回显原始 URL。作品 URL 下载一件作品；用户 URL 按输入位置展开其全部 `illust`、`manga`、`ugoira`，不下载小说，并且必须使用 App OAuth，不能走匿名 Web fallback。
+
+下载先按 `illust_ids` 的数组顺序、再按可选 `illust_id`、最后按 `urls` 的数组顺序处理；MCP 的独立字段不能表达它们之间的交错顺序。不会跨次持久化、去重、缓存或补齐历史记录，重复引用会再次处理。用户批量下载没有隐式数量、分页、重试或超时限制。取消立即停止；单件或单页失败不会阻止之后的目标，`items` 与 `failures` 会一起返回，因此含失败的报告 result 为 `isError=true`。成功项使用规范作品 URL，失败项给出安全的 URL/ID/类型/消息摘要。
+
+两个下载 tool 在参数校验、SDK、推荐获取、下载、结果整理失败时，都会保留原有业务错误文本，并返回有效 structured output：`delivery` 固定为 `local_path`（非法 `delivery` 时同样回落到该值），`items`、`failures` 与 `files` 是空数组而不是 `null`。这些全量失败结果返回 `isError=false`，不会被 typed output schema 的校验错误替代。成功与失败均不内嵌图片内容。
 
 ## 作品与用户读取
 
 | tool | 参数 | structured output |
 | --- | --- | --- |
-| `search_illust` | `word`、`search_target`、`sort`、`duration`、`page`、`limit`、`rating`、`content_type`、`ai_mode`、`aspect_ratio`、`resolution`、`tool` | structured output `{text}`；作品列表仍在文本中呈现。 |
+| `search_illust` | `word`、`search_target`、`sort`、`duration`、`start_date`、`end_date`、`page`、`limit`、`rating`、`content_type`、`ai_mode`、`aspect_ratio`、`resolution`、`tool`、`bookmark_min`、`bookmark_max` | `{items, pagination, text}`；`items` 可直接作为后续下载的作品引用来源。 |
 | `search_novel` | `word`、`search_target`、`sort`、`duration`、`page`、`limit`、`rating`、`min_text_length`、`max_text_length`、`original_only` | 仅 App 的 `{novels, pagination, text}`；可分类失败会令 `isError=true`。 |
 | `search_illust_options` | 必填 `word` | 当前搜索词可用的 `{tools,text}`；需要认证，不支持 Web fallback。 |
-| `illust_detail` | `illust_id` | 作品详情；Pixiv 提供时包含原始 HTML `caption`。 |
-| `illust_related` | `illust_id`、`page`、`limit` | 相关作品。 |
-| `illust_ranking` | `mode`、`date`、`page`、`limit` | 排行榜作品。 |
-| `illust_recommended` | `page`、`limit` | 推荐作品；文本输出经公开 SDK 调用链执行。 |
+| `illust_detail` | `illust_id` 或 `url` 二选一 | `{illust, text}`；作品详情；Pixiv 提供时包含原始 HTML `caption`。 |
+| `illust_related` | `illust_id`、`page`、`limit` | `{items, pagination, text}` 相关作品。 |
+| `illust_ranking` | `mode`、`date`、`page`、`limit` | `{items, pagination, text}` 排行榜作品。 |
+| `illust_recommended` | `page`、`limit` | `{items, pagination, text}` 推荐作品；文本输出经公开 SDK 调用链执行。 |
 | `recommended` | 必填 `kind`（`all`、`illust`、`manga`、`novel`、`user`），可选 `page`、`limit` | 通过认证 App SDK 返回 `{kind, illusts, manga, novels, user_previews, pagination}`；单类只填对应流，`all` 顺序读取四流。每条流独立应用分页，`pagination` 按流给出逻辑页信息；不暴露 SDK cursor，不支持 Web fallback。 |
-| `trending_tags_illust` | 无 | 热门标签。 |
-| `illust_follow` | `restrict`、`page`、`limit` | 关注新作；需要认证。 |
+| `trending_tags_illust` | 无 | `{tags, text}` 热门标签。 |
+| `illust_follow` | `restrict`、`page`、`limit` | `{items, pagination, text}` 关注新作；需要认证。 |
 | `search_user` | `word`、`page`、`limit` | `{source, user_previews, pagination, text}`；认证官方 App 搜索为 `app_search`，匿名 fallback 为 `related_illust_authors`，后者不是用户名搜索。 |
 | `user_detail` | 必填 `user_id` | 完整稳定的 `{user, profile, profile_publicity, workspace}`；需要认证，不支持 Web fallback。 |
 | `user_artworks` | 可选 `user_id`、`type`、`page`、`limit` | `{user_id, items, pagination}`；缺省 UID 为当前认证用户。 |
@@ -63,11 +67,20 @@ SDK cursor 不出现在 MCP 参数或输出。列表工具统一使用逻辑 `pa
 - `resolution`：`all|high|medium|low`，三档分别为宽高均 `>=3000`、均在 `1000..2999`、均
   `<=999`；
 - `tool`：上游绘图工具原值，不做模糊匹配。
+- `search_target`：`partial_match_for_tags|exact_match_for_tags|title_and_caption|keyword`；`keyword` 搜索标签、标题、说明文字，且需要 App OAuth。
+- `duration`：`within_last_day|within_last_week|within_last_month|within_half_year|within_year`；不能和日期边界同用。两个长周期会在本地展开为包含边界的东京日期区间。
+- `start_date` / `end_date`：包含边界的 `YYYY-MM-DD`；可只给一端，两端都有时起始不得晚于结束。
+- `bookmark_min` / `bookmark_max`：包含边界的非负公开收藏数；最小值不能大于最大值，且都需要 App OAuth。
 
 有 refresh token 时，分辨率、横纵比、工具、作品类型和 `ai_mode=exclude` 由 App 服务端筛选，
 `rating` 与 `ai_mode=only` 由 public SDK 基于 App 返回字段筛选；App 失败不回落 Web。无 token 的匿名
-Web 路径只执行已验证可靠的筛选；`rating=r18|r18g|mature` 在请求前返回需要登录，不伪装成空结果。
-`search_illust_options` 只走 App API。所有搜索 tool 都不接受 Cookie，当前也不提供收藏数筛选。
+Web 路径只执行已验证可靠的筛选；`rating=r18|r18g|mature`、`search_target=keyword` 和收藏数边界在请求前返回需要登录，不伪装成空结果。
+`search_illust_options` 只走 App API。所有搜索 tool 都不接受 Cookie。
+
+对认证态 `search_illust`，标签 `search_target` 会在 `word` 中保留已验证的 Pixiv App 查询语法：
+`exact_match_for_tags` 下 `tagA tagB` 要求两个完整标签同时存在，大写 `tagA OR tagB` 接受任一标签；字面量
+`AND` 不是运算符。`partial_match_for_tags` 也接受已验证的大写 `OR`，但它使用模糊标签词，不能视为严格的
+精确标签 AND。`title_and_caption` 和 `keyword` 都没有布尔标签契约，且尚未验证字面量大写 `OR` 标签/关键词的转义语法。
 
 `search_novel.rating` 使用 `all|sfw|r18|r18g|mature`。`min_text_length`、`max_text_length` 为非负字符数边界，
 `0` 关闭对应边界；非零上界小于下界会返回参数错误。`original_only` 仅保留标记为原创的小说。Pixiv 没有已验证的

--- a/docs/zh-CN/sdk.md
+++ b/docs/zh-CN/sdk.md
@@ -47,6 +47,14 @@ local, err := pixiv.OpenDefault(pixiv.Options{
 请求型方法使用命名 request，例如 `SearchIllustRequest`、`SearchNovelRequest`、`SearchIllustOptionsRequest`、`UserArtworksRequest`、`UserBookmarksRequest`、`UserFollowingRequest`、`AddBookmarkRequest`、`FollowUserRequest`。返回模型为 `IllustListResult`、`NovelListResult`、`SearchIllustOptionsResult`、`UserListResult`、`IllustDetail`、`UserDetailResult` 等，均来自顶层 `pixiv` package。
 每个 public `Illust` 都包含稳定作品页 URL `https://www.pixiv.net/artworks/{id}`，JSON 首字段为 `url`。SDK 不提供点赞数字段，不得把收藏数文案为点赞。`Download` 支持 `DownloadOptions`：`ParsePageSpec` 页选择与 `DownloadQuality`（`original|regular|small|thumb|mini`）；ugoira 对页选择或非 original 质量返回 unsupported。
 
+### 本地 Pixiv 引用解析
+
+`ParseReference(raw)` 不执行 I/O，接受正整数作品 ID 或严格的官方 Pixiv HTTPS URL，并返回
+`Reference{Kind, ID}`：ID 与 `/artworks/{id}` 的 `Kind` 是 `artwork`，`/users/{id}` 与
+`/users/{id}/artworks` 的 `Kind` 是 `user`。host 必须为 `pixiv.net` 或 `www.pixiv.net`，可带可选
+locale、query 与 fragment。`ParseArtworkReference(raw)` 是仅接受作品的变体，`Reference.URL()` 返回规范
+作品或用户页 URL。解析器不跟随跳转、不抓取 HTML，拒绝其他 Pixiv 属性或 URL 形式，校验错误也不会复现输入 URL。
+
 `UserArtworksRequest.UserID` 等 SDK 用户 ID 必填；“省略 UID 就是自己”是 CLI/MCP adapter 行为，外部 Go 调用方先调用 `CurrentUserID(ctx)` 后再组装 request。
 
 `UserDetail` 固定返回 `UserDetailResult{User, Profile, ProfilePublicity, Workspace}` 四个 envelope。上游任一 envelope 缺失、`null`、非 object 或 `user.id <= 0` 时，SDK 返回带 `OperationUserDetail`、`BackendAppAPI` 和请求 UID 的 `malformed_upstream_response`；不会暴露上游 body、URL 或凭据。`User.ProfileImageURLs.Medium`、`Profile` 中的网页/背景/社交 URL 以及 `Workspace.WorkspaceImageURL` 均是可选指针，缺失、`null` 与空字符串统一为 `nil`；未公开的文本、计数和字段保持 Go 零值。
@@ -85,10 +93,13 @@ auth store，不读取 `PIXIV_REFRESH_TOKEN` 或 runtime config，不刷新、�
 | `AspectRatio` | `all`、`landscape`、`portrait`、`square` |
 | `Resolution` | `all`、`high`、`medium`、`low`；三档分别要求宽高均 `>=3000`、均在 `1000..2999`、均 `<=999` |
 | `Tool` | 上游绘图工具原值；不做模糊匹配 |
+| `BookmarkMin` / `BookmarkMax` | 可选、包含边界的非负公开收藏数；`Min` 不得大于 `Max` |
 
 枚举零值规范化为 `all`，`Tool` 会去除首尾空白；未知枚举返回 `invalid_argument`，不会发起上游
-请求。认证路径把分辨率、横纵比、工具、作品类型和 `exclude` AI 翻译为 App 服务端参数；分级与
-`only` AI 再基于当前 App 批次的规范化字段筛选。`Illust.Tools []string` 保留 App 返回的工具顺序和
+请求。`SearchIllustRequest.Target` 还接受搜索标签、标题、说明文字的 `keyword`；`Duration` 接受
+`within_last_day|within_last_week|within_last_month`；`StartDate`、`EndDate` 是可选、包含边界的
+`YYYY-MM-DD`。日期区间不能与 `Duration` 同用，且起始不得晚于结束。认证路径把分辨率、横纵比、工具、作品类型、`exclude` AI、
+日期边界和收藏数边界翻译为 App 服务端参数；分级与 `only` AI 再基于当前 App 批次的规范化字段筛选。`Illust.Tools []string` 保留 App 返回的工具顺序和
 原值；该字段不是收藏数筛选。
 
 `SearchIllustOptions(ctx, SearchIllustOptionsRequest{Word: word})` 需要非空关键词和 App 认证，返回
@@ -132,8 +143,8 @@ next, err := client.UserArtworks(ctx, pixiv.UserArtworksRequest{
 _ = next
 ```
 
-cursor 是版本化、不透明、绑定操作和完整查询的 token；插画 `SearchIllust` cursor 同时绑定规范化后的
-`Rating`、`ContentType`、`AIMode`、`AspectRatio`、`Resolution` 与 `Tool`；小说搜索 cursor 绑定 target、sort、duration、
+cursor 是版本化、不透明、绑定操作和完整查询的 token；插画 `SearchIllust` cursor 同时绑定 target、duration、日期边界，以及规范化后的
+`Rating`、`ContentType`、`AIMode`、`AspectRatio`、`Resolution`、`Tool` 与收藏数边界；小说搜索 cursor 绑定 target、sort、duration、
 分级、正文长度边界与原创条件。改变任一筛选字段后复用旧 cursor 会返回 `invalid_argument`。cursor 不可解析、编辑、跨请求复用或替换为上游 offset/page。
 SDK 不以 `page` 为输入；CLI/MCP 在边缘层将逻辑 `page`/`limit` 转为 cursor 遍历。
 
@@ -142,7 +153,7 @@ SDK 不以 `page` 为输入；CLI/MCP 在边缘层将逻辑 `page`/`limit` 转�
 有 refresh token 时，插画搜索只走 App API；App 的认证、网络、服务端失败不自动 Web fallback。
 `NewClient` 无 refresh token 且 `WebFallbackEnabled=true` 时，匿名白名单读操作使用 Web API；
 `OpenDefault` 则每次 snapshot 读取本地 `web_fallback_enabled`。匿名 `SearchIllust` 只执行 Web 能可靠
-表达的筛选；`Rating` 为 `r18`、`r18g` 或 `mature` 时在联网前返回 `unauthorized`，不会伪装为空结果。
+表达的筛选；`Rating` 为 `r18`、`r18g`、`mature`、`Target=keyword` 或收藏数边界时在联网前返回 `unauthorized`，不会伪装为空结果。
 匿名 `SearchIllustOptions` 返回 `unsupported`，不会请求 Web。SDK 不读取或注入 Cookie，也不把 refresh
 token 转换为 Web session。
 

--- a/internal/application/download.go
+++ b/internal/application/download.go
@@ -17,6 +17,13 @@ type DownloadClient interface {
 	Download(context.Context, sdk.ResourceRef, string) error
 }
 
+// DownloadTargetClient 在下载资源能力之外提供作者作品列表，用于把用户 URL 展开为视觉作品。
+// 该接口仍只依赖顶层 public SDK 的规范化能力。
+type DownloadTargetClient interface {
+	DownloadClient
+	UserArtworks(context.Context, sdk.UserArtworksRequest) (*sdk.IllustListResult, error)
+}
+
 // 质量与页选择契约由 public SDK 拥有，application 仅 alias 以便 CLI/MCP 共用。
 type DownloadQuality = sdk.DownloadQuality
 
@@ -46,6 +53,21 @@ type DownloadedFile struct {
 	Page int
 }
 
+// DownloadFailure 是一次无状态批量下载中单个作品或作者列表读取的可展示失败。
+// Message 仅承接 SDK/下载器的安全错误文本，不保存用户输入的原始 URL。
+type DownloadFailure struct {
+	URL      string
+	IllustID int64
+	Type     string
+	Message  string
+}
+
+// DownloadReport 同时保留成功产物和独立失败，使作者全量下载无需持久化 job 状态也能说明结果。
+type DownloadReport struct {
+	Items    []DownloadedArtwork
+	Failures []DownloadFailure
+}
+
 // DownloadManager 接收完整 DownloadRequest，避免 CLI/MCP 与实现各自解析 pages/quality。
 type DownloadManager interface {
 	Download(context.Context, DownloadRequest) ([]DownloadedArtwork, error)
@@ -69,26 +91,127 @@ type DownloadService struct {
 
 // Download 把 operation snapshot 与本次运行配置交给 composition root 注入的下载器。
 func (s DownloadService) Download(ctx context.Context, client DownloadClient, request DownloadRequest) ([]DownloadedArtwork, error) {
+	manager, request, err := s.newManager(client, request)
+	if err != nil {
+		return nil, err
+	}
+	return manager.Download(ctx, request)
+}
+
+// DownloadTargets 依输入顺序下载作品，或展开作者的全部 illust、manga、ugoira。
+// 单件失败会进入 report 并继续；用户取消则立即返回 context 错误，不伪装成普通部分失败。
+func (s DownloadService) DownloadTargets(ctx context.Context, client DownloadTargetClient, targets []sdk.Reference, request DownloadRequest) (DownloadReport, error) {
+	report := DownloadReport{Items: []DownloadedArtwork{}, Failures: []DownloadFailure{}}
+	if len(targets) == 0 {
+		return report, errors.New("at least one download target is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return report, err
+	}
+	manager, request, err := s.newManager(client, request)
+	if err != nil {
+		return report, err
+	}
+	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+		if target.ID <= 0 || target.URL() == "" {
+			return report, errors.New("download target is invalid")
+		}
+		switch target.Kind {
+		case sdk.ReferenceKindArtwork:
+			if err := downloadOne(ctx, manager, request, target, "", &report); err != nil {
+				return report, err
+			}
+		case sdk.ReferenceKindUser:
+			if err := downloadUserArtworks(ctx, client, manager, request, target, &report); err != nil {
+				return report, err
+			}
+		default:
+			return report, errors.New("download target is invalid")
+		}
+	}
+	return report, nil
+}
+
+func (s DownloadService) newManager(client DownloadClient, request DownloadRequest) (DownloadManager, DownloadRequest, error) {
 	if s.NewManager == nil {
-		return nil, errors.New("download manager factory is not configured")
+		return nil, DownloadRequest{}, errors.New("download manager factory is not configured")
 	}
 	if isNilLike(client) {
-		return nil, errors.New("download operation client is not configured")
+		return nil, DownloadRequest{}, errors.New("download operation client is not configured")
 	}
 	if request.Quality == "" {
 		request.Quality = DownloadQualityOriginal
 	}
 	if err := ValidateDownloadQuality(request.Quality); err != nil {
-		return nil, err
+		return nil, DownloadRequest{}, err
 	}
 	manager, err := s.NewManager(client, request.DownloadPath, request.FilenameTemplate)
 	if err != nil {
-		return nil, err
+		return nil, DownloadRequest{}, err
 	}
 	if isNilLike(manager) {
-		return nil, errors.New("download manager factory returned nil")
+		return nil, DownloadRequest{}, errors.New("download manager factory returned nil")
 	}
-	return manager.Download(ctx, request)
+	return manager, request, nil
+}
+
+func downloadUserArtworks(ctx context.Context, client DownloadTargetClient, manager DownloadManager, request DownloadRequest, user sdk.Reference, report *DownloadReport) error {
+	for _, illustType := range []sdk.IllustType{sdk.IllustTypeIllust, sdk.IllustTypeManga, sdk.IllustTypeUgoira} {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_, err := TraversePages(ctx, PagePlan{}, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
+			result, err := client.UserArtworks(ctx, sdk.UserArtworksRequest{UserID: user.ID, Type: illustType, Cursor: cursor})
+			if err != nil {
+				return nil, "", err
+			}
+			if result == nil {
+				return nil, "", errors.New("pixiv sdk returned an empty user artworks result")
+			}
+			return result.Illusts, result.NextCursor, nil
+		}, func(items []sdk.Illust) error {
+			for _, illust := range items {
+				target := sdk.Reference{Kind: sdk.ReferenceKindArtwork, ID: illust.ID}
+				if err := downloadOne(ctx, manager, request, target, illust.Type, report); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err == nil {
+			continue
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		report.Failures = append(report.Failures, DownloadFailure{
+			URL: user.URL(), Type: string(illustType), Message: err.Error(),
+		})
+	}
+	return nil
+}
+
+func downloadOne(ctx context.Context, manager DownloadManager, request DownloadRequest, target sdk.Reference, illustType string, report *DownloadReport) error {
+	one := request
+	one.IllustIDs = []int64{target.ID}
+	items, err := manager.Download(ctx, one)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		report.Failures = append(report.Failures, DownloadFailure{
+			URL: target.URL(), IllustID: target.ID, Type: illustType, Message: err.Error(),
+		})
+		return nil
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	report.Items = append(report.Items, items...)
+	return nil
 }
 
 // isNilLike 处理 Go interface 携带 typed nil 的情况；仅对允许 IsNil 的 kind

--- a/internal/application/download_test.go
+++ b/internal/application/download_test.go
@@ -58,6 +58,98 @@ func TestDownloadServiceDelegatesOperationClientAndRequest(t *testing.T) {
 	require.Equal(t, want, got)
 }
 
+func TestDownloadServiceReportsArtworkFailuresAndPreservesInputOrder(t *testing.T) {
+	client := downloadTargetClientStub{}
+	var calls []int64
+	service := application.DownloadService{NewManager: func(application.DownloadClient, string, string) (application.DownloadManager, error) {
+		return &downloadManagerStub{download: func(_ context.Context, request application.DownloadRequest) ([]application.DownloadedArtwork, error) {
+			require.Len(t, request.IllustIDs, 1)
+			id := request.IllustIDs[0]
+			calls = append(calls, id)
+			if id == 2 {
+				return nil, errors.New("upstream unavailable")
+			}
+			return []application.DownloadedArtwork{{IllustID: id, Title: "work"}}, nil
+		}}, nil
+	}}
+
+	report, err := service.DownloadTargets(context.Background(), client, []sdk.Reference{
+		{Kind: sdk.ReferenceKindArtwork, ID: 1},
+		{Kind: sdk.ReferenceKindArtwork, ID: 2},
+		{Kind: sdk.ReferenceKindArtwork, ID: 1},
+	}, application.DownloadRequest{})
+
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 2, 1}, calls)
+	require.Equal(t, []application.DownloadedArtwork{{IllustID: 1, Title: "work"}, {IllustID: 1, Title: "work"}}, report.Items)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, int64(2), report.Failures[0].IllustID)
+	require.Equal(t, "https://www.pixiv.net/artworks/2", report.Failures[0].URL)
+	require.Equal(t, "upstream unavailable", report.Failures[0].Message)
+}
+
+func TestDownloadServiceExpandsEveryVisualArtworkTypeForUserTargets(t *testing.T) {
+	var requests []sdk.UserArtworksRequest
+	client := userArtworksDownloadClient{userArtworks: func(_ context.Context, request sdk.UserArtworksRequest) (*sdk.IllustListResult, error) {
+		requests = append(requests, request)
+		switch request.Type {
+		case sdk.IllustTypeIllust:
+			if request.Cursor == "" {
+				return &sdk.IllustListResult{Illusts: []sdk.Illust{{ID: 1, Type: "illust"}}, NextCursor: "illust-next"}, nil
+			}
+			return &sdk.IllustListResult{Illusts: []sdk.Illust{{ID: 2, Type: "illust"}}}, nil
+		case sdk.IllustTypeManga:
+			return &sdk.IllustListResult{Illusts: []sdk.Illust{{ID: 3, Type: "manga"}}}, nil
+		case sdk.IllustTypeUgoira:
+			return &sdk.IllustListResult{Illusts: []sdk.Illust{{ID: 4, Type: "ugoira"}}}, nil
+		default:
+			return nil, errors.New("unexpected artwork type")
+		}
+	}}
+	var downloaded []int64
+	service := application.DownloadService{NewManager: func(application.DownloadClient, string, string) (application.DownloadManager, error) {
+		return &downloadManagerStub{download: func(_ context.Context, request application.DownloadRequest) ([]application.DownloadedArtwork, error) {
+			id := request.IllustIDs[0]
+			downloaded = append(downloaded, id)
+			return []application.DownloadedArtwork{{IllustID: id}}, nil
+		}}, nil
+	}}
+
+	report, err := service.DownloadTargets(context.Background(), client, []sdk.Reference{{Kind: sdk.ReferenceKindUser, ID: 7}}, application.DownloadRequest{})
+
+	require.NoError(t, err)
+	require.Empty(t, report.Failures)
+	require.Equal(t, []int64{1, 2, 3, 4}, downloaded)
+	require.Equal(t, []sdk.UserArtworksRequest{
+		{UserID: 7, Type: sdk.IllustTypeIllust},
+		{UserID: 7, Type: sdk.IllustTypeIllust, Cursor: "illust-next"},
+		{UserID: 7, Type: sdk.IllustTypeManga},
+		{UserID: 7, Type: sdk.IllustTypeUgoira},
+	}, requests)
+}
+
+func TestDownloadServiceStopsImmediatelyWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	service := application.DownloadService{NewManager: func(application.DownloadClient, string, string) (application.DownloadManager, error) {
+		return &downloadManagerStub{download: func(ctx context.Context, _ application.DownloadRequest) ([]application.DownloadedArtwork, error) {
+			calls++
+			return nil, ctx.Err()
+		}}, nil
+	}}
+
+	report, err := service.DownloadTargets(ctx, downloadTargetClientStub{}, []sdk.Reference{
+		{Kind: sdk.ReferenceKindArtwork, ID: 1},
+		{Kind: sdk.ReferenceKindArtwork, ID: 2},
+	}, application.DownloadRequest{})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, calls)
+	require.Empty(t, report.Items)
+	require.Empty(t, report.Failures)
+}
+
 func TestDownloadServiceRejectsMissingFactory(t *testing.T) {
 	_, err := (application.DownloadService{}).Download(context.Background(), downloadClientStub{}, application.DownloadRequest{})
 
@@ -145,6 +237,13 @@ func (m *downloadManagerStub) Download(ctx context.Context, request application.
 
 type downloadClientStub struct{}
 
+type downloadTargetClientStub struct{ downloadClientStub }
+
+type userArtworksDownloadClient struct {
+	downloadClientStub
+	userArtworks func(context.Context, sdk.UserArtworksRequest) (*sdk.IllustListResult, error)
+}
+
 type typedNilDownloadClient struct{}
 
 func (*typedNilDownloadClient) IllustDetail(context.Context, int64) (*sdk.IllustDetail, error) {
@@ -177,4 +276,12 @@ func (downloadClientStub) ParseResourceRef(string) (sdk.ResourceRef, error) {
 
 func (downloadClientStub) Download(context.Context, sdk.ResourceRef, string) error {
 	return nil
+}
+
+func (downloadTargetClientStub) UserArtworks(context.Context, sdk.UserArtworksRequest) (*sdk.IllustListResult, error) {
+	return &sdk.IllustListResult{}, nil
+}
+
+func (c userArtworksDownloadClient) UserArtworks(ctx context.Context, request sdk.UserArtworksRequest) (*sdk.IllustListResult, error) {
+	return c.userArtworks(ctx, request)
 }

--- a/internal/application/search_dates.go
+++ b/internal/application/search_dates.go
@@ -1,0 +1,38 @@
+package application
+
+import "time"
+
+const tokyoOffsetSeconds = 9 * 60 * 60
+
+// SearchQuickDateRange 将官方 App 的长日期快捷项规范化为包含边界的日本日期。
+// App 搜索接口以 start_date/end_date 表示半年和一年，而非可依赖的 duration 枚举。
+func SearchQuickDateRange(value string, now time.Time) (startDate, endDate string, ok bool) {
+	today := now.In(time.FixedZone("Asia/Tokyo", tokyoOffsetSeconds))
+	today = time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, today.Location())
+
+	var start time.Time
+	switch value {
+	case "within_half_year":
+		start = addMonthsClamped(today, -6)
+	case "within_year":
+		start = addMonthsClamped(today, -12)
+	default:
+		return "", "", false
+	}
+	return start.Format("2006-01-02"), today.Format("2006-01-02"), true
+}
+
+// addMonthsClamped 对齐 LocalDate.minusMonths/minusYears：目标月份没有同一天时取该月末日。
+func addMonthsClamped(date time.Time, months int) time.Time {
+	monthIndex := int(date.Month()) - 1 + months
+	year := date.Year() + monthIndex/12
+	monthIndex %= 12
+	if monthIndex < 0 {
+		monthIndex += 12
+		year--
+	}
+	month := time.Month(monthIndex + 1)
+	lastDay := time.Date(year, month+1, 0, 0, 0, 0, 0, date.Location()).Day()
+	day := min(date.Day(), lastDay)
+	return time.Date(year, month, day, 0, 0, 0, 0, date.Location())
+}

--- a/internal/application/search_dates_test.go
+++ b/internal/application/search_dates_test.go
@@ -1,0 +1,29 @@
+package application
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSearchQuickDateRangeUsesTokyoDateAndClampsMonthEnd(t *testing.T) {
+	location := time.FixedZone("UTC-8", -8*60*60)
+	now := time.Date(2026, time.August, 31, 23, 0, 0, 0, location)
+	start, end, ok := SearchQuickDateRange("within_half_year", now)
+	if !ok || start != "2026-03-01" || end != "2026-09-01" {
+		t.Fatalf("half year range = %q..%q ok=%v", start, end, ok)
+	}
+}
+
+func TestSearchQuickDateRangeClampsLeapDayForYear(t *testing.T) {
+	now := time.Date(2024, time.February, 29, 12, 0, 0, 0, time.FixedZone("Asia/Tokyo", tokyoOffsetSeconds))
+	start, end, ok := SearchQuickDateRange("within_year", now)
+	if !ok || start != "2023-02-28" || end != "2024-02-29" {
+		t.Fatalf("year range = %q..%q ok=%v", start, end, ok)
+	}
+}
+
+func TestSearchQuickDateRangeRejectsUnknownValue(t *testing.T) {
+	if _, _, ok := SearchQuickDateRange("within_last_month", time.Now()); ok {
+		t.Fatal("short duration unexpectedly resolved to an explicit date range")
+	}
+}

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -14,7 +14,8 @@ func NewUpdateCoordinator(proxy string, out, errOut io.Writer) (*update.UpdateCo
 	if err != nil {
 		return nil, fmt.Errorf("create update HTTP client: %w", err)
 	}
-	releaseClient, err := update.NewGitHubReleaseClient(update.ReleaseClientOptions{HTTPClient: httpClient})
+	usePublicReleaseSources := proxy == ""
+	releaseClient, err := update.NewGitHubReleaseClient(update.ReleaseClientOptions{HTTPClient: httpClient, EnablePublicReleaseSources: usePublicReleaseSources})
 	if err != nil {
 		return nil, fmt.Errorf("create GitHub release client: %w", err)
 	}
@@ -22,7 +23,7 @@ func NewUpdateCoordinator(proxy string, out, errOut io.Writer) (*update.UpdateCo
 		SourceDetector:   update.SourceDetectorFunc(update.DetectInstallSource),
 		ReleaseChecker:   releaseClient,
 		CommandRunner:    update.NewCommandRunner(out, errOut),
-		ReleaseInstaller: update.NewReleaseInstaller(productionReleaseInstallerOptions(httpClient)),
+		ReleaseInstaller: update.NewReleaseInstaller(withPublicReleaseSources(productionReleaseInstallerOptions(httpClient), usePublicReleaseSources)),
 	})
 }
 
@@ -33,7 +34,8 @@ func NewAutomaticUpdateChecker(proxy string) (*update.AutomaticUpdateChecker, er
 	if err != nil {
 		return nil, fmt.Errorf("create update HTTP client: %w", err)
 	}
-	releaseClient, err := update.NewGitHubReleaseClient(update.ReleaseClientOptions{HTTPClient: httpClient})
+	usePublicReleaseSources := proxy == ""
+	releaseClient, err := update.NewGitHubReleaseClient(update.ReleaseClientOptions{HTTPClient: httpClient, EnablePublicReleaseSources: usePublicReleaseSources})
 	if err != nil {
 		return nil, fmt.Errorf("create GitHub release client: %w", err)
 	}
@@ -41,4 +43,9 @@ func NewAutomaticUpdateChecker(proxy string) (*update.AutomaticUpdateChecker, er
 		SourceDetector: update.SourceDetectorFunc(update.DetectInstallSource),
 		ReleaseChecker: releaseClient,
 	})
+}
+
+func withPublicReleaseSources(options update.ReleaseInstallerOptions, enabled bool) update.ReleaseInstallerOptions {
+	options.EnablePublicReleaseSources = enabled
+	return options
 }

--- a/internal/cli/api_cmd.go
+++ b/internal/cli/api_cmd.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/FlanChanXwO/pixiv-cli/internal/application"
-	"github.com/FlanChanXwO/pixiv-cli/internal/utils/parse"
 	sdk "github.com/FlanChanXwO/pixiv-cli/pixiv"
 	"github.com/spf13/cobra"
 )
@@ -19,13 +19,17 @@ type searchOptions struct {
 	searchBy    string
 	sortMode    string
 	period      string
+	startDate   string
+	endDate     string
 	resolution  string
 	aspectRatio string
 	drawTool    string
 	aiMode      string
 	listOptions
-	rating string
-	typ    string
+	rating      string
+	typ         string
+	bookmarkMin int
+	bookmarkMax int
 }
 
 type rankingOptions struct {
@@ -41,9 +45,10 @@ type recommendedOptions struct {
 }
 
 const (
-	searchTargetTagPartial   = "tag-partial"
-	searchTargetTagExact     = "tag-exact"
-	searchTargetTitleCaption = "title-caption"
+	searchTargetTagPartial      = "tag-partial"
+	searchTargetTagExact        = "tag-exact"
+	searchTargetTitleCaption    = "title-caption"
+	searchTargetTagTitleCaption = "tag-title-caption"
 )
 
 func (a app) newSearchCommand() *cobra.Command {
@@ -67,15 +72,19 @@ func (a app) newSearchCommand() *cobra.Command {
 	}
 	a.bindCommonFlags(cmd, &opts.commandOptions)
 	flags := cmd.Flags()
-	flags.StringVar(&opts.searchBy, "search-by", opts.searchBy, "search field: tag-partial, tag-exact, title-caption")
+	flags.StringVar(&opts.searchBy, "search-by", opts.searchBy, "search field: tag-partial, tag-exact, title-caption, tag-title-caption")
 	flags.StringVar(&opts.sortMode, "sort", opts.sortMode, "sort mode: date_desc, date_asc")
-	flags.StringVar(&opts.period, "period", "", "time range: day, week, month")
+	flags.StringVar(&opts.period, "period", "", "time range: day, week, month, half-year, year")
+	flags.StringVar(&opts.startDate, "start-date", "", "inclusive start date: YYYY-MM-DD")
+	flags.StringVar(&opts.endDate, "end-date", "", "inclusive end date: YYYY-MM-DD")
 	flags.StringVar(&opts.rating, "rating", opts.rating, "rating filter: sfw, r18, r18g, mature, all")
 	flags.StringVar(&opts.typ, "type", opts.typ, "artwork type filter: all, illust-and-ugoira, illust, manga, ugoira")
 	flags.StringVar(&opts.resolution, "resolution", opts.resolution, "resolution filter: all, high, medium, low")
 	flags.StringVar(&opts.aspectRatio, "aspect-ratio", opts.aspectRatio, "aspect ratio filter: all, landscape, portrait, square")
 	flags.StringVar(&opts.drawTool, "draw-tool", "", "drawing tool name from search-options")
 	flags.StringVar(&opts.aiMode, "ai-mode", opts.aiMode, "AI artwork filter: all, exclude, only")
+	flags.IntVar(&opts.bookmarkMin, "bookmark-min", 0, "minimum public bookmark count (requires App OAuth)")
+	flags.IntVar(&opts.bookmarkMax, "bookmark-max", 0, "maximum public bookmark count (requires App OAuth)")
 	bindListFlags(cmd, &opts.listOptions)
 	return cmd
 }
@@ -90,6 +99,10 @@ func (a app) runSearch(cmd *cobra.Command, args []string, opts searchOptions) er
 		return err
 	}
 	period, err := resolveSearchPeriod(opts.period)
+	if err != nil {
+		return err
+	}
+	period, startDate, endDate, err := resolveSearchDateRange(opts, period)
 	if err != nil {
 		return err
 	}
@@ -117,7 +130,7 @@ func (a app) runSearch(cmd *cobra.Command, args []string, opts searchOptions) er
 	return a.runIllustList(cmd.Context(), plan, jsonOut, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
 		result, err := client.SearchIllust(ctx, sdk.SearchIllustRequest{
 			Word: word, Target: target, Sort: sdk.SortMode(opts.sortMode),
-			Duration: period, Cursor: cursor, Filters: filters,
+			Duration: period, StartDate: startDate, EndDate: endDate, Cursor: cursor, Filters: filters,
 		})
 		if err != nil {
 			return nil, "", err
@@ -134,8 +147,10 @@ func resolveSearchBy(value string) (sdk.SearchTarget, error) {
 		return sdk.SearchTargetExactMatchForTags, nil
 	case searchTargetTitleCaption:
 		return sdk.SearchTargetTitleAndCaption, nil
+	case searchTargetTagTitleCaption:
+		return sdk.SearchTargetKeyword, nil
 	default:
-		return "", fmt.Errorf("search-by must be one of %s, %s, %s", searchTargetTagPartial, searchTargetTagExact, searchTargetTitleCaption)
+		return "", fmt.Errorf("search-by must be one of %s, %s, %s, %s", searchTargetTagPartial, searchTargetTagExact, searchTargetTitleCaption, searchTargetTagTitleCaption)
 	}
 }
 
@@ -149,12 +164,39 @@ func resolveSearchPeriod(value string) (string, error) {
 		return "within_last_week", nil
 	case "month":
 		return "within_last_month", nil
+	case "half-year":
+		return "within_half_year", nil
+	case "year":
+		return "within_year", nil
 	default:
-		return "", errors.New("period must be one of day, week, month")
+		return "", errors.New("period must be one of day, week, month, half-year, year")
 	}
 }
 
-func resolveSearchFilters(_ *cobra.Command, opts searchOptions) (sdk.SearchIllustFilters, error) {
+func resolveSearchDateRange(opts searchOptions, period string) (string, string, string, error) {
+	startDate := strings.TrimSpace(opts.startDate)
+	endDate := strings.TrimSpace(opts.endDate)
+	if period != "" && (startDate != "" || endDate != "") {
+		return "", "", "", errors.New("period cannot be combined with start-date or end-date")
+	}
+	if startDate != "" && !validSearchDate(startDate) || endDate != "" && !validSearchDate(endDate) {
+		return "", "", "", errors.New("start-date and end-date must use YYYY-MM-DD")
+	}
+	if startDate != "" && endDate != "" && startDate > endDate {
+		return "", "", "", errors.New("start-date cannot be later than end-date")
+	}
+	if startDate, endDate, ok := application.SearchQuickDateRange(period, time.Now()); ok {
+		return "", startDate, endDate, nil
+	}
+	return period, startDate, endDate, nil
+}
+
+func validSearchDate(value string) bool {
+	parsed, err := time.Parse("2006-01-02", value)
+	return err == nil && parsed.Format("2006-01-02") == value
+}
+
+func resolveSearchFilters(cmd *cobra.Command, opts searchOptions) (sdk.SearchIllustFilters, error) {
 	filters := sdk.SearchIllustFilters{}
 	switch opts.rating {
 	case "sfw", "r18", "r18g", "mature", "all":
@@ -187,6 +229,23 @@ func resolveSearchFilters(_ *cobra.Command, opts searchOptions) (sdk.SearchIllus
 		return filters, fmt.Errorf("ai-mode must be one of all, exclude, only")
 	}
 	filters.Tool = opts.drawTool
+	if cmd.Flags().Changed("bookmark-min") {
+		if opts.bookmarkMin < 0 {
+			return filters, errors.New("bookmark-min must be greater than or equal to zero")
+		}
+		minimum := opts.bookmarkMin
+		filters.BookmarkMin = &minimum
+	}
+	if cmd.Flags().Changed("bookmark-max") {
+		if opts.bookmarkMax < 0 {
+			return filters, errors.New("bookmark-max must be greater than or equal to zero")
+		}
+		maximum := opts.bookmarkMax
+		filters.BookmarkMax = &maximum
+	}
+	if filters.BookmarkMin != nil && filters.BookmarkMax != nil && *filters.BookmarkMin > *filters.BookmarkMax {
+		return filters, errors.New("bookmark-min cannot be greater than bookmark-max")
+	}
 	return filters, nil
 }
 
@@ -248,9 +307,9 @@ func safeTextLine(value string) string {
 func (a app) newDetailCommand() *cobra.Command {
 	var opts commandOptions
 	cmd := &cobra.Command{
-		Use:   "detail ILLUST_ID",
+		Use:   "detail ILLUST_ID_OR_URL",
 		Short: "Show one illustration",
-		Args:  requireExactArgs(1, "pixiv detail [options] ILLUST_ID"),
+		Args:  requireExactArgs(1, "pixiv detail [options] ILLUST_ID_OR_URL"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return a.runDetail(cmd, args[0], opts)
 		},
@@ -260,7 +319,7 @@ func (a app) newDetailCommand() *cobra.Command {
 }
 
 func (a app) runDetail(cmd *cobra.Command, arg string, opts commandOptions) error {
-	id, err := parse.PositiveInt64(arg, "illust_id")
+	id, err := sdk.ParseArtworkReference(arg)
 	if err != nil {
 		return err
 	}
@@ -362,9 +421,9 @@ type downloadOptions struct {
 func (a app) newDownloadCommand() *cobra.Command {
 	opts := downloadOptions{quality: string(application.DownloadQualityOriginal)}
 	cmd := &cobra.Command{
-		Use:   "download ILLUST_ID...",
+		Use:   "download TARGET...",
 		Short: "Download illustrations",
-		Args:  requireMinArgs(1, "pixiv download [options] ILLUST_ID..."),
+		Args:  requireMinArgs(1, "pixiv download [options] TARGET..."),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return a.runDownload(cmd, args, opts)
 		},
@@ -385,13 +444,13 @@ func (a app) bindDownloadRuntimeFlags(cmd *cobra.Command, opts *downloadOptions)
 }
 
 func (a app) runDownload(cmd *cobra.Command, args []string, opts downloadOptions) error {
-	ids := make([]int64, 0, len(args))
+	targets := make([]sdk.Reference, 0, len(args))
 	for _, arg := range args {
-		id, err := parse.PositiveInt64(arg, fmt.Sprintf("illust_id %q", arg))
+		target, err := sdk.ParseReference(arg)
 		if err != nil {
 			return err
 		}
-		ids = append(ids, id)
+		targets = append(targets, target)
 	}
 	pages, err := application.ParsePageSpec(opts.pages)
 	if err != nil {
@@ -429,8 +488,7 @@ func (a app) runDownload(cmd *cobra.Command, args []string, opts downloadOptions
 	if err != nil {
 		return err
 	}
-	artworks, err := services.Download.Download(cmd.Context(), client, application.DownloadRequest{
-		IllustIDs:        ids,
+	report, err := services.Download.DownloadTargets(cmd.Context(), client, targets, application.DownloadRequest{
 		DownloadPath:     runtime.DownloadPath,
 		FilenameTemplate: runtime.FilenameTemplate,
 		Pages:            pages,
@@ -440,15 +498,79 @@ func (a app) runDownload(cmd *cobra.Command, args []string, opts downloadOptions
 		return err
 	}
 	if jsonOut {
-		return a.printJSON(artworks)
-	}
-	for _, artwork := range artworks {
-		fmt.Fprintf(a.out, "downloaded %d %q by %s\n", artwork.IllustID, artwork.Title, artwork.Author)
-		for _, file := range artwork.Files {
-			fmt.Fprintf(a.out, "  %s\n", file.Path)
+		if err := a.printJSON(downloadReportOutput(report)); err != nil {
+			return err
 		}
+	} else {
+		printDownloadReport(a.out, report)
+	}
+	if len(report.Failures) > 0 {
+		return fmt.Errorf("download completed with %d failures", len(report.Failures))
 	}
 	return nil
+}
+
+// downloadReportOut 是 CLI 的稳定 JSON 下载报告；作品 URL 始终按 ID 重建为规范地址。
+type downloadReportOut struct {
+	Items    []downloadArtworkOut `json:"items"`
+	Failures []downloadFailureOut `json:"failures"`
+}
+
+type downloadArtworkOut struct {
+	URL      string            `json:"url"`
+	IllustID int64             `json:"illust_id"`
+	Title    string            `json:"title"`
+	Author   string            `json:"author"`
+	Type     string            `json:"type"`
+	Files    []downloadFileOut `json:"files"`
+}
+
+type downloadFileOut struct {
+	Path string `json:"path"`
+	Page int    `json:"page"`
+}
+
+type downloadFailureOut struct {
+	URL      string `json:"url"`
+	IllustID int64  `json:"illust_id"`
+	Type     string `json:"type"`
+	Message  string `json:"message"`
+}
+
+func downloadReportOutput(report application.DownloadReport) downloadReportOut {
+	out := downloadReportOut{Items: []downloadArtworkOut{}, Failures: []downloadFailureOut{}}
+	for _, artwork := range report.Items {
+		item := downloadArtworkOut{
+			URL:      sdk.Reference{Kind: sdk.ReferenceKindArtwork, ID: artwork.IllustID}.URL(),
+			IllustID: artwork.IllustID,
+			Title:    artwork.Title,
+			Author:   artwork.Author,
+			Type:     artwork.Type,
+			Files:    []downloadFileOut{},
+		}
+		for _, file := range artwork.Files {
+			item.Files = append(item.Files, downloadFileOut{Path: file.Path, Page: file.Page})
+		}
+		out.Items = append(out.Items, item)
+	}
+	for _, failure := range report.Failures {
+		out.Failures = append(out.Failures, downloadFailureOut{
+			URL: failure.URL, IllustID: failure.IllustID, Type: failure.Type, Message: failure.Message,
+		})
+	}
+	return out
+}
+
+func printDownloadReport(w io.Writer, report application.DownloadReport) {
+	for _, artwork := range report.Items {
+		fmt.Fprintf(w, "downloaded %d %q by %s\n", artwork.IllustID, artwork.Title, artwork.Author)
+		for _, file := range artwork.Files {
+			fmt.Fprintf(w, "  %s\n", file.Path)
+		}
+	}
+	for _, failure := range report.Failures {
+		fmt.Fprintf(w, "failed %s: %s\n", failure.URL, failure.Message)
+	}
 }
 
 func printIllusts(w io.Writer, illusts []sdk.Illust, offset int, ranked bool) {

--- a/internal/cli/api_test.go
+++ b/internal/cli/api_test.go
@@ -101,6 +101,40 @@ func TestDetailRendersCaptionAsSafePlainText(t *testing.T) {
 	assert.NotContains(t, stdout.String(), "<p>")
 }
 
+func TestDetailAcceptsArtworkURL(t *testing.T) {
+	useTempPaths(t)
+	var gotID int64
+	setTestSDKCommandClient(t, sdkCommandFake{detail: func(_ context.Context, id int64) (*sdk.IllustDetail, error) {
+		gotID = id
+		return &sdk.IllustDetail{Illust: commandIllust(id)}, nil
+	}})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"pixiv", "detail", "https://www.pixiv.net/en/artworks/42?utm_source=share#page=1", "--json"}, strings.NewReader(""), &stdout, &stderr)
+
+	require.Equal(t, 0, code, stderr.String())
+	assert.Equal(t, int64(42), gotID)
+	assert.JSONEq(t, `{"illust":{"url":"https://www.pixiv.net/artworks/42","id":42,"title":"work","type":"","page_count":0,"total_bookmarks":0,"total_view":0,"x_restrict":0,"user":{"id":0,"name":"artist","account":"","comment":"","is_followed":false,"profile_image_urls":{}},"tags":null,"image_urls":{"square_medium":"","medium":"","large":"","original":""},"meta_single_page":{"original_image_url":""},"meta_pages":null,"ai_type":0,"create_date":"","width":0,"height":0,"tools":null}}`, stdout.String())
+}
+
+func TestDetailRejectsUnsupportedURLBeforeOpeningSDK(t *testing.T) {
+	useTempPaths(t)
+	factoryCalls := 0
+	setTestSDKCommandFactory(t, func(application.SDKClientRequest) (application.SDKClient, error) {
+		factoryCalls++
+		return sdkCommandFake{}, nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"pixiv", "detail", "https://www.pixiv.net/users/7?secret=must-not-echo"}, strings.NewReader(""), &stdout, &stderr)
+
+	require.NotZero(t, code)
+	assert.Zero(t, factoryCalls)
+	assert.Empty(t, stdout.String())
+	assert.NotContains(t, stderr.String(), "must-not-echo")
+	assert.Contains(t, stderr.String(), "supported Pixiv URL")
+}
+
 func TestSearchHelpUsesEnglishExamples(t *testing.T) {
 	for _, command := range []string{"search", "search-options"} {
 		t.Run(command, func(t *testing.T) {
@@ -188,16 +222,79 @@ func TestSearchUsesPeriodInsteadOfDuration(t *testing.T) {
 	}})
 
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"pixiv", "search", "miku", "--period", "week", "--json"}, strings.NewReader(""), &stdout, &stderr)
-
-	require.Equal(t, 0, code, stderr.String())
-	assert.Equal(t, "within_last_week", got.Duration)
+	for _, test := range []struct {
+		period          string
+		duration        string
+		explicitDateSet bool
+	}{
+		{period: "week", duration: "within_last_week"},
+		{period: "half-year", explicitDateSet: true},
+		{period: "year", explicitDateSet: true},
+	} {
+		stdout.Reset()
+		stderr.Reset()
+		code := Run([]string{"pixiv", "search", "miku", "--period", test.period, "--json"}, strings.NewReader(""), &stdout, &stderr)
+		require.Equal(t, 0, code, stderr.String())
+		assert.Equal(t, test.duration, got.Duration)
+		if test.explicitDateSet {
+			assert.NotEmpty(t, got.StartDate)
+			assert.NotEmpty(t, got.EndDate)
+			assert.LessOrEqual(t, got.StartDate, got.EndDate)
+		} else {
+			assert.Empty(t, got.StartDate)
+			assert.Empty(t, got.EndDate)
+		}
+	}
 
 	stdout.Reset()
 	stderr.Reset()
-	code = Run([]string{"pixiv", "search", "miku", "--duration", "within_last_week"}, strings.NewReader(""), &stdout, &stderr)
+	code := Run([]string{"pixiv", "search", "miku", "--duration", "within_last_week"}, strings.NewReader(""), &stdout, &stderr)
 	require.NotZero(t, code)
 	assert.Contains(t, stderr.String(), "unknown flag: --duration")
+}
+
+func TestSearchMapsKeywordDateAndBookmarkFilters(t *testing.T) {
+	useTempPaths(t)
+	var got sdk.SearchIllustRequest
+	setTestSDKCommandClient(t, sdkCommandFake{search: func(_ context.Context, request sdk.SearchIllustRequest) (*sdk.IllustListResult, error) {
+		got = request
+		return &sdk.IllustListResult{}, nil
+	}})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"pixiv", "search", "miku", "--search-by", "tag-title-caption", "--start-date", "2026-01-01", "--end-date", "2026-01-31",
+		"--bookmark-min", "1000", "--bookmark-max", "10000", "--json",
+	}, strings.NewReader(""), &stdout, &stderr)
+
+	require.Equal(t, 0, code, stderr.String())
+	assert.Equal(t, sdk.SearchTargetKeyword, got.Target)
+	assert.Equal(t, "2026-01-01", got.StartDate)
+	assert.Equal(t, "2026-01-31", got.EndDate)
+	if got.Filters.BookmarkMin == nil || *got.Filters.BookmarkMin != 1000 || got.Filters.BookmarkMax == nil || *got.Filters.BookmarkMax != 10000 {
+		t.Fatalf("bookmark filters = %+v", got.Filters)
+	}
+}
+
+func TestSearchRejectsInvalidDateAndBookmarkRangesBeforeSearch(t *testing.T) {
+	useTempPaths(t)
+	calls := 0
+	setTestSDKCommandClient(t, sdkCommandFake{search: func(_ context.Context, _ sdk.SearchIllustRequest) (*sdk.IllustListResult, error) {
+		calls++
+		return &sdk.IllustListResult{}, nil
+	}})
+
+	for _, args := range [][]string{
+		{"pixiv", "search", "miku", "--period", "week", "--start-date", "2026-01-01"},
+		{"pixiv", "search", "miku", "--start-date", "2026-02-30"},
+		{"pixiv", "search", "miku", "--start-date", "2026-02-01", "--end-date", "2026-01-31"},
+		{"pixiv", "search", "miku", "--bookmark-min", "10000", "--bookmark-max", "1000"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := Run(args, strings.NewReader(""), &stdout, &stderr)
+		require.NotZero(t, code, "args=%v", args)
+	}
+	assert.Zero(t, calls)
 }
 
 func TestListHelpDoesNotExposeInternalLimitSentinel(t *testing.T) {
@@ -635,6 +732,7 @@ func TestDownloadDelegatesOperationSnapshotAndFlagOverrides(t *testing.T) {
 	ctx := context.WithValue(context.Background(), contextKey("download"), "same-context")
 	client := &sdkCommandFake{}
 	var gotClientRequest application.SDKClientRequest
+	var downloadRequests []application.DownloadRequest
 	setTestDownloadCommandServices(t, func(request application.SDKClientRequest) (application.SDKClient, error) {
 		gotClientRequest = request
 		return client, nil
@@ -644,9 +742,10 @@ func TestDownloadDelegatesOperationSnapshotAndFlagOverrides(t *testing.T) {
 		require.Equal(t, "flag-template", gotTemplate)
 		return downloadManagerFake{download: func(gotContext context.Context, request application.DownloadRequest) ([]application.DownloadedArtwork, error) {
 			require.Same(t, ctx, gotContext)
-			require.Equal(t, []int64{42, 84}, request.IllustIDs)
+			require.Len(t, request.IllustIDs, 1)
+			downloadRequests = append(downloadRequests, request)
 			return []application.DownloadedArtwork{{
-				IllustID: 42,
+				IllustID: request.IllustIDs[0],
 				Title:    "work",
 				Author:   "artist",
 				Files:    []application.DownloadedFile{{Path: "/flag/path/42.jpg"}},
@@ -669,7 +768,45 @@ func TestDownloadDelegatesOperationSnapshotAndFlagOverrides(t *testing.T) {
 	require.Equal(t, "http://flag-proxy", *gotClientRequest.HTTPSProxyOverride)
 	require.Equal(t, int64(9), gotClientRequest.UserID)
 	require.Equal(t, "refresh", gotClientRequest.RefreshToken)
-	require.Equal(t, "downloaded 42 \"work\" by artist\n  /flag/path/42.jpg\n", stdout.String())
+	require.Equal(t, []int64{42, 84}, []int64{downloadRequests[0].IllustIDs[0], downloadRequests[1].IllustIDs[0]})
+	assert.Contains(t, stdout.String(), "downloaded 42 \"work\" by artist\n  /flag/path/42.jpg\n")
+	assert.Contains(t, stdout.String(), "downloaded 84 \"work\" by artist\n  /flag/path/42.jpg\n")
+}
+
+func TestDownloadAcceptsArtworkAndUserURLsAndPrintsReportJSON(t *testing.T) {
+	useTempPaths(t)
+	client := sdkCommandFake{artworks: func(_ context.Context, request sdk.UserArtworksRequest) (*sdk.IllustListResult, error) {
+		switch request.Type {
+		case sdk.IllustTypeIllust:
+			return &sdk.IllustListResult{Illusts: []sdk.Illust{{ID: 2, Type: "illust"}}}, nil
+		case sdk.IllustTypeManga:
+			return &sdk.IllustListResult{Illusts: []sdk.Illust{{ID: 3, Type: "manga"}}}, nil
+		case sdk.IllustTypeUgoira:
+			return &sdk.IllustListResult{Illusts: []sdk.Illust{{ID: 4, Type: "ugoira"}}}, nil
+		default:
+			return nil, errors.New("unexpected type")
+		}
+	}}
+	var requests []application.DownloadRequest
+	setTestDownloadCommandServices(t, func(application.SDKClientRequest) (application.SDKClient, error) {
+		return client, nil
+	}, config.RuntimeConfig{}, func(application.DownloadClient, string, string) (application.DownloadManager, error) {
+		return downloadManagerFake{download: func(_ context.Context, request application.DownloadRequest) ([]application.DownloadedArtwork, error) {
+			requests = append(requests, request)
+			id := request.IllustIDs[0]
+			return []application.DownloadedArtwork{{
+				IllustID: id, Title: "work", Author: "artist", Type: "illust",
+				Files: []application.DownloadedFile{{Path: fmt.Sprintf("/downloads/%d.jpg", id), Page: 1}},
+			}}, nil
+		}}, nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"pixiv", "download", "https://www.pixiv.net/artworks/1", "https://www.pixiv.net/en/users/7/artworks", "--json"}, strings.NewReader(""), &stdout, &stderr)
+
+	require.Equal(t, 0, code, stderr.String())
+	require.Equal(t, []int64{1, 2, 3, 4}, []int64{requests[0].IllustIDs[0], requests[1].IllustIDs[0], requests[2].IllustIDs[0], requests[3].IllustIDs[0]})
+	assert.JSONEq(t, `{"items":[{"url":"https://www.pixiv.net/artworks/1","illust_id":1,"title":"work","author":"artist","type":"illust","files":[{"path":"/downloads/1.jpg","page":1}]},{"url":"https://www.pixiv.net/artworks/2","illust_id":2,"title":"work","author":"artist","type":"illust","files":[{"path":"/downloads/2.jpg","page":1}]},{"url":"https://www.pixiv.net/artworks/3","illust_id":3,"title":"work","author":"artist","type":"illust","files":[{"path":"/downloads/3.jpg","page":1}]},{"url":"https://www.pixiv.net/artworks/4","illust_id":4,"title":"work","author":"artist","type":"illust","files":[{"path":"/downloads/4.jpg","page":1}]}],"failures":[]}`, stdout.String())
 }
 
 func TestDownloadDelegatesRuntimePathAndTemplateWithoutFlags(t *testing.T) {
@@ -723,11 +860,11 @@ func TestDownloadReportsManagerFailure(t *testing.T) {
 	code := Run([]string{"pixiv", "download", "42"}, strings.NewReader(""), &stdout, &stderr)
 
 	require.NotZero(t, code)
-	require.Empty(t, stdout.String())
-	require.Contains(t, stderr.String(), want.Error())
+	require.Contains(t, stdout.String(), "failed https://www.pixiv.net/artworks/42: "+want.Error())
+	require.Contains(t, stderr.String(), "download completed with 1 failures")
 }
 
-func TestDownloadPreservesJSONOutputShape(t *testing.T) {
+func TestDownloadJSONUsesReportShape(t *testing.T) {
 	useTempPaths(t)
 	setTestDownloadCommandServices(t, func(application.SDKClientRequest) (application.SDKClient, error) {
 		return &sdkCommandFake{}, nil
@@ -747,7 +884,7 @@ func TestDownloadPreservesJSONOutputShape(t *testing.T) {
 	code := Run([]string{"pixiv", "download", "42", "--json"}, strings.NewReader(""), &stdout, &stderr)
 
 	require.Equal(t, 0, code, stderr.String())
-	require.JSONEq(t, `[{"IllustID":42,"Title":"work","Author":"artist","Type":"illust","Files":[{"Path":"/downloads/42.jpg","Page":2}]}]`, stdout.String())
+	require.JSONEq(t, `{"items":[{"url":"https://www.pixiv.net/artworks/42","illust_id":42,"title":"work","author":"artist","type":"illust","files":[{"path":"/downloads/42.jpg","page":2}]}],"failures":[]}`, stdout.String())
 }
 
 func TestDownloadRejectsInvalidPagesAndQuality(t *testing.T) {

--- a/internal/mcpserver/download_tools.go
+++ b/internal/mcpserver/download_tools.go
@@ -31,27 +31,37 @@ func (a *App) setDownloadPath(ctx context.Context, _ *mcp.CallToolRequest, in se
 }
 
 type downloadIn struct {
-	IllustID  int64   `json:"illust_id,omitempty" jsonschema:"single artwork ID to download"`
-	IllustIDs []int64 `json:"illust_ids,omitempty" jsonschema:"artwork IDs to download"`
-	Pages     string  `json:"pages,omitempty" jsonschema:"1-based page selection, e.g. 1,3-5; default all pages"`
-	Quality   string  `json:"quality,omitempty" jsonschema:"static image quality: original, regular, small, thumb, mini"`
+	IllustID  int64    `json:"illust_id,omitempty" jsonschema:"single artwork ID to download"`
+	IllustIDs []int64  `json:"illust_ids,omitempty" jsonschema:"artwork IDs to download"`
+	URLs      []string `json:"urls,omitempty" jsonschema:"Pixiv artwork or user artworks URLs to download"`
+	Pages     string   `json:"pages,omitempty" jsonschema:"1-based page selection, e.g. 1,3-5; default all pages"`
+	Quality   string   `json:"quality,omitempty" jsonschema:"static image quality: original, regular, small, thumb, mini"`
 	// Delivery 仅保留 local_path 兼容字段；image_content 已移除。
 	Delivery string `json:"delivery,omitempty" jsonschema:"delivery mode: local_path only"`
 }
 
 type downloadOut struct {
-	Delivery string            `json:"delivery"`
-	Items    []downloadItemOut `json:"items"`
-	Files    []downloadFileOut `json:"files"`
-	Text     string            `json:"text"`
+	Delivery string               `json:"delivery"`
+	Items    []downloadItemOut    `json:"items"`
+	Failures []downloadFailureOut `json:"failures"`
+	Files    []downloadFileOut    `json:"files"`
+	Text     string               `json:"text"`
 }
 
 type downloadItemOut struct {
+	URL      string            `json:"url"`
 	IllustID int64             `json:"illust_id"`
 	Title    string            `json:"title"`
 	Author   string            `json:"author"`
 	Type     string            `json:"type"`
 	Files    []downloadFileOut `json:"files"`
+}
+
+type downloadFailureOut struct {
+	URL      string `json:"url"`
+	IllustID int64  `json:"illust_id"`
+	Type     string `json:"type"`
+	Message  string `json:"message"`
 }
 
 type downloadFileOut struct {
@@ -70,12 +80,9 @@ const (
 )
 
 func (a *App) download(ctx context.Context, _ *mcp.CallToolRequest, in downloadIn) (*mcp.CallToolResult, downloadOut, error) {
-	ids := append([]int64(nil), in.IllustIDs...)
-	if in.IllustID > 0 {
-		ids = append(ids, in.IllustID)
-	}
-	if len(ids) == 0 {
-		return emptyDownloadError(ctx, errLegacyValidation, deliveryLocalPath, "Error: provide either illust_id (single ID) or illust_ids (list of IDs).")
+	targets, err := parseDownloadReferences(in)
+	if err != nil {
+		return emptyDownloadError(ctx, errLegacyValidation, deliveryLocalPath, "Error: "+err.Error())
 	}
 	delivery, errText := normalizeDelivery(in.Delivery)
 	if errText != "" {
@@ -85,16 +92,75 @@ func (a *App) download(ctx context.Context, _ *mcp.CallToolRequest, in downloadI
 	if err != nil {
 		return emptyDownloadError(ctx, err, delivery, "Error: "+err.Error())
 	}
-	artworks, err := a.downloadArtworks(ctx, ids, nil, pages, quality)
+	report, err := a.downloadTargets(ctx, targets, pages, quality)
 	if err != nil {
 		return emptyDownloadError(ctx, err, delivery, "Download failed: "+err.Error())
 	}
-	out, err := buildDownloadOut(delivery, artworks)
+	out, err := buildDownloadReportOut(delivery, report)
 	if err != nil {
 		return emptyDownloadError(ctx, err, delivery, "Could not build the download result: "+err.Error())
 	}
 	// MCP 下载只返回本地 path/file_uri/mime_type/页号/大小，不再内嵌 ImageContent。
-	return downloadResult(out), out, nil
+	result := downloadResult(out)
+	if len(out.Failures) > 0 {
+		result.IsError = true
+		recordToolError(ctx, errors.New("download completed with failures"))
+	}
+	return result, out, nil
+}
+
+// parseDownloadReferences 保持旧 ID 字段的顺序，并把 URL 按数组顺序追加；MCP 多字段
+// 本身没有跨字段顺序，调用方需要精确交错顺序时使用 CLI positional targets。
+func parseDownloadReferences(in downloadIn) ([]sdk.Reference, error) {
+	targets := make([]sdk.Reference, 0, len(in.IllustIDs)+len(in.URLs)+1)
+	for _, id := range in.IllustIDs {
+		targets = append(targets, sdk.Reference{Kind: sdk.ReferenceKindArtwork, ID: id})
+	}
+	if in.IllustID > 0 {
+		targets = append(targets, sdk.Reference{Kind: sdk.ReferenceKindArtwork, ID: in.IllustID})
+	}
+	for _, raw := range in.URLs {
+		target, err := sdk.ParseReference(raw)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, target)
+	}
+	if len(targets) == 0 {
+		return nil, errors.New("provide either illust_id (single ID) or illust_ids (list of IDs).")
+	}
+	return targets, nil
+}
+
+func (a *App) downloadTargets(ctx context.Context, targets []sdk.Reference, pages []int, quality application.DownloadQuality) (application.DownloadReport, error) {
+	// 旧嵌入构造器没有 SDK runtime，只保留纯 ID 的既有下载路径；URL/作者展开必须
+	// 经 public SDK operation 执行，不能伪造匿名或 Cookie 路径。
+	if a.newDownloads == nil && a.sdk.NewClient == nil {
+		ids := make([]int64, 0, len(targets))
+		for _, target := range targets {
+			if target.Kind != sdk.ReferenceKindArtwork {
+				return application.DownloadReport{}, errors.New("downloading a user URL requires an authenticated Pixiv SDK operation")
+			}
+			ids = append(ids, target.ID)
+		}
+		artworks, err := a.downloads.Download(ctx, application.DownloadRequest{IllustIDs: ids, Pages: pages, Quality: quality})
+		if err != nil {
+			return application.DownloadReport{}, err
+		}
+		return application.DownloadReport{Items: artworks, Failures: []application.DownloadFailure{}}, nil
+	}
+	client, release, err := a.openSDKOperation(ctx)
+	if err != nil {
+		return application.DownloadReport{}, err
+	}
+	defer release()
+	service := application.DownloadService{NewManager: func(_ application.DownloadClient, _, _ string) (application.DownloadManager, error) {
+		if a.newDownloads != nil {
+			return a.newDownloads(client), nil
+		}
+		return a.downloads, nil
+	}}
+	return service.DownloadTargets(ctx, client, targets, application.DownloadRequest{Pages: pages, Quality: quality})
 }
 
 func (a *App) downloadArtworks(ctx context.Context, ids []int64, client application.SDKClient, pages []int, quality application.DownloadQuality) ([]download.DownloadedArtwork, error) {
@@ -142,6 +208,7 @@ func emptyDownloadResult(delivery, text string) (*mcp.CallToolResult, downloadOu
 	out := downloadOut{
 		Delivery: delivery,
 		Items:    []downloadItemOut{},
+		Failures: []downloadFailureOut{},
 		Files:    []downloadFileOut{},
 		Text:     text,
 	}
@@ -163,10 +230,11 @@ func normalizeDelivery(value string) (string, string) {
 }
 
 func buildDownloadOut(delivery string, artworks []download.DownloadedArtwork) (downloadOut, error) {
-	out := downloadOut{Delivery: delivery, Items: []downloadItemOut{}, Files: []downloadFileOut{}}
+	out := downloadOut{Delivery: delivery, Items: []downloadItemOut{}, Failures: []downloadFailureOut{}, Files: []downloadFileOut{}}
 	lines := []string{fmt.Sprintf("Download completed; delivery: %s.", delivery)}
 	for _, artwork := range artworks {
 		item := downloadItemOut{
+			URL:      sdk.Reference{Kind: sdk.ReferenceKindArtwork, ID: artwork.IllustID}.URL(),
 			IllustID: artwork.IllustID,
 			Title:    artwork.Title,
 			Author:   artwork.Author,
@@ -197,6 +265,20 @@ func buildDownloadOut(delivery string, artworks []download.DownloadedArtwork) (d
 		out.Items = append(out.Items, item)
 	}
 	out.Text = strings.Join(lines, "\n")
+	return out, nil
+}
+
+func buildDownloadReportOut(delivery string, report application.DownloadReport) (downloadOut, error) {
+	out, err := buildDownloadOut(delivery, report.Items)
+	if err != nil {
+		return downloadOut{}, err
+	}
+	for _, failure := range report.Failures {
+		out.Failures = append(out.Failures, downloadFailureOut{
+			URL: failure.URL, IllustID: failure.IllustID, Type: failure.Type, Message: failure.Message,
+		})
+		out.Text += fmt.Sprintf("\nFailed %s: %s", failure.URL, failure.Message)
+	}
 	return out, nil
 }
 

--- a/internal/mcpserver/legacy_observability_test.go
+++ b/internal/mcpserver/legacy_observability_test.go
@@ -45,14 +45,14 @@ func TestLegacySearchFailurePreservesWireResultAndLogsTypedError(t *testing.T) {
 	defer session.Close()
 
 	result := callTool(t, session, "search_illust", map[string]any{"word": queryCanary})
-	if result.IsError {
-		t.Fatalf("legacy search failure changed isError: %+v", result)
+	if !result.IsError {
+		t.Fatalf("structured search failure must set isError: %+v", result)
 	}
-	wantOut := textOut{Text: typedErr.Error()}
-	var gotOut textOut
+	wantText := "Error: " + typedErr.Error()
+	var gotOut illustQueryOut
 	decodeStructured(t, result, &gotOut)
-	if gotOut != wantOut {
-		t.Fatalf("structured output=%+v, want %+v", gotOut, wantOut)
+	if len(gotOut.Items) != 0 || gotOut.Text != wantText {
+		t.Fatalf("structured output=%+v, want empty items and %q", gotOut, wantText)
 	}
 	if len(result.Content) != 1 {
 		t.Fatalf("content len=%d, want 1", len(result.Content))
@@ -61,12 +61,8 @@ func TestLegacySearchFailurePreservesWireResultAndLogsTypedError(t *testing.T) {
 	if !ok {
 		t.Fatalf("content[0]=%T, want *mcp.TextContent", result.Content[0])
 	}
-	var contentOut textOut
-	if err := json.Unmarshal([]byte(textContent.Text), &contentOut); err != nil {
-		t.Fatalf("decode text content %q: %v", textContent.Text, err)
-	}
-	if contentOut != wantOut {
-		t.Fatalf("text content=%+v, want %+v", contentOut, wantOut)
+	if textContent.Text != wantText {
+		t.Fatalf("text content=%q, want %q", textContent.Text, wantText)
 	}
 
 	event := findOperationEvent(t, logs.String(), "search_illust")
@@ -119,14 +115,14 @@ func TestLegacySearchFailureRejectsHostileTypedLogMetadataWithoutChangingWire(t 
 	defer session.Close()
 
 	result := callTool(t, session, "search_illust", map[string]any{"word": "ordinary-query"})
-	if result.IsError {
-		t.Fatalf("legacy search failure changed isError: %+v", result)
+	if !result.IsError {
+		t.Fatalf("structured search failure must set isError: %+v", result)
 	}
-	wantOut := textOut{Text: typedErr.Error()}
-	var gotOut textOut
+	wantText := "Error: " + typedErr.Error()
+	var gotOut illustQueryOut
 	decodeStructured(t, result, &gotOut)
-	if gotOut != wantOut {
-		t.Fatalf("structured output=%+v, want %+v", gotOut, wantOut)
+	if len(gotOut.Items) != 0 || gotOut.Text != wantText {
+		t.Fatalf("structured output=%+v, want empty items and %q", gotOut, wantText)
 	}
 	if len(result.Content) != 1 {
 		t.Fatalf("content len=%d, want 1", len(result.Content))
@@ -135,12 +131,8 @@ func TestLegacySearchFailureRejectsHostileTypedLogMetadataWithoutChangingWire(t 
 	if !ok {
 		t.Fatalf("content[0]=%T, want *mcp.TextContent", result.Content[0])
 	}
-	var contentOut textOut
-	if err := json.Unmarshal([]byte(textContent.Text), &contentOut); err != nil {
-		t.Fatalf("decode text content %q: %v", textContent.Text, err)
-	}
-	if contentOut != wantOut {
-		t.Fatalf("text content=%+v, want %+v", contentOut, wantOut)
+	if textContent.Text != wantText {
+		t.Fatalf("text content=%q, want %q", textContent.Text, wantText)
 	}
 
 	event := findOperationEvent(t, logs.String(), "search_illust")

--- a/internal/mcpserver/legacy_tools.go
+++ b/internal/mcpserver/legacy_tools.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/FlanChanXwO/pixiv-cli/internal/application"
 	sdk "github.com/FlanChanXwO/pixiv-cli/pixiv"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -19,6 +21,8 @@ type searchIllustIn struct {
 	SearchTarget string `json:"search_target,omitempty"`
 	Sort         string `json:"sort,omitempty"`
 	Duration     string `json:"duration,omitempty"`
+	StartDate    string `json:"start_date,omitempty"`
+	EndDate      string `json:"end_date,omitempty"`
 	Page         *int   `json:"page,omitempty"`
 	Limit        *int   `json:"limit,omitempty"`
 	Rating       string `json:"rating,omitempty"`
@@ -27,6 +31,8 @@ type searchIllustIn struct {
 	AspectRatio  string `json:"aspect_ratio,omitempty"`
 	Resolution   string `json:"resolution,omitempty"`
 	Tool         string `json:"tool,omitempty"`
+	BookmarkMin  *int   `json:"bookmark_min,omitempty"`
+	BookmarkMax  *int   `json:"bookmark_max,omitempty"`
 }
 
 // searchIllustInputSchema 显式发布稳定筛选枚举。go-sdk 会在解码 handler 输入前
@@ -46,9 +52,11 @@ func searchIllustInputSchema() map[string]any {
 		"required":             []string{"word"},
 		"properties": map[string]any{
 			"word":          stringProperty("Illustration search keyword."),
-			"search_target": stringProperty("Pixiv search target."),
+			"search_target": enumProperty("Pixiv search target.", "partial_match_for_tags", "exact_match_for_tags", "title_and_caption", "keyword"),
 			"sort":          stringProperty("Pixiv result order."),
-			"duration":      stringProperty("Pixiv search duration."),
+			"duration":      enumProperty("Pixiv quick date range; cannot be combined with start_date or end_date.", "within_last_day", "within_last_week", "within_last_month", "within_half_year", "within_year"),
+			"start_date":    map[string]any{"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$", "description": "Inclusive start date in YYYY-MM-DD; may be used with end_date."},
+			"end_date":      map[string]any{"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$", "description": "Inclusive end date in YYYY-MM-DD; may be used with start_date."},
 			"page":          map[string]any{"type": "integer", "description": "1-based logical page; requires a positive limit."},
 			"limit":         map[string]any{"type": "integer", "description": "Maximum logical results; 0 returns all; omit for one logical batch."},
 			"rating":        enumProperty("Artwork age rating filter.", "all", "sfw", "r18", "r18g", "mature"),
@@ -57,6 +65,8 @@ func searchIllustInputSchema() map[string]any {
 			"aspect_ratio":  enumProperty("Artwork aspect ratio filter.", "all", "landscape", "portrait", "square"),
 			"resolution":    enumProperty("Artwork resolution tier filter.", "all", "high", "medium", "low"),
 			"tool":          stringProperty("Exact Pixiv drawing tool name from search_illust_options."),
+			"bookmark_min":  map[string]any{"type": "integer", "minimum": 0, "description": "Inclusive minimum public bookmark count; requires App OAuth."},
+			"bookmark_max":  map[string]any{"type": "integer", "minimum": 0, "description": "Inclusive maximum public bookmark count; requires App OAuth."},
 		},
 	}
 }
@@ -217,12 +227,38 @@ func (a *App) searchIllustOptionsError(ctx context.Context, err error) (*mcp.Cal
 	return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: "Error: " + err.Error()}}}, searchIllustOptionsOut{Tools: []string{}, Text: "Error: " + err.Error()}, nil
 }
 
-func (a *App) searchIllust(ctx context.Context, _ *mcp.CallToolRequest, in searchIllustIn) (*mcp.CallToolResult, textOut, error) {
+// illustQueryOut 统一旧读取 tool 的 machine-readable 作品结果，并保留文本摘要兼容客户端。
+type illustQueryOut struct {
+	Items      []sdk.Illust  `json:"items"`
+	Pagination paginationOut `json:"pagination"`
+	Text       string        `json:"text"`
+}
+
+func illustQueryResult(out illustQueryOut, isError bool) *mcp.CallToolResult {
+	return &mcp.CallToolResult{IsError: isError, Content: []mcp.Content{&mcp.TextContent{Text: out.Text}}}
+}
+
+func (a *App) illustQueryError(ctx context.Context, err error) (*mcp.CallToolResult, illustQueryOut, error) {
+	recordToolError(ctx, err)
+	out := illustQueryOut{Items: []sdk.Illust{}, Pagination: paginationOut{Page: 1}, Text: "Error: " + err.Error()}
+	return illustQueryResult(out, true), out, nil
+}
+
+func (a *App) searchIllust(ctx context.Context, _ *mcp.CallToolRequest, in searchIllustIn) (*mcp.CallToolResult, illustQueryOut, error) {
 	if in.SearchTarget == "" {
 		in.SearchTarget = string(sdk.SearchTargetPartialMatchForTags)
 	}
 	if in.Sort == "" {
 		in.Sort = string(sdk.SortModeDateDesc)
+	}
+	// 官方 App 以日期边界而非 duration 表达半年和一年，先在本地展开，
+	// 使 MCP 与 CLI 的快捷日期语义保持一致。
+	if in.StartDate == "" && in.EndDate == "" {
+		if startDate, endDate, ok := application.SearchQuickDateRange(in.Duration, time.Now()); ok {
+			in.Duration = ""
+			in.StartDate = startDate
+			in.EndDate = endDate
+		}
 	}
 	word := in.Word
 	filters := sdk.SearchIllustFilters{
@@ -232,21 +268,26 @@ func (a *App) searchIllust(ctx context.Context, _ *mcp.CallToolRequest, in searc
 		AspectRatio: sdk.SearchAspectRatio(in.AspectRatio),
 		Resolution:  sdk.SearchResolution(in.Resolution),
 		Tool:        in.Tool,
+		BookmarkMin: in.BookmarkMin,
+		BookmarkMax: in.BookmarkMax,
+	}
+	if err := validateSearchIllustInput(in); err != nil {
+		return a.illustQueryError(ctx, err)
 	}
 	plan, err := searchIllustListPlan(in)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
 	client, release, err := a.openSDKOperation(ctx)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
 	defer release()
 	// 本地筛选（rating/AI）可能产生空上游批次；nextNonEmpty + CollectPages 共同保证
 	// 默认逻辑批、limit 填满与 page 逻辑分页都跳过连续空批。
-	items, _, err := collectPages(ctx, plan, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
+	items, more, err := collectPages(ctx, plan, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
 		return nextNonEmptySearchBatch(ctx, cursor, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
-			result, err := client.SearchIllust(ctx, sdk.SearchIllustRequest{Word: word, Target: sdk.SearchTarget(in.SearchTarget), Sort: sdk.SortMode(in.Sort), Duration: in.Duration, Cursor: cursor, Filters: filters})
+			result, err := client.SearchIllust(ctx, sdk.SearchIllustRequest{Word: word, Target: sdk.SearchTarget(in.SearchTarget), Sort: sdk.SortMode(in.Sort), Duration: in.Duration, StartDate: in.StartDate, EndDate: in.EndDate, Cursor: cursor, Filters: filters})
 			if err != nil {
 				return nil, "", err
 			}
@@ -254,13 +295,37 @@ func (a *App) searchIllust(ctx context.Context, _ *mcp.CallToolRequest, in searc
 		})
 	})
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
+	out := illustQueryOut{Items: normalizeIllusts(items), Pagination: listPagination(plan, in.Limit, len(items), more)}
 	if len(items) == 0 {
-		return toolText(fmt.Sprintf("No illustrations found for %q.", word))
+		out.Text = fmt.Sprintf("No illustrations found for %q.", word)
+		return illustQueryResult(out, false), out, nil
 	}
 	displayOffset := plan.skip
-	return toolText(fmt.Sprintf("Found %d illustrations for %q:\n\n%s", len(items), word, formatIllusts(items, displayOffset, false)))
+	out.Text = fmt.Sprintf("Found %d illustrations for %q:\n\n%s", len(items), word, formatIllusts(items, displayOffset, false))
+	return illustQueryResult(out, false), out, nil
+}
+
+func validateSearchIllustInput(in searchIllustIn) error {
+	if in.Duration != "" && (in.StartDate != "" || in.EndDate != "") {
+		return errors.New("duration cannot be combined with start_date or end_date")
+	}
+	if in.StartDate != "" && !validMCPDate(in.StartDate) || in.EndDate != "" && !validMCPDate(in.EndDate) {
+		return errors.New("start_date and end_date must use YYYY-MM-DD")
+	}
+	if in.StartDate != "" && in.EndDate != "" && in.StartDate > in.EndDate {
+		return errors.New("start_date cannot be later than end_date")
+	}
+	if in.BookmarkMin != nil && in.BookmarkMax != nil && *in.BookmarkMin > *in.BookmarkMax {
+		return errors.New("bookmark_min cannot be greater than bookmark_max")
+	}
+	return nil
+}
+
+func validMCPDate(value string) bool {
+	parsed, err := time.Parse("2006-01-02", value)
+	return err == nil && parsed.Format("2006-01-02") == value
 }
 
 // searchIllustListPlan 将 search_illust 的 page/limit 归一为 mcpListPlan。
@@ -289,22 +354,80 @@ func nextNonEmptySearchBatch[T any](ctx context.Context, cursor sdk.Cursor, fetc
 	}
 }
 
-type illustIDIn struct {
-	IllustID int64 `json:"illust_id"`
+type illustReferenceIn struct {
+	IllustID int64  `json:"illust_id,omitempty" jsonschema:"artwork ID; provide exactly one of illust_id or url"`
+	URL      string `json:"url,omitempty" jsonschema:"supported Pixiv artwork URL; provide exactly one of illust_id or url"`
 }
 
-func (a *App) illustDetail(ctx context.Context, _ *mcp.CallToolRequest, in illustIDIn) (*mcp.CallToolResult, textOut, error) {
+type illustDetailOut struct {
+	Illust any    `json:"illust"`
+	Text   string `json:"text"`
+}
+
+func illustDetailResult(out illustDetailOut, isError bool) *mcp.CallToolResult {
+	return &mcp.CallToolResult{IsError: isError, Content: []mcp.Content{&mcp.TextContent{Text: out.Text}}}
+}
+
+func (a *App) illustDetail(ctx context.Context, _ *mcp.CallToolRequest, in illustReferenceIn) (*mcp.CallToolResult, illustDetailOut, error) {
+	id, err := resolveMCPArtworkReference(in)
+	if err != nil {
+		return a.illustDetailError(ctx, err)
+	}
 	client, release, err := a.openSDKOperation(ctx)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustDetailError(ctx, err)
 	}
 	defer release()
-	result, err := client.IllustDetail(ctx, in.IllustID)
+	result, err := client.IllustDetail(ctx, id)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustDetailError(ctx, err)
 	}
-	body, _ := json.MarshalIndent(result.Illust, "", "  ")
-	return toolText(string(body))
+	if result == nil {
+		return a.illustDetailError(ctx, errors.New("pixiv sdk returned an empty illustration detail result"))
+	}
+	illust := normalizeIllusts([]sdk.Illust{result.Illust})[0]
+	structured, err := illustStructuredContent(illust)
+	if err != nil {
+		return a.illustDetailError(ctx, err)
+	}
+	out := illustDetailOut{Illust: structured, Text: formatIllust(illust)}
+	return illustDetailResult(out, false), out, nil
+}
+
+// illustStructuredContent 通过 JSON 边界生成与 public SDK 模型同形的 object。
+// 单个嵌套 SDK struct 的推导 schema 无法表达可选数组字段，因此仅在 MCP adapter
+// 以 object 发布；客户端仍得到完整、规范化的作品字段。
+func illustStructuredContent(illust sdk.Illust) (map[string]any, error) {
+	raw, err := json.Marshal(illust)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func resolveMCPArtworkReference(in illustReferenceIn) (int64, error) {
+	hasID := in.IllustID != 0
+	hasURL := strings.TrimSpace(in.URL) != ""
+	if hasID == hasURL {
+		return 0, errors.New("provide exactly one of illust_id or url")
+	}
+	if hasID {
+		if in.IllustID <= 0 {
+			return 0, errors.New("illust_id must be a positive integer")
+		}
+		return in.IllustID, nil
+	}
+	return sdk.ParseArtworkReference(in.URL)
+}
+
+func (a *App) illustDetailError(ctx context.Context, err error) (*mcp.CallToolResult, illustDetailOut, error) {
+	recordToolError(ctx, err)
+	out := illustDetailOut{Text: "Error: " + err.Error()}
+	return illustDetailResult(out, true), out, nil
 }
 
 type relatedIn struct {
@@ -312,17 +435,17 @@ type relatedIn struct {
 	pageLimitIn
 }
 
-func (a *App) illustRelated(ctx context.Context, _ *mcp.CallToolRequest, in relatedIn) (*mcp.CallToolResult, textOut, error) {
+func (a *App) illustRelated(ctx context.Context, _ *mcp.CallToolRequest, in relatedIn) (*mcp.CallToolResult, illustQueryOut, error) {
 	plan, err := parseMCPListPlan(in.pageLimitIn)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
 	client, release, err := a.openSDKOperation(ctx)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
 	defer release()
-	items, _, err := collectPages(ctx, plan, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
+	items, more, err := collectPages(ctx, plan, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
 		result, err := client.IllustRelated(ctx, sdk.IllustRelatedRequest{IllustID: in.IllustID, Cursor: cursor})
 		if err != nil {
 			return nil, "", err
@@ -330,12 +453,15 @@ func (a *App) illustRelated(ctx context.Context, _ *mcp.CallToolRequest, in rela
 		return result.Illusts, result.NextCursor, nil
 	})
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
+	out := illustQueryOut{Items: normalizeIllusts(items), Pagination: listPagination(plan, in.Limit, len(items), more)}
 	if len(items) == 0 {
-		return toolText(fmt.Sprintf("No related illustrations found for artwork %d.", in.IllustID))
+		out.Text = fmt.Sprintf("No related illustrations found for artwork %d.", in.IllustID)
+		return illustQueryResult(out, false), out, nil
 	}
-	return toolText(fmt.Sprintf("Found %d related illustrations:\n\n%s", len(items), formatIllusts(items, plan.skip, false)))
+	out.Text = fmt.Sprintf("Found %d related illustrations:\n\n%s", len(items), formatIllusts(items, plan.skip, false))
+	return illustQueryResult(out, false), out, nil
 }
 
 type rankingIn struct {
@@ -370,20 +496,20 @@ func rankingLabel(mode string) string {
 	return mode + " ranking"
 }
 
-func (a *App) illustRanking(ctx context.Context, _ *mcp.CallToolRequest, in rankingIn) (*mcp.CallToolResult, textOut, error) {
+func (a *App) illustRanking(ctx context.Context, _ *mcp.CallToolRequest, in rankingIn) (*mcp.CallToolResult, illustQueryOut, error) {
 	if in.Mode == "" {
 		in.Mode = string(sdk.RankingModeDay)
 	}
 	plan, err := parseMCPListPlan(in.pageLimitIn)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
 	client, release, err := a.openSDKOperation(ctx)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
 	defer release()
-	items, _, err := collectPages(ctx, plan, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
+	items, more, err := collectPages(ctx, plan, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
 		result, err := client.IllustRanking(ctx, sdk.IllustRankingRequest{Mode: sdk.RankingMode(in.Mode), Date: in.Date, Cursor: cursor})
 		if err != nil {
 			return nil, "", err
@@ -391,12 +517,15 @@ func (a *App) illustRanking(ctx context.Context, _ *mcp.CallToolRequest, in rank
 		return result.Illusts, result.NextCursor, nil
 	})
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
+	out := illustQueryOut{Items: normalizeIllusts(items), Pagination: listPagination(plan, in.Limit, len(items), more)}
 	if len(items) == 0 {
-		return toolText(fmt.Sprintf("No ranking results found for mode %q.", in.Mode))
+		out.Text = fmt.Sprintf("No ranking results found for mode %q.", in.Mode)
+		return illustQueryResult(out, false), out, nil
 	}
-	return toolText(fmt.Sprintf("%s:\n\n%s", rankingLabel(in.Mode), formatIllusts(items, plan.skip, true)))
+	out.Text = fmt.Sprintf("%s:\n\n%s", rankingLabel(in.Mode), formatIllusts(items, plan.skip, true))
+	return illustQueryResult(out, false), out, nil
 }
 
 type searchUserIn struct {
@@ -485,17 +614,17 @@ type recommendedLegacyIn struct {
 	pageLimitIn
 }
 
-func (a *App) illustRecommended(ctx context.Context, _ *mcp.CallToolRequest, in recommendedLegacyIn) (*mcp.CallToolResult, textOut, error) {
+func (a *App) illustRecommended(ctx context.Context, _ *mcp.CallToolRequest, in recommendedLegacyIn) (*mcp.CallToolResult, illustQueryOut, error) {
 	plan, err := parseMCPListPlan(in.pageLimitIn)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
 	client, release, err := a.openSDKOperation(ctx)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
 	defer release()
-	items, _, err := collectPages(ctx, plan, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
+	items, more, err := collectPages(ctx, plan, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
 		result, err := client.IllustRecommended(ctx, sdk.IllustRecommendedRequest{Cursor: cursor})
 		if err != nil {
 			return nil, "", err
@@ -503,36 +632,77 @@ func (a *App) illustRecommended(ctx context.Context, _ *mcp.CallToolRequest, in 
 		return result.Illusts, result.NextCursor, nil
 	})
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
+	out := illustQueryOut{Items: normalizeIllusts(items), Pagination: listPagination(plan, in.Limit, len(items), more)}
 	if len(items) == 0 {
-		return toolText("No recommendations are available.")
+		out.Text = "No recommendations are available."
+		return illustQueryResult(out, false), out, nil
 	}
-	return toolText(fmt.Sprintf("Recommended %d illustrations:\n\n%s", len(items), formatIllusts(items, plan.skip, false)))
+	out.Text = fmt.Sprintf("Recommended %d illustrations:\n\n%s", len(items), formatIllusts(items, plan.skip, false))
+	return illustQueryResult(out, false), out, nil
 }
 
-func (a *App) trendingTags(ctx context.Context, _ *mcp.CallToolRequest, _ emptyIn) (*mcp.CallToolResult, textOut, error) {
+type trendingTagsOut struct {
+	Tags []any  `json:"tags"`
+	Text string `json:"text"`
+}
+
+func trendingTagsResult(out trendingTagsOut, isError bool) *mcp.CallToolResult {
+	return &mcp.CallToolResult{IsError: isError, Content: []mcp.Content{&mcp.TextContent{Text: out.Text}}}
+}
+
+func (a *App) trendingTags(ctx context.Context, _ *mcp.CallToolRequest, _ emptyIn) (*mcp.CallToolResult, trendingTagsOut, error) {
 	client, release, err := a.openSDKOperation(ctx)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.trendingTagsError(ctx, err)
 	}
 	defer release()
 	result, err := client.TrendingTagsIllust(ctx)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.trendingTagsError(ctx, err)
 	}
+	if result == nil {
+		return a.trendingTagsError(ctx, errors.New("pixiv sdk returned an empty trending tags result"))
+	}
+	out := trendingTagsOut{Tags: []any{}}
 	if len(result.TrendTags) == 0 {
-		return toolText("Could not retrieve trending tags.")
+		out.Text = "Could not retrieve trending tags."
+		return trendingTagsResult(out, false), out, nil
 	}
 	lines := make([]string, 0, len(result.TrendTags))
 	for _, tag := range result.TrendTags {
+		structured, err := trendTagStructured(tag)
+		if err != nil {
+			return a.trendingTagsError(ctx, err)
+		}
+		out.Tags = append(out.Tags, structured)
 		translated := tag.TranslatedName
 		if translated == "" {
 			translated = "none"
 		}
 		lines = append(lines, fmt.Sprintf("- %s (translation: %s)", tag.Tag, translated))
 	}
-	return toolText("Trending tags:\n" + strings.Join(lines, "\n"))
+	out.Text = "Trending tags:\n" + strings.Join(lines, "\n")
+	return trendingTagsResult(out, false), out, nil
+}
+
+func trendTagStructured(tag sdk.TrendTag) (map[string]any, error) {
+	raw, err := json.Marshal(tag)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (a *App) trendingTagsError(ctx context.Context, err error) (*mcp.CallToolResult, trendingTagsOut, error) {
+	recordToolError(ctx, err)
+	out := trendingTagsOut{Tags: []any{}, Text: "Error: " + err.Error()}
+	return trendingTagsResult(out, true), out, nil
 }
 
 type followIn struct {
@@ -540,20 +710,20 @@ type followIn struct {
 	pageLimitIn
 }
 
-func (a *App) illustFollow(ctx context.Context, _ *mcp.CallToolRequest, in followIn) (*mcp.CallToolResult, textOut, error) {
+func (a *App) illustFollow(ctx context.Context, _ *mcp.CallToolRequest, in followIn) (*mcp.CallToolResult, illustQueryOut, error) {
 	if in.Restrict == "" {
 		in.Restrict = string(sdk.RestrictPublic)
 	}
 	plan, err := parseMCPListPlan(in.pageLimitIn)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
 	client, release, err := a.openSDKOperation(ctx)
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
 	defer release()
-	items, _, err := collectPages(ctx, plan, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
+	items, more, err := collectPages(ctx, plan, func(ctx context.Context, cursor sdk.Cursor) ([]sdk.Illust, sdk.Cursor, error) {
 		result, err := client.FollowingIllusts(ctx, sdk.FollowingIllustsRequest{Restrict: sdk.Restrict(in.Restrict), Cursor: cursor})
 		if err != nil {
 			return nil, "", err
@@ -561,10 +731,13 @@ func (a *App) illustFollow(ctx context.Context, _ *mcp.CallToolRequest, in follo
 		return result.Illusts, result.NextCursor, nil
 	})
 	if err != nil {
-		return toolTextError(ctx, err, err.Error())
+		return a.illustQueryError(ctx, err)
 	}
+	out := illustQueryOut{Items: normalizeIllusts(items), Pagination: listPagination(plan, in.Limit, len(items), more)}
 	if len(items) == 0 {
-		return toolText("No new artworks from followed users.")
+		out.Text = "No new artworks from followed users."
+		return illustQueryResult(out, false), out, nil
 	}
-	return toolText(fmt.Sprintf("Found %d new artworks from followed users:\n\n%s", len(items), formatIllusts(items, plan.skip, false)))
+	out.Text = fmt.Sprintf("Found %d new artworks from followed users:\n\n%s", len(items), formatIllusts(items, plan.skip, false))
+	return illustQueryResult(out, false), out, nil
 }

--- a/internal/mcpserver/registration.go
+++ b/internal/mcpserver/registration.go
@@ -4,14 +4,14 @@ import "github.com/modelcontextprotocol/go-sdk/mcp"
 
 func (a *App) register(server *mcp.Server) {
 	addTool(a, server, &mcp.Tool{Name: "set_download_path", Description: "Set the default local save location for images and animations."}, a.setDownloadPath)
-	addTool(a, server, &mcp.Tool{Name: "download", Description: "Download one or more artworks by ID with intelligent storage rules."}, a.download)
+	addTool(a, server, &mcp.Tool{Name: "download", Description: "Download artwork IDs or supported Pixiv artwork/user URLs with intelligent storage rules."}, a.download)
 	addTool(a, server, &mcp.Tool{Name: "refresh_token", Description: "Manually refresh Pixiv API token when encountering authentication errors."}, a.refreshToken)
 	addTool(a, server, &mcp.Tool{Name: "set_refresh_token", Description: "Set or update the Pixiv refresh token for authentication."}, a.setRefreshToken)
 	addTool(a, server, &mcp.Tool{Name: "download_random_from_recommendation", Description: "Download random artworks from recommendations."}, a.downloadRandom)
 	addTool(a, server, &mcp.Tool{Name: "search_illust", Description: "Search for illustrations using keywords with filters.", InputSchema: searchIllustInputSchema()}, a.searchIllust)
 	addTool(a, server, &mcp.Tool{Name: "search_novel", Description: "Search for novels using keywords with supported filters.", InputSchema: searchNovelInputSchema()}, a.searchNovel)
 	addTool(a, server, &mcp.Tool{Name: "search_illust_options", Description: "List drawing tools available for an authenticated illustration search."}, a.searchIllustOptions)
-	addTool(a, server, &mcp.Tool{Name: "illust_detail", Description: "Get detailed information about a specific artwork."}, a.illustDetail)
+	addTool(a, server, &mcp.Tool{Name: "illust_detail", Description: "Get detailed information from exactly one artwork ID or supported Pixiv URL."}, a.illustDetail)
 	addTool(a, server, &mcp.Tool{Name: "illust_related", Description: "Find artworks related to a specific illustration."}, a.illustRelated)
 	addTool(a, server, &mcp.Tool{Name: "illust_ranking", Description: "Browse Pixiv rankings."}, a.illustRanking)
 	addTool(a, server, &mcp.Tool{Name: "search_user", Description: "Search for users/artists on Pixiv."}, a.searchUser)

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -80,7 +80,7 @@ func TestServerListsExpectedTools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal search_illust input schema: %v", err)
 	}
-	for _, field := range []string{"rating", "content_type", "ai_mode", "aspect_ratio", "resolution", "tool"} {
+	for _, field := range []string{"search_target", "duration", "start_date", "end_date", "rating", "content_type", "ai_mode", "aspect_ratio", "resolution", "tool", "bookmark_min", "bookmark_max"} {
 		if !strings.Contains(string(schema), `"`+field+`"`) {
 			t.Fatalf("search_illust input schema missing %q: %s", field, schema)
 		}
@@ -95,11 +95,13 @@ func TestServerListsExpectedTools(t *testing.T) {
 		t.Fatalf("decode search_illust input schema: %v", err)
 	}
 	wantEnums := map[string][]string{
-		"rating":       {"all", "sfw", "r18", "r18g", "mature"},
-		"content_type": {"all", "illust-and-ugoira", "illust", "manga", "ugoira"},
-		"ai_mode":      {"all", "exclude", "only"},
-		"aspect_ratio": {"all", "landscape", "portrait", "square"},
-		"resolution":   {"all", "high", "medium", "low"},
+		"search_target": {"partial_match_for_tags", "exact_match_for_tags", "title_and_caption", "keyword"},
+		"duration":      {"within_last_day", "within_last_week", "within_last_month", "within_half_year", "within_year"},
+		"rating":        {"all", "sfw", "r18", "r18g", "mature"},
+		"content_type":  {"all", "illust-and-ugoira", "illust", "manga", "ugoira"},
+		"ai_mode":       {"all", "exclude", "only"},
+		"aspect_ratio":  {"all", "landscape", "portrait", "square"},
+		"resolution":    {"all", "high", "medium", "low"},
 	}
 	for field, enum := range wantEnums {
 		property := schemaObject.Properties[field]
@@ -107,8 +109,10 @@ func TestServerListsExpectedTools(t *testing.T) {
 			t.Fatalf("search_illust schema %s = %+v, want enum %v with description", field, property, enum)
 		}
 	}
-	if schemaObject.Properties["tool"].Description == "" {
-		t.Fatal("search_illust schema tool is missing description")
+	for _, field := range []string{"start_date", "end_date", "tool", "bookmark_min", "bookmark_max"} {
+		if schemaObject.Properties[field].Description == "" {
+			t.Fatalf("search_illust schema %s is missing description", field)
+		}
 	}
 	novelSchema, err := json.Marshal(searchNovelTool.InputSchema)
 	if err != nil {
@@ -131,8 +135,10 @@ func TestSearchIllustMapsStableFiltersToPublicSDK(t *testing.T) {
 	defer closeSession()
 
 	result := callTool(t, session, "search_illust", map[string]any{
-		"word": "cat", "rating": "r18g", "content_type": "manga", "ai_mode": "only",
+		"word": "cat", "search_target": "keyword", "start_date": "2026-01-01", "end_date": "2026-01-31",
+		"rating": "r18g", "content_type": "manga", "ai_mode": "only",
 		"aspect_ratio": "landscape", "resolution": "high", "tool": "CLIP STUDIO PAINT",
+		"bookmark_min": 1000, "bookmark_max": 10000,
 	})
 	if result.IsError {
 		t.Fatalf("search_illust returned MCP error: %+v", result)
@@ -142,8 +148,47 @@ func TestSearchIllustMapsStableFiltersToPublicSDK(t *testing.T) {
 		AIMode: sdk.SearchAIModeOnly, AspectRatio: sdk.SearchAspectRatioLandscape,
 		Resolution: sdk.SearchResolutionHigh, Tool: "CLIP STUDIO PAINT",
 	}
-	if got.Word != "cat" || got.Filters != want {
+	if got.Word != "cat" || got.Target != sdk.SearchTargetKeyword || got.StartDate != "2026-01-01" || got.EndDate != "2026-01-31" ||
+		got.Filters.Rating != want.Rating || got.Filters.ContentType != want.ContentType || got.Filters.AIMode != want.AIMode ||
+		got.Filters.AspectRatio != want.AspectRatio || got.Filters.Resolution != want.Resolution || got.Filters.Tool != want.Tool ||
+		got.Filters.BookmarkMin == nil || *got.Filters.BookmarkMin != 1000 || got.Filters.BookmarkMax == nil || *got.Filters.BookmarkMax != 10000 {
 		t.Fatalf("SearchIllust request = %+v, want word=cat filters=%+v", got, want)
+	}
+}
+
+func TestSearchIllustExpandsLongQuickDurationToTokyoDateRange(t *testing.T) {
+	var got sdk.SearchIllustRequest
+	client := &fakeSDKClient{searchIllust: func(_ context.Context, request sdk.SearchIllustRequest) (*sdk.IllustListResult, error) {
+		got = request
+		return &sdk.IllustListResult{}, nil
+	}}
+	session, closeSession := newSDKTestSession(t, client)
+	defer closeSession()
+
+	result := callTool(t, session, "search_illust", map[string]any{"word": "cat", "duration": "within_half_year"})
+	if result.IsError {
+		t.Fatalf("search_illust returned MCP error: %+v", result)
+	}
+	if got.Duration != "" || got.StartDate == "" || got.EndDate == "" || got.StartDate > got.EndDate {
+		t.Fatalf("SearchIllust request = %+v, want date range without duration", got)
+	}
+}
+
+func TestSearchIllustReturnsTypedItemsAlongsideText(t *testing.T) {
+	client := &fakeSDKClient{searchIllust: func(_ context.Context, _ sdk.SearchIllustRequest) (*sdk.IllustListResult, error) {
+		return &sdk.IllustListResult{Illusts: []sdk.Illust{testSDKIllust(42, "work", 7)}}, nil
+	}}
+	session, closeSession := newSDKTestSession(t, client)
+	defer closeSession()
+
+	result := callTool(t, session, "search_illust", map[string]any{"word": "cat"})
+	if result.IsError {
+		t.Fatalf("search_illust returned MCP error: %+v", result)
+	}
+	var out illustQueryOut
+	decodeStructured(t, result, &out)
+	if len(out.Items) != 1 || out.Items[0].ID != 42 || out.Pagination.Returned != 1 || !strings.Contains(out.Text, "Found 1 illustrations") {
+		t.Fatalf("search_illust output = %+v", out)
 	}
 }
 
@@ -175,6 +220,45 @@ func TestSearchNovelMapsStableFiltersAndReturnsStructuredOutput(t *testing.T) {
 	}
 	if len(out.Novels) != 1 || out.Novels[0].ID != 12 || out.Pagination.Returned != 1 || !strings.Contains(out.Text, "Found 1 novels") {
 		t.Fatalf("search_novel output = %+v", out)
+	}
+}
+
+func TestIllustDetailAcceptsArtworkURLAndReturnsStructuredOutput(t *testing.T) {
+	var gotID int64
+	client := &fakeSDKClient{illustDetail: func(_ context.Context, id int64) (*sdk.IllustDetail, error) {
+		gotID = id
+		return &sdk.IllustDetail{Illust: testSDKIllust(id, "work", 7)}, nil
+	}}
+	session, closeSession := newSDKTestSession(t, client)
+	defer closeSession()
+
+	result := callTool(t, session, "illust_detail", map[string]any{"url": "https://www.pixiv.net/en/artworks/42?from=share"})
+	if result.IsError {
+		t.Fatalf("illust_detail returned MCP error: %+v", result)
+	}
+	var out struct {
+		Illust sdk.Illust `json:"illust"`
+		Text   string     `json:"text"`
+	}
+	decodeStructured(t, result, &out)
+	if gotID != 42 || out.Illust.ID != 42 || !strings.Contains(out.Text, "ID: 42") {
+		t.Fatalf("illust_detail id=%d output=%+v, want URL-resolved artwork", gotID, out)
+	}
+
+	invalid := callTool(t, session, "illust_detail", map[string]any{"illust_id": 42, "url": "https://www.pixiv.net/artworks/42"})
+	if !invalid.IsError {
+		t.Fatalf("illust_detail accepted both references: %+v", invalid)
+	}
+	text, ok := invalid.Content[0].(*mcp.TextContent)
+	if !ok || !strings.Contains(text.Text, "exactly one") || strings.Contains(text.Text, "https://") {
+		t.Fatalf("illust_detail invalid input = %#v", invalid.Content)
+	}
+}
+
+func TestNormalizeIllustsProvidesStructuredEmptyArrays(t *testing.T) {
+	got := normalizeIllusts([]sdk.Illust{{ID: 1}})[0]
+	if got.Tools == nil || got.Tags == nil || got.MetaPages == nil {
+		t.Fatalf("normalizeIllusts() = %#v, want non-nil structured arrays", got)
 	}
 }
 
@@ -389,6 +473,8 @@ func TestSearchIllustSchemaRejectsInvalidEnumsBeforeOpeningSDK(t *testing.T) {
 		{"ai_mode", "maybe"},
 		{"aspect_ratio", "wide"},
 		{"resolution", "ultra"},
+		{"search_target", "tags_and_caption"},
+		{"duration", "within_last_decade"},
 	} {
 		t.Run(test.field, func(t *testing.T) {
 			factoryCalls := 0
@@ -403,6 +489,27 @@ func TestSearchIllustSchemaRejectsInvalidEnumsBeforeOpeningSDK(t *testing.T) {
 				t.Fatalf("invalid %s=%q error=%v factoryCalls=%d", test.field, test.value, err, factoryCalls)
 			}
 		})
+	}
+}
+
+func TestSearchIllustRejectsInvalidCrossFieldFiltersBeforeOpeningSDK(t *testing.T) {
+	for _, arguments := range []map[string]any{
+		{"word": "cat", "duration": "within_last_week", "start_date": "2026-01-01"},
+		{"word": "cat", "start_date": "2026-02-30"},
+		{"word": "cat", "start_date": "2026-02-01", "end_date": "2026-01-31"},
+		{"word": "cat", "bookmark_min": 10000, "bookmark_max": 1000},
+	} {
+		factoryCalls := 0
+		service := application.SDKService{NewClient: func(application.SDKClientRequest) (application.SDKClient, error) {
+			factoryCalls++
+			return &fakeSDKClient{}, nil
+		}}
+		session, closeSession := newSDKTestSessionWithService(t, &fakeAPI{}, service)
+		result := callTool(t, session, "search_illust", arguments)
+		closeSession()
+		if !result.IsError || factoryCalls != 0 {
+			t.Fatalf("arguments=%v result=%+v factoryCalls=%d", arguments, result, factoryCalls)
+		}
 	}
 }
 
@@ -1031,6 +1138,58 @@ func TestDownloadDefaultsToLocalPathResult(t *testing.T) {
 	}
 	if !slices.Equal(downloads.downloadIDs, []int64{42, 42, -1}) {
 		t.Fatalf("download IDs = %v", downloads.downloadIDs)
+	}
+}
+
+func TestDownloadAcceptsArtworkURLsAndIncludesCanonicalURL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "42.jpg")
+	if err := os.WriteFile(path, []byte("jpeg"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	downloads := &fakeDownloads{artworks: []download.DownloadedArtwork{{
+		IllustID: 42, Title: "work", Author: "artist", Type: "illust", Files: []download.DownloadedFile{{Path: path, Page: 1}},
+	}}}
+	session, closeSession := newSDKDownloadTestSession(t, &fakeSDKClient{}, downloads)
+	defer closeSession()
+
+	result := callTool(t, session, "download", map[string]any{"urls": []string{"https://www.pixiv.net/en/artworks/42?from=share"}})
+	if result.IsError {
+		t.Fatalf("download result=%+v", result)
+	}
+	out := decodeDownloadOut(t, result)
+	if len(out.Items) != 1 || out.Items[0].URL != "https://www.pixiv.net/artworks/42" || downloads.downloadIDs[0] != 42 {
+		t.Fatalf("download output=%+v ids=%v", out, downloads.downloadIDs)
+	}
+}
+
+func TestDownloadUserURLExpandsEveryVisualArtworkType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "42.jpg")
+	if err := os.WriteFile(path, []byte("jpeg"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	downloads := &fakeDownloads{artworks: []download.DownloadedArtwork{{
+		IllustID: 42, Title: "work", Author: "artist", Type: "illust", Files: []download.DownloadedFile{{Path: path}},
+	}}}
+	client := &fakeSDKClient{artworks: []sdk.Illust{testSDKIllust(42, "work", 7)}}
+	session, closeSession := newSDKDownloadTestSession(t, client, downloads)
+	defer closeSession()
+
+	result := callTool(t, session, "download", map[string]any{"urls": []string{"https://www.pixiv.net/users/7/artworks"}})
+	if result.IsError {
+		t.Fatalf("download result=%+v", result)
+	}
+	out := decodeDownloadOut(t, result)
+	if len(out.Items) != 3 || downloads.downloadCalls != 3 {
+		t.Fatalf("download output=%+v calls=%d", out, downloads.downloadCalls)
+	}
+	gotTypes := make([]sdk.IllustType, 0, len(client.artworksRequests))
+	for _, request := range client.artworksRequests {
+		gotTypes = append(gotTypes, request.Type)
+	}
+	if !slices.Equal(gotTypes, []sdk.IllustType{sdk.IllustTypeIllust, sdk.IllustTypeManga, sdk.IllustTypeUgoira}) {
+		t.Fatalf("UserArtworks types = %v", gotTypes)
 	}
 }
 
@@ -2521,6 +2680,27 @@ func newTestSession(t *testing.T, downloads *fakeDownloads) (*mcp.ClientSession,
 
 func newSDKTestSession(t *testing.T, sdkClient application.SDKClient) (*mcp.ClientSession, func()) {
 	return newSDKTestSessionWithAPI(t, &fakeAPI{}, sdkClient)
+}
+
+func newSDKDownloadTestSession(t *testing.T, sdkClient application.SDKClient, downloads DownloadManager) (*mcp.ClientSession, func()) {
+	t.Helper()
+	service := application.SDKService{NewClient: func(application.SDKClientRequest) (application.SDKClient, error) {
+		return sdkClient, nil
+	}}
+	server := NewWithSDKDownloadFactory(downloads, func(application.SDKClient) DownloadManager { return downloads }, slog.New(slog.NewTextHandler(io.Discard, nil)), service, application.SDKClientRequest{})
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = server.Run(ctx, serverTransport) }()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("connect: %v", err)
+	}
+	return session, func() {
+		session.Close()
+		cancel()
+	}
 }
 
 func newSDKTestSessionWithAPI(t *testing.T, api any, sdkClient application.SDKClient) (*mcp.ClientSession, func()) {

--- a/internal/pixiv/appapi/client.go
+++ b/internal/pixiv/appapi/client.go
@@ -98,9 +98,11 @@ func New(opts ...Option) *Client {
 	return c
 }
 
-func (c *Client) SearchIllust(ctx context.Context, word, target, sort, duration string, offset int, filterOptions ...model.SearchIllustFilters) (*model.IllustList, error) {
+func (c *Client) SearchIllust(ctx context.Context, word, target, sort, duration, startDate, endDate string, offset int, filterOptions ...model.SearchIllustFilters) (*model.IllustList, error) {
 	q := url.Values{"word": {word}, "search_target": {target}, "sort": {sort}}
 	setOptional(q, "duration", duration)
+	setOptional(q, "start_date", startDate)
+	setOptional(q, "end_date", endDate)
 	if len(filterOptions) > 0 {
 		setSearchIllustFilters(q, filterOptions[0])
 	}
@@ -134,6 +136,12 @@ func setSearchIllustFilters(query url.Values, filters model.SearchIllustFilters)
 		query.Set("content_type", filters.ContentType)
 	}
 	setOptional(query, "tool", filters.Tool)
+	if filters.BookmarkMin != nil {
+		query.Set("bookmark_num_min", strconv.Itoa(*filters.BookmarkMin))
+	}
+	if filters.BookmarkMax != nil {
+		query.Set("bookmark_num_max", strconv.Itoa(*filters.BookmarkMax))
+	}
 	switch filters.Resolution {
 	case "high":
 		query.Set("width_min", "3000")

--- a/internal/pixiv/appapi/client_test.go
+++ b/internal/pixiv/appapi/client_test.go
@@ -88,12 +88,40 @@ func TestSearchIllustMapsNormalizedFiltersToAppQuery(t *testing.T) {
 			}))
 			defer api.Close()
 			_, err := New(WithBaseURL(api.URL), WithHTTPClient(api.Client()), WithAccessToken("access")).SearchIllust(
-				context.Background(), "miku", "partial_match_for_tags", "date_desc", "", 0, test.filters,
+				context.Background(), "miku", "partial_match_for_tags", "date_desc", "", "", "", 0, test.filters,
 			)
 			if err != nil {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestSearchIllustMapsDateAndBookmarkBoundsToAppQuery(t *testing.T) {
+	minimum, maximum := 1000, 10000
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		want := map[string]string{
+			"search_target":    "keyword",
+			"start_date":       "2026-01-01",
+			"end_date":         "2026-01-31",
+			"bookmark_num_min": "1000",
+			"bookmark_num_max": "10000",
+		}
+		for key, value := range want {
+			if got := query.Get(key); got != value {
+				t.Fatalf("%s = %q, want %q; query=%v", key, got, value, query)
+			}
+		}
+		_, _ = w.Write([]byte(`{"illusts":[]}`))
+	}))
+	defer api.Close()
+	_, err := New(WithBaseURL(api.URL), WithHTTPClient(api.Client()), WithAccessToken("access")).SearchIllust(
+		context.Background(), "miku", "keyword", "date_desc", "", "2026-01-01", "2026-01-31", 0,
+		model.SearchIllustFilters{BookmarkMin: &minimum, BookmarkMax: &maximum},
+	)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/pixiv/model/enums.go
+++ b/internal/pixiv/model/enums.go
@@ -59,4 +59,6 @@ type SearchIllustFilters struct {
 	AspectRatio string
 	Resolution  string
 	Tool        string
+	BookmarkMin *int
+	BookmarkMax *int
 }

--- a/internal/pixiv/webapi/client.go
+++ b/internal/pixiv/webapi/client.go
@@ -52,7 +52,7 @@ func New(opts ...Option) *Client {
 	return c
 }
 
-func (c *Client) SearchIllust(ctx context.Context, word, target, sort, duration string, offset int, filterOptions ...model.SearchIllustFilters) (*model.IllustList, error) {
+func (c *Client) SearchIllust(ctx context.Context, word, target, sort, duration, startDate, endDate string, offset int, filterOptions ...model.SearchIllustFilters) (*model.IllustList, error) {
 	pagination, err := checkedWebPagination(offset, artworkSearchPageSize)
 	if err != nil {
 		return nil, err
@@ -74,6 +74,8 @@ func (c *Client) SearchIllust(ctx context.Context, word, target, sort, duration 
 	if err := setDuration(q, duration); err != nil {
 		return nil, err
 	}
+	setOptionalSearchValue(q, "scd", startDate)
+	setOptionalSearchValue(q, "ecd", endDate)
 	var out ajaxEnvelope[webSearchBody]
 	if err := c.getJSON(ctx, webSearchIllustPath(word, filters.ContentType, q), q, &out); err != nil {
 		return nil, err
@@ -239,7 +241,7 @@ func (c *Client) IllustRanking(ctx context.Context, mode, date string, offset in
 }
 
 func (c *Client) SearchUser(ctx context.Context, word string, offset int) (*model.UserPreviewList, error) {
-	illusts, err := c.SearchIllust(ctx, word, string(model.SearchTargetPartialMatchForTags), string(model.SortModeDateDesc), "", offset)
+	illusts, err := c.SearchIllust(ctx, word, string(model.SearchTargetPartialMatchForTags), string(model.SortModeDateDesc), "", "", "", offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pixiv/webapi/client_test.go
+++ b/internal/pixiv/webapi/client_test.go
@@ -32,8 +32,23 @@ func TestSearchIllustPreservesCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := New(WithWebBase("https://example.invalid")).SearchIllust(ctx, "cat", "partial_match_for_tags", "date_desc", "", 0)
+	_, err := New(WithWebBase("https://example.invalid")).SearchIllust(ctx, "cat", "partial_match_for_tags", "date_desc", "", "", "", 0)
 	require.True(t, errors.Is(err, context.Canceled), "error = %v", err)
+}
+
+func TestSearchIllustMapsExplicitDateRangeToWebQuery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		query := request.URL.Query()
+		if query.Get("scd") != "2026-01-01" || query.Get("ecd") != "2026-01-31" {
+			t.Fatalf("query=%v", query)
+		}
+		_, _ = w.Write([]byte(`{"error":false,"body":{"illustManga":{"data":[]}}}`))
+	}))
+	defer server.Close()
+	_, err := New(WithHTTPClient(server.Client()), WithWebBase(server.URL)).SearchIllust(
+		context.Background(), "miku", "partial_match_for_tags", "date_desc", "", "2026-01-01", "2026-01-31", 0,
+	)
+	require.NoError(t, err)
 }
 
 func TestWebEndpointPageSizesDefineWirePageBoundaries(t *testing.T) {
@@ -74,7 +89,7 @@ func TestWebEndpointPageSizesDefineWirePageBoundaries(t *testing.T) {
 				_, err := client.IllustRanking(context.Background(), "day", "", test.offset)
 				require.NoError(t, err)
 			} else {
-				_, err := client.SearchIllust(context.Background(), "miku", "partial_match_for_tags", "date_desc", "", test.offset)
+				_, err := client.SearchIllust(context.Background(), "miku", "partial_match_for_tags", "date_desc", "", "", "", test.offset)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, test.wantPage, gotPage)
@@ -122,7 +137,7 @@ func TestClientContinuationPreservesTotalsBeyondInt32(t *testing.T) {
 			name: "search illust",
 			body: `{"error":false,"body":{"illustManga":{"total":2147483648,"data":[{"id":"1","userId":"10"}]}}}`,
 			call: func(client *Client) (int, bool, error) {
-				result, err := client.SearchIllust(context.Background(), "miku", "partial_match_for_tags", "date_desc", "", 0)
+				result, err := client.SearchIllust(context.Background(), "miku", "partial_match_for_tags", "date_desc", "", "", "", 0)
 				if err != nil {
 					return 0, false, err
 				}
@@ -216,7 +231,7 @@ func TestWebContinuationUsesPageStartForInPageOffsets(t *testing.T) {
 				require.NoError(t, err)
 				gotNext = result.ContinuationExists
 			default:
-				result, err := client.SearchIllust(context.Background(), "miku", "partial_match_for_tags", "date_desc", "", test.offset)
+				result, err := client.SearchIllust(context.Background(), "miku", "partial_match_for_tags", "date_desc", "", "", "", test.offset)
 				require.NoError(t, err)
 				gotNext = result.ContinuationExists
 			}
@@ -237,7 +252,7 @@ func TestClientSearchIllustMapsWebArtworkResults(t *testing.T) {
 	defer server.Close()
 
 	client := New(WithHTTPClient(server.Client()), WithWebBase(server.URL))
-	result, err := client.SearchIllust(context.Background(), "初音ミク", "partial_match_for_tags", "date_desc", "", 0)
+	result, err := client.SearchIllust(context.Background(), "初音ミク", "partial_match_for_tags", "date_desc", "", "", "", 0)
 
 	require.NoError(t, err)
 	require.Len(t, result.Illusts, 1)
@@ -288,7 +303,7 @@ func TestClientSearchIllustMapsContentTypeAndFilterVariants(t *testing.T) {
 			}))
 			defer server.Close()
 			_, err := New(WithWebBase(server.URL), WithHTTPClient(server.Client())).SearchIllust(
-				context.Background(), "miku", "partial_match_for_tags", "date_desc", "", 0, test.filters,
+				context.Background(), "miku", "partial_match_for_tags", "date_desc", "", "", "", 0, test.filters,
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -305,7 +320,7 @@ func TestClientSearchIllustAppliesInPageOffset(t *testing.T) {
 	defer server.Close()
 
 	client := New(WithHTTPClient(server.Client()), WithWebBase(server.URL))
-	result, err := client.SearchIllust(context.Background(), "初音ミク", "partial_match_for_tags", "date_desc", "", 1)
+	result, err := client.SearchIllust(context.Background(), "初音ミク", "partial_match_for_tags", "date_desc", "", "", "", 1)
 
 	require.NoError(t, err)
 	require.Len(t, result.Illusts, 1)

--- a/internal/update/installer.go
+++ b/internal/update/installer.go
@@ -45,13 +45,14 @@ type ReleaseFileReplacer interface {
 // ReleaseInstallerOptions 允许生产组装与受控测试分别注入信任根和系统依赖。
 // TrustedKeys 只允许 Ed25519 公钥；私钥绝不能进入生产组装或此 API。
 type ReleaseInstallerOptions struct {
-	HTTPClient     *http.Client
-	TrustedKeys    map[string]ed25519.PublicKey
-	ExecutablePath func() (string, error)
-	GOOS           string
-	GOARCH         string
-	BinaryChecker  ReleaseBinaryChecker
-	Replacer       ReleaseFileReplacer
+	HTTPClient                 *http.Client
+	TrustedKeys                map[string]ed25519.PublicKey
+	ExecutablePath             func() (string, error)
+	GOOS                       string
+	GOARCH                     string
+	BinaryChecker              ReleaseBinaryChecker
+	Replacer                   ReleaseFileReplacer
+	EnablePublicReleaseSources bool
 }
 
 // NewReleaseInstaller 建立 Release 自更新器。未配置 trusted key 时仍返回实例，
@@ -85,7 +86,7 @@ func NewReleaseInstaller(options ReleaseInstallerOptions) ReleaseInstaller {
 	for keyID, publicKey := range options.TrustedKeys {
 		keys[keyID] = append(ed25519.PublicKey(nil), publicKey...)
 	}
-	return &releaseInstaller{
+	installer := &releaseInstaller{
 		httpClient:        httpClient,
 		trustedKeys:       keys,
 		executablePath:    executablePath,
@@ -95,6 +96,10 @@ func NewReleaseInstaller(options ReleaseInstallerOptions) ReleaseInstaller {
 		replacer:          replacer,
 		assetURLValidator: validateOfficialGitHubReleaseAssetURL,
 	}
+	if options.EnablePublicReleaseSources {
+		installer.sourceSelector = newDefaultReleaseSourceSelector(httpClient)
+	}
+	return installer
 }
 
 type releaseInstaller struct {
@@ -106,6 +111,7 @@ type releaseInstaller struct {
 	checker           ReleaseBinaryChecker
 	replacer          ReleaseFileReplacer
 	assetURLValidator func(Release, ReleaseAsset) error
+	sourceSelector    *releaseSourceSelector
 	// 下列 hook 仅供同包测试精确触发并观测取消边界；生产构造始终为 nil。
 	afterStagedCreate func()
 	afterStagedClose  func()
@@ -138,11 +144,15 @@ func (i *releaseInstaller) Install(ctx context.Context, release Release) (err er
 	if err := i.validateAssetURLs(release, assets); err != nil {
 		return err
 	}
-	checksums, err := i.download(ctx, assets.checksums)
+	assetSources, err := i.assetSources(ctx, assets.checksums)
+	if err != nil {
+		return err
+	}
+	checksums, err := i.download(ctx, assets.checksums, assetSources)
 	if err != nil {
 		return fmt.Errorf("download %s: %w", checksumsAssetName, err)
 	}
-	manifestBytes, err := i.download(ctx, assets.manifest)
+	manifestBytes, err := i.download(ctx, assets.manifest, assetSources)
 	if err != nil {
 		return fmt.Errorf("download %s: %w", manifestAssetName, err)
 	}
@@ -152,7 +162,7 @@ func (i *releaseInstaller) Install(ctx context.Context, release Release) (err er
 	if err := verifyArchiveChecksum(checksums, assets.archive.Name, nil); err != nil {
 		return err
 	}
-	archive, err := i.download(ctx, assets.archive)
+	archive, err := i.download(ctx, assets.archive, assetSources)
 	if err != nil {
 		return fmt.Errorf("download release archive %q: %w", assets.archive.Name, err)
 	}
@@ -354,8 +364,39 @@ func releaseBinaryName(goos string) string {
 	return "pixiv"
 }
 
-func (i *releaseInstaller) download(ctx context.Context, asset ReleaseAsset) ([]byte, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, asset.DownloadURL, nil)
+func (i *releaseInstaller) assetSources(ctx context.Context, probe ReleaseAsset) ([]releaseSource, error) {
+	if i.sourceSelector == nil {
+		return nil, nil
+	}
+	sources, err := i.sourceSelector.ordered(ctx, releaseSourceAsset, probe.DownloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("select source for release assets: %w", err)
+	}
+	return sources, nil
+}
+
+func (i *releaseInstaller) download(ctx context.Context, asset ReleaseAsset, sources []releaseSource) ([]byte, error) {
+	if len(sources) == 0 {
+		return i.downloadURL(ctx, asset, asset.DownloadURL)
+	}
+	errorsBySource := make([]error, 0, len(sources))
+	for _, source := range sources {
+		requestURL, err := source.assetURL(asset.DownloadURL)
+		if err != nil {
+			errorsBySource = append(errorsBySource, fmt.Errorf("release source %q: %w", source.id, err))
+			continue
+		}
+		body, err := i.downloadURL(ctx, asset, requestURL)
+		if err == nil {
+			return body, nil
+		}
+		errorsBySource = append(errorsBySource, fmt.Errorf("release source %q: %w", source.id, err))
+	}
+	return nil, fmt.Errorf("download asset %q from every release source: %w", asset.Name, errors.Join(errorsBySource...))
+}
+
+func (i *releaseInstaller) downloadURL(ctx context.Context, asset ReleaseAsset, requestURL string) ([]byte, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request for asset %q: %w", asset.Name, err)
 	}

--- a/internal/update/release_source_selector.go
+++ b/internal/update/release_source_selector.go
@@ -1,0 +1,158 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type releaseSourceKind string
+
+const (
+	releaseSourceAPI   releaseSourceKind = "GitHub Releases API"
+	releaseSourceAsset releaseSourceKind = "release asset"
+)
+
+// releaseSourceSelector 以同一个调用 context 并发探测内置传输路径；首个返回可用响应的
+// 候选即为本次首选。显式 update 不添加人为截止时间，自动检查沿用调用方已有的总截止时间。
+type releaseSourceSelector struct {
+	sources    []releaseSource
+	httpClient *http.Client
+}
+
+func newReleaseSourceSelector(sources []releaseSource, httpClient *http.Client) *releaseSourceSelector {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &releaseSourceSelector{sources: append([]releaseSource(nil), sources...), httpClient: httpClient}
+}
+
+func newDefaultReleaseSourceSelector(httpClient *http.Client) *releaseSourceSelector {
+	return newReleaseSourceSelector(defaultReleaseSources(), httpClient)
+}
+
+// ordered 返回首个通过探测的候选，随后按内置顺序附上尚未使用的同类候选，供下载失败时逐一
+// 尝试。候选只改写 canonical URL；后续签名、checksum 与 URL allowlist 仍在调用处执行。
+func (s *releaseSourceSelector) ordered(ctx context.Context, kind releaseSourceKind, canonicalURL string) ([]releaseSource, error) {
+	if s == nil {
+		return nil, fmt.Errorf("release source selector is nil")
+	}
+	if err := checkContext(ctx, "select release source"); err != nil {
+		return nil, err
+	}
+	candidates := s.candidates(kind)
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no release source supports %s", kind)
+	}
+
+	probeContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+	results := make(chan releaseSourceProbeResult, len(candidates))
+	for _, source := range candidates {
+		source := source
+		go func() {
+			err := s.probe(probeContext, source, kind, canonicalURL)
+			results <- releaseSourceProbeResult{source: source, err: err}
+		}()
+	}
+
+	errorsBySource := make([]error, 0, len(candidates))
+	for range candidates {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("select release source: %w", ctx.Err())
+		case result := <-results:
+			if result.err == nil {
+				return placeReleaseSourceFirst(result.source, candidates), nil
+			}
+			errorsBySource = append(errorsBySource, fmt.Errorf("release source %q: %w", result.source.id, result.err))
+		}
+	}
+	return nil, fmt.Errorf("no release source returned a valid %s response: %w", kind, errors.Join(errorsBySource...))
+}
+
+type releaseSourceProbeResult struct {
+	source releaseSource
+	err    error
+}
+
+func (s *releaseSourceSelector) candidates(kind releaseSourceKind) []releaseSource {
+	var candidates []releaseSource
+	for _, source := range s.sources {
+		supported := source.asset.raw != ""
+		if kind == releaseSourceAPI {
+			supported = source.api.raw != ""
+		}
+		if supported {
+			candidates = append(candidates, source)
+		}
+	}
+	return candidates
+}
+
+func (s *releaseSourceSelector) probe(ctx context.Context, source releaseSource, kind releaseSourceKind, canonicalURL string) error {
+	transformedURL, err := source.assetURL(canonicalURL)
+	if kind == releaseSourceAPI {
+		transformedURL, err = source.apiURL(canonicalURL)
+	}
+	if err != nil {
+		return err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, transformedURL, nil)
+	if err != nil {
+		return fmt.Errorf("create probe request: %w", err)
+	}
+	request.Header.Set("User-Agent", githubReleaseUserAgent)
+	response, err := s.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("request probe URL: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("probe URL returned HTTP %s", response.Status)
+	}
+	if kind != releaseSourceAPI {
+		_, err := io.Copy(io.Discard, response.Body)
+		if err != nil {
+			return fmt.Errorf("read probe response: %w", err)
+		}
+		return nil
+	}
+	var releases []githubRelease
+	decoder := json.NewDecoder(response.Body)
+	if err := decoder.Decode(&releases); err != nil {
+		return fmt.Errorf("decode GitHub Releases JSON: %w", err)
+	}
+	if releases == nil {
+		return fmt.Errorf("decode GitHub Releases JSON: expected an array")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("decode GitHub Releases JSON: contains more than one JSON value")
+		}
+		return fmt.Errorf("decode GitHub Releases JSON trailing data: %w", err)
+	}
+	return nil
+}
+
+func placeReleaseSourceFirst(first releaseSource, sources []releaseSource) []releaseSource {
+	ordered := make([]releaseSource, 0, len(sources))
+	ordered = append(ordered, first)
+	for _, source := range sources {
+		if source.id != first.id {
+			ordered = append(ordered, source)
+		}
+	}
+	return ordered
+}
+
+func firstReleaseSource(sources []releaseSource) *releaseSource {
+	if len(sources) == 0 {
+		return nil
+	}
+	return &sources[0]
+}

--- a/internal/update/release_sources.go
+++ b/internal/update/release_sources.go
@@ -1,0 +1,139 @@
+package update
+
+import (
+	_ "embed"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+const (
+	releaseSourceURLPlaceholder      = "{url}"
+	releaseSourceURLQueryPlaceholder = "{url_query}"
+)
+
+var releaseSourceIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*$`)
+
+//go:embed release_sources.txt
+var embeddedReleaseSources []byte
+
+// releaseSource 是一个版本内置的 GitHub Releases 传输路径。它只改变请求目的地，
+// 不改变版本选择、资产名称、签名或 checksum 的信任边界。
+type releaseSource struct {
+	id    string
+	api   releaseSourceTemplate
+	asset releaseSourceTemplate
+}
+
+type releaseSourceTemplate struct {
+	raw         string
+	placeholder string
+}
+
+func defaultReleaseSources() []releaseSource {
+	sources, err := parseReleaseSources(embeddedReleaseSources)
+	if err != nil {
+		panic(fmt.Sprintf("parse embedded release sources: %v", err))
+	}
+	return sources
+}
+
+func parseReleaseSources(body []byte) ([]releaseSource, error) {
+	var sources []releaseSource
+	seenIDs := make(map[string]struct{})
+	for lineNumber, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Split(line, "|")
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("release source line %d must have id, API template, and asset template", lineNumber+1)
+		}
+		id := strings.TrimSpace(fields[0])
+		if !releaseSourceIDPattern.MatchString(id) {
+			return nil, fmt.Errorf("release source line %d has invalid ID %q", lineNumber+1, id)
+		}
+		if _, duplicate := seenIDs[id]; duplicate {
+			return nil, fmt.Errorf("release source line %d repeats ID %q", lineNumber+1, id)
+		}
+		api, err := parseReleaseSourceTemplate(strings.TrimSpace(fields[1]))
+		if err != nil {
+			return nil, fmt.Errorf("release source line %d API template: %w", lineNumber+1, err)
+		}
+		asset, err := parseReleaseSourceTemplate(strings.TrimSpace(fields[2]))
+		if err != nil {
+			return nil, fmt.Errorf("release source line %d asset template: %w", lineNumber+1, err)
+		}
+		if asset.raw == "" {
+			return nil, fmt.Errorf("release source line %d must provide an asset template", lineNumber+1)
+		}
+		seenIDs[id] = struct{}{}
+		sources = append(sources, releaseSource{id: id, api: api, asset: asset})
+	}
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("release source list is empty")
+	}
+	return sources, nil
+}
+
+func parseReleaseSourceTemplate(value string) (releaseSourceTemplate, error) {
+	if value == "-" {
+		return releaseSourceTemplate{}, nil
+	}
+	placeholder := ""
+	for _, candidate := range []string{releaseSourceURLPlaceholder, releaseSourceURLQueryPlaceholder} {
+		count := strings.Count(value, candidate)
+		if count == 0 {
+			continue
+		}
+		if count != 1 || placeholder != "" {
+			return releaseSourceTemplate{}, fmt.Errorf("must contain exactly one URL placeholder")
+		}
+		placeholder = candidate
+	}
+	remaining := strings.Replace(value, placeholder, "", 1)
+	if placeholder == "" || strings.Contains(remaining, releaseSourceURLPlaceholder) || strings.Contains(remaining, releaseSourceURLQueryPlaceholder) {
+		return releaseSourceTemplate{}, fmt.Errorf("must contain exactly one URL placeholder")
+	}
+	template := releaseSourceTemplate{raw: value, placeholder: placeholder}
+	if _, err := template.apply("https://github.com/FlanChanXwO/pixiv-cli/releases"); err != nil {
+		return releaseSourceTemplate{}, err
+	}
+	return template, nil
+}
+
+func (source releaseSource) apiURL(canonical string) (string, error) {
+	if source.api.raw == "" {
+		return "", fmt.Errorf("release source %q does not support GitHub Releases API", source.id)
+	}
+	return source.api.apply(canonical)
+}
+
+func (source releaseSource) assetURL(canonical string) (string, error) {
+	return source.asset.apply(canonical)
+}
+
+func (template releaseSourceTemplate) apply(canonical string) (string, error) {
+	canonicalURL, err := url.Parse(canonical)
+	if err != nil {
+		return "", fmt.Errorf("parse canonical release URL: %w", err)
+	}
+	if canonicalURL.Scheme != "https" || canonicalURL.Host == "" || canonicalURL.User != nil || canonicalURL.Fragment != "" {
+		return "", fmt.Errorf("canonical release URL %q must be an absolute HTTPS URL without userinfo or fragment", canonical)
+	}
+	replacement := canonical
+	if template.placeholder == releaseSourceURLQueryPlaceholder {
+		replacement = url.QueryEscape(canonical)
+	}
+	value := strings.Replace(template.raw, template.placeholder, replacement, 1)
+	transformed, err := url.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("parse transformed release URL: %w", err)
+	}
+	if (transformed.Scheme != "http" && transformed.Scheme != "https") || transformed.Host == "" || transformed.User != nil || transformed.Fragment != "" {
+		return "", fmt.Errorf("transformed release URL %q must be an absolute HTTP(S) URL without userinfo or fragment", value)
+	}
+	return value, nil
+}

--- a/internal/update/release_sources.txt
+++ b/internal/update/release_sources.txt
@@ -1,0 +1,8 @@
+# id|github_releases_api_template|release_asset_template
+# {url} inserts the canonical HTTPS URL as a path-style proxy target.
+# {url_query} percent-encodes the complete canonical HTTPS URL for a query parameter.
+gh-proxy|https://gh-proxy.com/{url}|https://gh-proxy.com/{url}
+ghfast|-|https://ghfast.top/{url}
+gh-xmly|-|https://gh.xmly.dev/{url}
+github-boki|-|https://github.boki.moe/{url}
+github-direct|{url}|{url}

--- a/internal/update/release_sources_test.go
+++ b/internal/update/release_sources_test.go
@@ -1,0 +1,239 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseReleaseSourcesAcceptsPathAndQueryTemplates(t *testing.T) {
+	t.Parallel()
+
+	sources, err := parseReleaseSources([]byte("" +
+		"prefix|https://proxy.example/{url}|https://proxy.example/{url}\n" +
+		"query|https://proxy.example/api?target={url_query}|https://proxy.example/download?target={url_query}\n"))
+	if err != nil {
+		t.Fatalf("parseReleaseSources() error = %v", err)
+	}
+	if len(sources) != 2 {
+		t.Fatalf("source count = %d, want 2", len(sources))
+	}
+
+	canonical := "https://github.com/FlanChanXwO/pixiv-cli/releases/download/v1.2.3/checksums.txt?part=1"
+	if got, err := sources[0].assetURL(canonical); err != nil || got != "https://proxy.example/"+canonical {
+		t.Fatalf("prefix assetURL() = %q, %v", got, err)
+	}
+	if got, err := sources[1].assetURL(canonical); err != nil || got != "https://proxy.example/download?target=https%3A%2F%2Fgithub.com%2FFlanChanXwO%2Fpixiv-cli%2Freleases%2Fdownload%2Fv1.2.3%2Fchecksums.txt%3Fpart%3D1" {
+		t.Fatalf("query assetURL() = %q, %v", got, err)
+	}
+}
+
+func TestParseReleaseSourcesRejectsAmbiguousOrUnsafeEntries(t *testing.T) {
+	t.Parallel()
+
+	for name, content := range map[string]string{
+		"duplicate identifier": "a|{url}|{url}\na|{url}|{url}\n",
+		"both placeholders":    "a|https://proxy.example/{url}{url_query}|{url}\n",
+		"missing placeholder":  "a|https://proxy.example/api|{url}\n",
+		"invalid field count":  "a|{url}\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parseReleaseSources([]byte(content)); err == nil {
+				t.Fatal("parseReleaseSources() succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestReleaseSourceSelectorChoosesFastestValidAPIResponse(t *testing.T) {
+	t.Parallel()
+
+	slowStarted := make(chan struct{}, 1)
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		slowStarted <- struct{}{}
+		<-r.Context().Done()
+	}))
+	t.Cleanup(slow.Close)
+	fast := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-slowStarted:
+		case <-r.Context().Done():
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"tag_name":"v1.2.3","draft":false,"prerelease":false}]`)
+	}))
+	t.Cleanup(fast.Close)
+
+	sources := mustTestReleaseSources(t,
+		"slow|"+slow.URL+"?target={url_query}|"+slow.URL+"?target={url_query}",
+		"fast|"+fast.URL+"?target={url_query}|"+fast.URL+"?target={url_query}",
+	)
+	selector := newReleaseSourceSelector(sources, fast.Client())
+	ordered, err := selector.ordered(context.Background(), releaseSourceAPI, "https://api.github.com/repos/FlanChanXwO/pixiv-cli/releases")
+	if err != nil {
+		t.Fatalf("ordered() error = %v", err)
+	}
+	if got := ordered[0].id; got != "fast" {
+		t.Fatalf("first selected source = %q, want fast", got)
+	}
+}
+
+func TestReleaseSourceSelectorSkipsInvalidAPIResponse(t *testing.T) {
+	t.Parallel()
+
+	invalidDone := make(chan struct{}, 1)
+	invalid := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		invalidDone <- struct{}{}
+		fmt.Fprint(w, "not GitHub releases JSON")
+	}))
+	t.Cleanup(invalid.Close)
+	valid := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-invalidDone:
+		case <-r.Context().Done():
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[]`)
+	}))
+	t.Cleanup(valid.Close)
+
+	sources := mustTestReleaseSources(t,
+		"invalid|"+invalid.URL+"?target={url_query}|"+invalid.URL+"?target={url_query}",
+		"valid|"+valid.URL+"?target={url_query}|"+valid.URL+"?target={url_query}",
+	)
+	ordered, err := newReleaseSourceSelector(sources, valid.Client()).ordered(context.Background(), releaseSourceAPI, "https://api.github.com/repos/FlanChanXwO/pixiv-cli/releases")
+	if err != nil {
+		t.Fatalf("ordered() error = %v", err)
+	}
+	if got := ordered[0].id; got != "valid" {
+		t.Fatalf("first selected source = %q, want valid", got)
+	}
+}
+
+func TestReleaseSourceSelectorReturnsParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+	sources := mustTestReleaseSources(t, "blocked|"+server.URL+"?target={url_query}|"+server.URL+"?target={url_query}")
+	context, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := newReleaseSourceSelector(sources, server.Client()).ordered(context, releaseSourceAPI, "https://api.github.com/repos/FlanChanXwO/pixiv-cli/releases")
+	if !errors.Is(err, context.Err()) {
+		t.Fatalf("ordered() error = %v, want canceled context error", err)
+	}
+}
+
+func TestReleaseAssetDownloadRetriesRemainingSourcesAfterPreferredSourceFails(t *testing.T) {
+	t.Parallel()
+
+	const canonical = "https://github.com/FlanChanXwO/pixiv-cli/releases/download/v1.2.3/checksums.txt"
+	preferred := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusBadGateway)
+	}))
+	t.Cleanup(preferred.Close)
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "verified checksums")
+	}))
+	t.Cleanup(fallback.Close)
+
+	sources := mustTestReleaseSources(t,
+		"preferred|-|"+preferred.URL+"?target={url_query}",
+		"fallback|-|"+fallback.URL+"?target={url_query}",
+	)
+	installer := NewReleaseInstaller(ReleaseInstallerOptions{HTTPClient: preferred.Client()}).(*releaseInstaller)
+	body, err := installer.download(context.Background(), ReleaseAsset{Name: checksumsAssetName, DownloadURL: canonical}, sources)
+	if err != nil {
+		t.Fatalf("download() error = %v", err)
+	}
+	if got := string(body); got != "verified checksums" {
+		t.Fatalf("downloaded body = %q, want fallback body", got)
+	}
+}
+
+func TestReleaseAssetDownloadReportsEverySourceFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusBadGateway)
+	}))
+	t.Cleanup(server.Close)
+	sources := mustTestReleaseSources(t,
+		"first|-|"+server.URL+"?target={url_query}",
+		"second|-|"+server.URL+"?target={url_query}",
+	)
+	installer := NewReleaseInstaller(ReleaseInstallerOptions{HTTPClient: server.Client()}).(*releaseInstaller)
+	_, err := installer.download(context.Background(), ReleaseAsset{Name: checksumsAssetName, DownloadURL: "https://github.com/FlanChanXwO/pixiv-cli/releases/download/v1.2.3/checksums.txt"}, sources)
+	if err == nil {
+		t.Fatal("download() succeeded, want aggregate source failure")
+	}
+	for _, sourceID := range []string{"first", "second"} {
+		if !strings.Contains(err.Error(), sourceID) {
+			t.Fatalf("download() error = %v, missing source %q", err, sourceID)
+		}
+	}
+}
+
+func TestGitHubReleaseClientUsesSelectedRouteButCachesCanonicalAPIURL(t *testing.T) {
+	t.Parallel()
+
+	const canonical = "https://api.github.com/repos/FlanChanXwO/pixiv-cli/releases"
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("target"); got != canonical {
+			t.Fatalf("proxy target = %q, want %q", got, canonical)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"tag_name":"v1.2.3","draft":false,"prerelease":false}]`)
+	}))
+	t.Cleanup(proxy.Close)
+
+	cacheDir := t.TempDir()
+	client, err := NewGitHubReleaseClient(ReleaseClientOptions{APIBaseURL: "https://api.github.com", HTTPClient: proxy.Client(), CacheDir: cacheDir})
+	if err != nil {
+		t.Fatalf("NewGitHubReleaseClient() error = %v", err)
+	}
+	client.sourceSelector = newReleaseSourceSelector(mustTestReleaseSources(t, "proxy|"+proxy.URL+"?target={url_query}|"+proxy.URL+"?target={url_query}"), proxy.Client())
+	result, err := client.Check(context.Background(), ReleaseCheckOptions{})
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if result.Release == nil || result.Release.TagName != "v1.2.3" {
+		t.Fatalf("Check() release = %#v, want v1.2.3", result.Release)
+	}
+	cache, err := os.ReadFile(filepath.Join(cacheDir, releaseCacheFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(cache), canonical) || strings.Contains(string(cache), proxy.URL) {
+		t.Fatalf("cache must retain canonical API URL, got:\n%s", cache)
+	}
+}
+
+func mustTestReleaseSources(t *testing.T, lines ...string) []releaseSource {
+	t.Helper()
+	sources, err := parseReleaseSources([]byte(joinReleaseSourceLines(lines)))
+	if err != nil {
+		t.Fatalf("parseReleaseSources() error = %v", err)
+	}
+	return sources
+}
+
+func joinReleaseSourceLines(lines []string) string {
+	result := ""
+	for _, line := range lines {
+		result += line + "\n"
+	}
+	return result
+}

--- a/internal/update/releases.go
+++ b/internal/update/releases.go
@@ -31,11 +31,12 @@ const (
 // ReleaseClientOptions 配置 GitHub Releases 客户端。
 // APIBaseURL、HTTPClient、CacheDir 和 Now 允许调用方为受控环境注入依赖。
 type ReleaseClientOptions struct {
-	APIBaseURL string
-	Repository string
-	HTTPClient *http.Client
-	CacheDir   string
-	Now        func() time.Time
+	APIBaseURL                 string
+	Repository                 string
+	HTTPClient                 *http.Client
+	CacheDir                   string
+	Now                        func() time.Time
+	EnablePublicReleaseSources bool
 }
 
 // ReleaseCheckOptions 表示一次 Releases 查询的渠道与触发方式。
@@ -72,6 +73,8 @@ type GitHubReleaseClient struct {
 	cacheDir   string
 	cachePath  string
 	now        func() time.Time
+	// sourceSelector 仅在调用方未显式配置 HTTP(S) proxy 时启用，避免改变用户指定代理的语义。
+	sourceSelector *releaseSourceSelector
 	// replaceFile 是每个 client 独立的替换 seam；生产构造固定使用 files.ReplaceFile。
 	replaceFile func(string, string) error
 }
@@ -116,14 +119,18 @@ func NewGitHubReleaseClient(options ReleaseClientOptions) (*GitHubReleaseClient,
 	if now == nil {
 		now = time.Now
 	}
-	return &GitHubReleaseClient{
+	client := &GitHubReleaseClient{
 		endpoint:    endpoint,
 		httpClient:  httpClient,
 		cacheDir:    cacheDir,
 		cachePath:   filepath.Join(cacheDir, releaseCacheFilename),
 		now:         now,
 		replaceFile: files.ReplaceFile,
-	}, nil
+	}
+	if options.EnablePublicReleaseSources {
+		client.sourceSelector = newDefaultReleaseSourceSelector(httpClient)
+	}
+	return client, nil
 }
 
 // Check 从 GitHub Releases API 选择符合渠道的最高 SemVer Release。
@@ -238,6 +245,14 @@ func (c *GitHubReleaseClient) fetchReleaseCache(ctx context.Context, previous re
 		}
 	}
 
+	var apiSources []releaseSource
+	if c.sourceSelector != nil {
+		var err error
+		apiSources, err = c.sourceSelector.ordered(ctx, releaseSourceAPI, c.endpoint.String())
+		if err != nil {
+			return releaseCache{}, err
+		}
+	}
 	current := *c.endpoint
 	visited := make(map[string]struct{})
 	refreshed := releaseCache{SchemaVersion: releaseCacheSchemaVersion}
@@ -252,7 +267,7 @@ func (c *GitHubReleaseClient) fetchReleaseCache(ctx context.Context, previous re
 		visited[pageID] = struct{}{}
 
 		cachedPage, hasCachedPage := cachedPages[pageID]
-		page, nextPage, err := c.fetchReleasePage(ctx, &current, cachedPage, hasCachedPage)
+		page, nextPage, err := c.fetchReleasePage(ctx, &current, cachedPage, hasCachedPage, firstReleaseSource(apiSources))
 		if err != nil {
 			return releaseCache{}, err
 		}
@@ -265,8 +280,16 @@ func (c *GitHubReleaseClient) fetchReleaseCache(ctx context.Context, previous re
 	}
 }
 
-func (c *GitHubReleaseClient) fetchReleasePage(ctx context.Context, pageURL *url.URL, cachedPage releaseCachePage, hasCachedPage bool) (releaseCachePage, *url.URL, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL.String(), nil)
+func (c *GitHubReleaseClient) fetchReleasePage(ctx context.Context, pageURL *url.URL, cachedPage releaseCachePage, hasCachedPage bool, source *releaseSource) (releaseCachePage, *url.URL, error) {
+	requestURL := pageURL.String()
+	if source != nil {
+		var err error
+		requestURL, err = source.apiURL(requestURL)
+		if err != nil {
+			return releaseCachePage{}, nil, fmt.Errorf("transform GitHub Releases page %q through source %q: %w", pageURL, source.id, err)
+		}
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return releaseCachePage{}, nil, fmt.Errorf("create GitHub Releases request: %w", err)
 	}

--- a/pixiv/lists.go
+++ b/pixiv/lists.go
@@ -11,11 +11,13 @@ import (
 )
 
 type searchIllustQuery struct {
-	Word     string              `json:"word"`
-	Target   SearchTarget        `json:"target"`
-	Sort     SortMode            `json:"sort"`
-	Duration string              `json:"duration"`
-	Filters  SearchIllustFilters `json:"filters"`
+	Word      string              `json:"word"`
+	Target    SearchTarget        `json:"target"`
+	Sort      SortMode            `json:"sort"`
+	Duration  string              `json:"duration"`
+	StartDate string              `json:"start_date"`
+	EndDate   string              `json:"end_date"`
+	Filters   SearchIllustFilters `json:"filters"`
 }
 type searchNovelQuery struct {
 	Word     string             `json:"word"`
@@ -86,7 +88,11 @@ func (c *Client) SearchIllust(ctx context.Context, request SearchIllustRequest) 
 	} else if scoped != c {
 		return scoped.SearchIllust(ctx, request)
 	}
-	query := searchIllustQuery{strings.TrimSpace(request.Word), request.Target, request.Sort, strings.TrimSpace(request.Duration), normalizeSearchIllustFilters(request.Filters)}
+	query := searchIllustQuery{
+		Word: strings.TrimSpace(request.Word), Target: request.Target, Sort: request.Sort,
+		Duration: strings.TrimSpace(request.Duration), StartDate: strings.TrimSpace(request.StartDate),
+		EndDate: strings.TrimSpace(request.EndDate), Filters: normalizeSearchIllustFilters(request.Filters),
+	}
 	if query.Word == "" {
 		return nil, invalidArgument(OperationSearchIllust, 0, errors.New("word is required"))
 	}
@@ -96,8 +102,14 @@ func (c *Client) SearchIllust(ctx context.Context, request SearchIllustRequest) 
 	if query.Sort == "" {
 		query.Sort = SortModeDateDesc
 	}
-	if !validSearchTarget(query.Target) || !validSortMode(query.Sort) || !validDuration(query.Duration) || !validSearchIllustFilters(query.Filters) {
+	if !validSearchTarget(query.Target) || !validSortMode(query.Sort) || !validIllustSearchDuration(query.Duration) || !validSearchIllustFilters(query.Filters) {
 		return nil, invalidArgument(OperationSearchIllust, 0, errors.New("search enum is invalid"))
+	}
+	if query.Duration != "" && (query.StartDate != "" || query.EndDate != "") {
+		return nil, invalidArgument(OperationSearchIllust, 0, errors.New("duration cannot be combined with start_date or end_date"))
+	}
+	if !validSearchDateRange(query.StartDate, query.EndDate) {
+		return nil, invalidArgument(OperationSearchIllust, 0, errors.New("start_date and end_date must use YYYY-MM-DD, with start_date no later than end_date"))
 	}
 	digest := queryDigest(OperationSearchIllust, query)
 	offset, err := c.cursorOffset(request.Cursor, OperationSearchIllust, digest, 0)
@@ -109,10 +121,10 @@ func (c *Client) SearchIllust(ctx context.Context, request SearchIllustRequest) 
 		return nil, err
 	}
 	if route == routeWeb {
-		if query.Filters.Rating == SearchRatingR18 || query.Filters.Rating == SearchRatingR18G || query.Filters.Rating == SearchRatingMature {
-			return nil, localRouteError(CodeUnauthorized, OperationSearchIllust, 0, 0, errors.New("authenticated App API search is required for the requested rating"))
+		if searchIllustRequiresAppAPI(query) {
+			return nil, localRouteError(CodeUnauthorized, OperationSearchIllust, 0, 0, errors.New("authenticated App API search is required for the requested target or filters"))
 		}
-		list, err := c.web.SearchIllust(ctx, query.Word, string(query.Target), string(query.Sort), query.Duration, offset, internalSearchIllustFilters(query.Filters))
+		list, err := c.web.SearchIllust(ctx, query.Word, string(query.Target), string(query.Sort), query.Duration, query.StartDate, query.EndDate, offset, internalSearchIllustFilters(query.Filters))
 		if err != nil {
 			return nil, mapWebListError(err, OperationSearchIllust, 0)
 		}
@@ -122,7 +134,7 @@ func (c *Client) SearchIllust(ctx context.Context, request SearchIllustRequest) 
 	if route != routeApp {
 		return nil, unexpectedRoute(OperationSearchIllust, 0, 0)
 	}
-	list, err := c.app.SearchIllust(ctx, query.Word, string(query.Target), string(query.Sort), query.Duration, offset, internalSearchIllustFilters(query.Filters))
+	list, err := c.app.SearchIllust(ctx, query.Word, string(query.Target), string(query.Sort), query.Duration, query.StartDate, query.EndDate, offset, internalSearchIllustFilters(query.Filters))
 	if err != nil {
 		return nil, mapAppOperationError(err, OperationSearchIllust, 0)
 	}
@@ -149,7 +161,7 @@ func (c *Client) SearchNovel(ctx context.Context, request SearchNovelRequest) (r
 	if query.Sort == "" {
 		query.Sort = SortModeDateDesc
 	}
-	if !validSearchTarget(query.Target) || !validSortMode(query.Sort) || !validDuration(query.Duration) || !validNovelSearchFilters(query.Filters) {
+	if !validSearchTarget(query.Target) || !validSortMode(query.Sort) || !validNovelSearchDuration(query.Duration) || !validNovelSearchFilters(query.Filters) {
 		return nil, invalidArgument(OperationSearchNovel, 0, errors.New("novel search parameters are invalid"))
 	}
 	digest := queryDigest(OperationSearchNovel, query)
@@ -267,6 +279,7 @@ func internalSearchIllustFilters(filters SearchIllustFilters) model.SearchIllust
 	return model.SearchIllustFilters{
 		Rating: string(filters.Rating), ContentType: string(filters.ContentType), AIMode: string(filters.AIMode),
 		AspectRatio: string(filters.AspectRatio), Resolution: string(filters.Resolution), Tool: filters.Tool,
+		BookmarkMin: filters.BookmarkMin, BookmarkMax: filters.BookmarkMax,
 	}
 }
 
@@ -275,7 +288,30 @@ func validSearchIllustFilters(filters SearchIllustFilters) bool {
 		oneOf(string(filters.ContentType), "all", "illust-and-ugoira", "illust", "manga", "ugoira") &&
 		oneOf(string(filters.AIMode), "all", "exclude", "only") &&
 		oneOf(string(filters.AspectRatio), "all", "landscape", "portrait", "square") &&
-		oneOf(string(filters.Resolution), "all", "high", "medium", "low")
+		oneOf(string(filters.Resolution), "all", "high", "medium", "low") &&
+		validBookmarkRange(filters.BookmarkMin, filters.BookmarkMax)
+}
+
+func validSearchDateRange(startDate, endDate string) bool {
+	if startDate != "" && !validRankingDate(startDate) {
+		return false
+	}
+	if endDate != "" && !validRankingDate(endDate) {
+		return false
+	}
+	return startDate == "" || endDate == "" || startDate <= endDate
+}
+
+func validBookmarkRange(minimum, maximum *int) bool {
+	if minimum != nil && *minimum < 0 || maximum != nil && *maximum < 0 {
+		return false
+	}
+	return minimum == nil || maximum == nil || *minimum <= *maximum
+}
+
+func searchIllustRequiresAppAPI(query searchIllustQuery) bool {
+	return query.Target == SearchTargetKeyword || query.Filters.BookmarkMin != nil || query.Filters.BookmarkMax != nil ||
+		query.Filters.Rating == SearchRatingR18 || query.Filters.Rating == SearchRatingR18G || query.Filters.Rating == SearchRatingMature
 }
 
 func oneOf(value string, allowed ...string) bool {
@@ -785,7 +821,7 @@ func mapWebListError(err error, operation Operation, userID int64) error {
 }
 
 func validSearchTarget(value SearchTarget) bool {
-	return value == SearchTargetPartialMatchForTags || value == SearchTargetExactMatchForTags || value == SearchTargetTitleAndCaption
+	return value == SearchTargetPartialMatchForTags || value == SearchTargetExactMatchForTags || value == SearchTargetTitleAndCaption || value == SearchTargetKeyword
 }
 
 func validSortMode(value SortMode) bool { return value == SortModeDateDesc || value == SortModeDateAsc }
@@ -819,6 +855,10 @@ func validIllustType(value IllustType) bool {
 	return value == IllustTypeIllust || value == IllustTypeManga || value == IllustTypeUgoira
 }
 
-func validDuration(value string) bool {
+func validIllustSearchDuration(value string) bool {
+	return value == "" || value == "within_last_day" || value == "within_last_week" || value == "within_last_month"
+}
+
+func validNovelSearchDuration(value string) bool {
 	return value == "" || value == "within_last_day" || value == "within_last_week" || value == "within_last_month"
 }

--- a/pixiv/lists_external_test.go
+++ b/pixiv/lists_external_test.go
@@ -744,17 +744,23 @@ func TestSearchIllustHighResolutionUsesAppServerBounds(t *testing.T) {
 
 func TestSearchIllustTranslatesStableFiltersToAppParameters(t *testing.T) {
 	t.Parallel()
+	minimum, maximum := 1000, 10000
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query()
 		want := map[string]string{
-			"search_ai_type": "1",
-			"ratio_pattern":  "landscape",
-			"content_type":   "manga",
-			"width_min":      "1000",
-			"width_max":      "2999",
-			"height_min":     "1000",
-			"height_max":     "2999",
-			"tool":           "CLIP STUDIO PAINT",
+			"search_target":    "keyword",
+			"start_date":       "2026-01-01",
+			"end_date":         "2026-01-31",
+			"bookmark_num_min": "1000",
+			"bookmark_num_max": "10000",
+			"search_ai_type":   "1",
+			"ratio_pattern":    "landscape",
+			"content_type":     "manga",
+			"width_min":        "1000",
+			"width_max":        "2999",
+			"height_min":       "1000",
+			"height_max":       "2999",
+			"tool":             "CLIP STUDIO PAINT",
 		}
 		for key, value := range want {
 			if got := query.Get(key); got != value {
@@ -769,13 +775,15 @@ func TestSearchIllustTranslatesStableFiltersToAppParameters(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = client.SearchIllust(context.Background(), pixiv.SearchIllustRequest{
-		Word: "miku",
+		Word: "miku", Target: pixiv.SearchTargetKeyword, StartDate: "2026-01-01", EndDate: "2026-01-31",
 		Filters: pixiv.SearchIllustFilters{
 			ContentType: pixiv.SearchContentTypeManga,
 			AIMode:      pixiv.SearchAIModeExclude,
 			AspectRatio: pixiv.SearchAspectRatioLandscape,
 			Resolution:  pixiv.SearchResolutionMedium,
 			Tool:        " CLIP STUDIO PAINT ",
+			BookmarkMin: &minimum,
+			BookmarkMax: &maximum,
 		},
 	})
 	if err != nil {
@@ -860,6 +868,7 @@ func TestSearchIllustFiltersRatingAndOnlyAIInPublicSDK(t *testing.T) {
 
 func TestSearchIllustCursorIsBoundToEveryFilter(t *testing.T) {
 	t.Parallel()
+	bookmarkMinimum, changedBookmarkMinimum := 1000, 5000
 	tests := []struct {
 		name    string
 		first   pixiv.SearchIllustFilters
@@ -871,6 +880,7 @@ func TestSearchIllustCursorIsBoundToEveryFilter(t *testing.T) {
 		{name: "aspect ratio", first: pixiv.SearchIllustFilters{AspectRatio: pixiv.SearchAspectRatioAll}, changed: pixiv.SearchIllustFilters{AspectRatio: pixiv.SearchAspectRatioPortrait}},
 		{name: "resolution", first: pixiv.SearchIllustFilters{Resolution: pixiv.SearchResolutionHigh}, changed: pixiv.SearchIllustFilters{Resolution: pixiv.SearchResolutionLow}},
 		{name: "tool", first: pixiv.SearchIllustFilters{Tool: "tool-a"}, changed: pixiv.SearchIllustFilters{Tool: "tool-b"}},
+		{name: "bookmark range", first: pixiv.SearchIllustFilters{BookmarkMin: &bookmarkMinimum}, changed: pixiv.SearchIllustFilters{BookmarkMin: &changedBookmarkMinimum}},
 	}
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -894,6 +904,28 @@ func TestSearchIllustCursorIsBoundToEveryFilter(t *testing.T) {
 		if want := int32(index + 1); requests.Load() != want {
 			t.Fatalf("%s network requests = %d, want %d", test.name, requests.Load(), want)
 		}
+	}
+}
+
+func TestSearchIllustCursorIsBoundToDateRange(t *testing.T) {
+	t.Parallel()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		fmt.Fprint(w, `{"illusts":[],"next_url":"https://app-api.pixiv.net/v1/search/illust?offset=30"}`)
+	}))
+	defer server.Close()
+	client, err := pixiv.NewClient(pixiv.Options{HTTPClient: server.Client(), AppAPIBaseURL: server.URL, AccessToken: "token"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := client.SearchIllust(context.Background(), pixiv.SearchIllustRequest{Word: "miku", StartDate: "2026-01-01", EndDate: "2026-01-31"})
+	if err != nil || first.NextCursor == "" {
+		t.Fatalf("first=%#v err=%v", first, err)
+	}
+	result, err := client.SearchIllust(context.Background(), pixiv.SearchIllustRequest{Word: "miku", StartDate: "2026-02-01", EndDate: "2026-02-28", Cursor: first.NextCursor})
+	if result != nil || !errors.Is(err, pixiv.ErrInvalidArgument) || requests.Load() != 1 {
+		t.Fatalf("result=%#v err=%v requests=%d", result, err, requests.Load())
 	}
 }
 
@@ -991,7 +1023,7 @@ func TestAnonymousSearchIllustTranslatesReliableWebFilters(t *testing.T) {
 	}
 }
 
-func TestAnonymousSearchIllustRejectsRestrictedRatingsBeforeNetwork(t *testing.T) {
+func TestAnonymousSearchIllustRejectsAppOnlySearchBeforeNetwork(t *testing.T) {
 	t.Parallel()
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1003,13 +1035,18 @@ func TestAnonymousSearchIllustRejectsRestrictedRatingsBeforeNetwork(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, rating := range []pixiv.SearchRating{pixiv.SearchRatingR18, pixiv.SearchRatingR18G, pixiv.SearchRatingMature} {
-		result, err := client.SearchIllust(context.Background(), pixiv.SearchIllustRequest{
-			Word: "miku", Filters: pixiv.SearchIllustFilters{Rating: rating},
-		})
+	minimum := 1000
+	for _, request := range []pixiv.SearchIllustRequest{
+		{Word: "miku", Filters: pixiv.SearchIllustFilters{Rating: pixiv.SearchRatingR18}},
+		{Word: "miku", Filters: pixiv.SearchIllustFilters{Rating: pixiv.SearchRatingR18G}},
+		{Word: "miku", Filters: pixiv.SearchIllustFilters{Rating: pixiv.SearchRatingMature}},
+		{Word: "miku", Target: pixiv.SearchTargetKeyword},
+		{Word: "miku", Filters: pixiv.SearchIllustFilters{BookmarkMin: &minimum}},
+	} {
+		result, err := client.SearchIllust(context.Background(), request)
 		var typed *pixiv.Error
 		if result != nil || !errors.As(err, &typed) || typed.Code != pixiv.CodeUnauthorized || typed.Operation != pixiv.OperationSearchIllust || typed.Backend != "" {
-			t.Fatalf("rating=%q result=%#v error=%#v", rating, result, typed)
+			t.Fatalf("request=%+v result=%#v error=%#v", request, result, typed)
 		}
 	}
 	if requests.Load() != 0 {
@@ -1558,6 +1595,7 @@ func TestAuthenticatedAppFailureNeverFallsBackToWeb(t *testing.T) {
 
 func TestInvalidListEnumsFailBeforeNetwork(t *testing.T) {
 	t.Parallel()
+	bookmarkMinimum, bookmarkMaximum := 10000, 1000
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests.Add(1); fmt.Fprint(w, `{"illusts":[]}`) }))
 	defer server.Close()
@@ -1580,6 +1618,30 @@ func TestInvalidListEnumsFailBeforeNetwork(t *testing.T) {
 		},
 		func() error {
 			_, err := client.SearchIllust(context.Background(), pixiv.SearchIllustRequest{Word: "x", Duration: "bad"})
+			return err
+		},
+		func() error {
+			_, err := client.SearchIllust(context.Background(), pixiv.SearchIllustRequest{Word: "x", Duration: "within_half_year"})
+			return err
+		},
+		func() error {
+			_, err := client.SearchNovel(context.Background(), pixiv.SearchNovelRequest{Word: "x", Duration: "within_half_year"})
+			return err
+		},
+		func() error {
+			_, err := client.SearchIllust(context.Background(), pixiv.SearchIllustRequest{Word: "x", Duration: "within_last_week", StartDate: "2026-01-01"})
+			return err
+		},
+		func() error {
+			_, err := client.SearchIllust(context.Background(), pixiv.SearchIllustRequest{Word: "x", StartDate: "2026-02-30"})
+			return err
+		},
+		func() error {
+			_, err := client.SearchIllust(context.Background(), pixiv.SearchIllustRequest{Word: "x", StartDate: "2026-02-01", EndDate: "2026-01-31"})
+			return err
+		},
+		func() error {
+			_, err := client.SearchIllust(context.Background(), pixiv.SearchIllustRequest{Word: "x", Filters: pixiv.SearchIllustFilters{BookmarkMin: &bookmarkMinimum, BookmarkMax: &bookmarkMaximum}})
 			return err
 		},
 		func() error {

--- a/pixiv/models.go
+++ b/pixiv/models.go
@@ -65,6 +65,7 @@ const (
 	SearchTargetPartialMatchForTags SearchTarget = "partial_match_for_tags"
 	SearchTargetExactMatchForTags   SearchTarget = "exact_match_for_tags"
 	SearchTargetTitleAndCaption     SearchTarget = "title_and_caption"
+	SearchTargetKeyword             SearchTarget = "keyword"
 )
 
 type SortMode string
@@ -165,15 +166,19 @@ type SearchIllustFilters struct {
 	AspectRatio SearchAspectRatio `json:"aspect_ratio,omitempty"`
 	Resolution  SearchResolution  `json:"resolution,omitempty"`
 	Tool        string            `json:"tool,omitempty"`
+	BookmarkMin *int              `json:"bookmark_min,omitempty"`
+	BookmarkMax *int              `json:"bookmark_max,omitempty"`
 }
 
 type SearchIllustRequest struct {
-	Word     string              `json:"word"`
-	Target   SearchTarget        `json:"search_target,omitempty"`
-	Sort     SortMode            `json:"sort,omitempty"`
-	Duration string              `json:"duration,omitempty"`
-	Cursor   Cursor              `json:"cursor,omitempty"`
-	Filters  SearchIllustFilters `json:"filters,omitempty"`
+	Word      string              `json:"word"`
+	Target    SearchTarget        `json:"search_target,omitempty"`
+	Sort      SortMode            `json:"sort,omitempty"`
+	Duration  string              `json:"duration,omitempty"`
+	StartDate string              `json:"start_date,omitempty"`
+	EndDate   string              `json:"end_date,omitempty"`
+	Cursor    Cursor              `json:"cursor,omitempty"`
+	Filters   SearchIllustFilters `json:"filters,omitempty"`
 }
 
 type SearchIllustOptionsRequest struct {

--- a/pixiv/reference.go
+++ b/pixiv/reference.go
@@ -1,0 +1,127 @@
+package pixiv
+
+import (
+	"errors"
+	"net/url"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// ReferenceKind 标识稳定 Pixiv 页面 URL 指向的资源类型。
+type ReferenceKind string
+
+const (
+	ReferenceKindArtwork ReferenceKind = "artwork"
+	ReferenceKindUser    ReferenceKind = "user"
+)
+
+// Reference 是本地解析后的 Pixiv 稳定资源标识，不包含原始 URL 或查询参数。
+type Reference struct {
+	Kind ReferenceKind
+	ID   int64
+}
+
+// URL 返回资源的稳定规范 Pixiv 页面地址；非法零值不生成虚假的 URL。
+func (r Reference) URL() string {
+	if r.ID <= 0 {
+		return ""
+	}
+	switch r.Kind {
+	case ReferenceKindArtwork:
+		return "https://www.pixiv.net/artworks/" + strconv.FormatInt(r.ID, 10)
+	case ReferenceKindUser:
+		return "https://www.pixiv.net/users/" + strconv.FormatInt(r.ID, 10)
+	default:
+		return ""
+	}
+}
+
+var errUnsupportedReference = errors.New("reference must be a positive artwork ID or a supported Pixiv URL")
+
+// ParseReference 只解析稳定的 Pixiv 作品页、用户主页和用户作品页 URL，或正整数作品 ID。
+// 它不会请求网络、跟随重定向或保留原始输入，避免把 query 中可能存在的敏感信息带进错误和日志。
+func ParseReference(raw string) (Reference, error) {
+	value := strings.TrimSpace(raw)
+	if id, ok := parsePositiveReferenceID(value); ok {
+		return Reference{Kind: ReferenceKindArtwork, ID: id}, nil
+	}
+
+	parsed, err := url.ParseRequestURI(value)
+	if err != nil || parsed.Scheme != "https" || parsed.User != nil || parsed.Port() != "" || !isPixivHost(parsed.Hostname()) {
+		return Reference{}, errUnsupportedReference
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if reference, ok := parseReferencePath(parts); ok {
+		return reference, nil
+	}
+	if len(parts) >= 3 && isLocaleSegment(parts[0]) {
+		if reference, ok := parseReferencePath(parts[1:]); ok {
+			return reference, nil
+		}
+	}
+	return Reference{}, errUnsupportedReference
+}
+
+// parseReferencePath 先匹配无 locale 的稳定路径，避免 users/artworks 这类合法路径段
+// 被宽松的 locale 语法错误地吞掉。
+func parseReferencePath(parts []string) (Reference, bool) {
+	if len(parts) == 2 && parts[0] == "artworks" {
+		if id, ok := parsePositiveReferenceID(parts[1]); ok {
+			return Reference{Kind: ReferenceKindArtwork, ID: id}, true
+		}
+	}
+	if len(parts) == 2 && parts[0] == "users" {
+		if id, ok := parsePositiveReferenceID(parts[1]); ok {
+			return Reference{Kind: ReferenceKindUser, ID: id}, true
+		}
+	}
+	if len(parts) == 3 && parts[0] == "users" && parts[2] == "artworks" {
+		if id, ok := parsePositiveReferenceID(parts[1]); ok {
+			return Reference{Kind: ReferenceKindUser, ID: id}, true
+		}
+	}
+	return Reference{}, false
+}
+
+// ParseArtworkReference 解析单件作品引用；用户 URL 和其他 Pixiv 页面不在 detail 的输入范围内。
+func ParseArtworkReference(raw string) (int64, error) {
+	reference, err := ParseReference(raw)
+	if err != nil || reference.Kind != ReferenceKindArtwork {
+		return 0, errUnsupportedReference
+	}
+	return reference.ID, nil
+}
+
+func parsePositiveReferenceID(value string) (int64, bool) {
+	id, err := strconv.ParseInt(value, 10, 64)
+	return id, err == nil && id > 0
+}
+
+func isPixivHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "pixiv.net", "www.pixiv.net":
+		return true
+	default:
+		return false
+	}
+}
+
+// isLocaleSegment 只放行 URL 路径中常见的 BCP 47 风格 locale，避免把任意层级误判为资源 URL。
+func isLocaleSegment(value string) bool {
+	parts := strings.Split(value, "-")
+	if len(parts) == 0 || len(parts) > 2 {
+		return false
+	}
+	for _, part := range parts {
+		if len(part) < 2 || len(part) > 8 {
+			return false
+		}
+		for _, char := range part {
+			if !unicode.IsLetter(char) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/pixiv/reference_external_test.go
+++ b/pixiv/reference_external_test.go
@@ -1,0 +1,54 @@
+package pixiv_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/FlanChanXwO/pixiv-cli/pixiv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseReferenceNormalizesArtworkAndUserURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want pixiv.Reference
+	}{
+		{name: "numeric artwork ID", raw: "42", want: pixiv.Reference{Kind: pixiv.ReferenceKindArtwork, ID: 42}},
+		{name: "artwork URL", raw: "https://www.pixiv.net/artworks/42", want: pixiv.Reference{Kind: pixiv.ReferenceKindArtwork, ID: 42}},
+		{name: "localized artwork URL with query and fragment", raw: "https://pixiv.net/zh-CN/artworks/42?utm_source=share#page=1", want: pixiv.Reference{Kind: pixiv.ReferenceKindArtwork, ID: 42}},
+		{name: "user profile URL", raw: "https://www.pixiv.net/users/7", want: pixiv.Reference{Kind: pixiv.ReferenceKindUser, ID: 7}},
+		{name: "user artworks URL", raw: "https://www.pixiv.net/users/7/artworks", want: pixiv.Reference{Kind: pixiv.ReferenceKindUser, ID: 7}},
+		{name: "localized user artworks URL", raw: "https://www.pixiv.net/en/users/7/artworks", want: pixiv.Reference{Kind: pixiv.ReferenceKindUser, ID: 7}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pixiv.ParseReference(tt.raw)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseArtworkReferenceRejectsUnsupportedTargetsWithoutEchoingInput(t *testing.T) {
+	for _, raw := range []string{
+		"https://www.pixiv.net/users/7",
+		"https://www.pixiv.net/novel/show.php?id=42",
+		"https://www.pixiv.net/member_illust.php?illust_id=42",
+		"https://fanbox.cc/@artist",
+		"https://pixiv.me/artist",
+		"https://example.invalid/artworks/42?secret=must-not-echo",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := pixiv.ParseArtworkReference(raw)
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), raw)
+			require.NotContains(t, err.Error(), "must-not-echo")
+		})
+	}
+
+	_, err := pixiv.ParseReference("https://www.pixiv.net/artworks/0")
+	require.Error(t, err)
+	require.False(t, strings.Contains(err.Error(), "artworks/0"))
+}

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -4,6 +4,11 @@ setlocal EnableExtensions DisableDelayedExpansion
 rem 该脚本只使用 Windows 10/11 自带的命令行工具，不调用其他脚本宿主。
 set "REPOSITORY=FlanChanXwO/pixiv-cli"
 set "RELEASE_ROOT=https://github.com/%REPOSITORY%/releases/latest/download"
+rem 发布阶段会把 internal/update/release_sources.txt 注入此块；工作树模板只保留直连。
+rem PIXIV_RELEASE_SOURCES_BEGIN
+set "RELEASE_SOURCE_COUNT=1"
+set "RELEASE_SOURCE_1=github-direct|{url}|{url}"
+rem PIXIV_RELEASE_SOURCES_END
 set "INSTALL_DIR=%LOCALAPPDATA%\Programs\pixiv"
 set "PATH_MODE=report"
 set "WORK_DIR="
@@ -40,6 +45,7 @@ if not defined INSTALL_DIR (set "ERROR_MESSAGE=install directory cannot be empty
 
 where curl.exe >nul 2>&1 || (set "ERROR_MESSAGE=curl.exe is required" & goto fatal)
 where certutil.exe >nul 2>&1 || (set "ERROR_MESSAGE=certutil.exe is required" & goto fatal)
+where fc.exe >nul 2>&1 || (set "ERROR_MESSAGE=fc.exe is required" & goto fatal)
 set "SYSTEM_TAR=%SystemRoot%\System32\tar.exe"
 if not exist "%SYSTEM_TAR%" (set "ERROR_MESSAGE=Windows system tar.exe is required" & goto fatal)
 
@@ -72,7 +78,7 @@ for %%F in ("%ASSET%") do if /I not "%%~nxF"=="%ASSET%" (set "ERROR_MESSAGE=rele
 
 set "ARCHIVE=%WORK_DIR%\%ASSET%"
 echo Downloading %ASSET%...
-curl.exe -fsSL "%RELEASE_ROOT%/%ASSET%" -o "%ARCHIVE%" || (set "ERROR_MESSAGE=cannot download the platform archive from the official release" & goto fatal)
+call :download_archive_from_sources || goto fatal
 
 set "ACTUAL="
 for /f "skip=1 tokens=* delims=" %%H in ('certutil.exe -hashfile "%ARCHIVE%" SHA256') do if not defined ACTUAL set "ACTUAL=%%H"
@@ -154,4 +160,65 @@ exit /b 1
 :cleanup
 if defined STAGED del /f /q "%STAGED%" >nul 2>&1
 if defined WORK_DIR rmdir /s /q "%WORK_DIR%" >nul 2>&1
+exit /b 0
+
+:download_archive_from_sources
+set /a SOURCE_INDEX=1
+:download_archive_next_source
+if %SOURCE_INDEX% GTR %RELEASE_SOURCE_COUNT% (
+  set "ERROR_MESSAGE=cannot download the platform archive from any release source"
+  exit /b 1
+)
+call :load_release_source %SOURCE_INDEX% || exit /b 1
+call :render_release_url "%SOURCE_TEMPLATE%" "%RELEASE_ROOT%/%ASSET%" || exit /b 1
+set "PROBE=%WORK_DIR%\release-source-%SOURCE_INDEX%.txt"
+call :render_release_url "%SOURCE_TEMPLATE%" "%RELEASE_ROOT%/checksums.txt" || exit /b 1
+curl.exe -fsSL "%SOURCE_URL%" -o "%PROBE%" >nul 2>&1
+if errorlevel 1 goto download_archive_try_next
+fc.exe /b "%CHECKSUMS%" "%PROBE%" >nul 2>&1
+if errorlevel 1 goto download_archive_try_next
+call :render_release_url "%SOURCE_TEMPLATE%" "%RELEASE_ROOT%/%ASSET%" || exit /b 1
+curl.exe -fsSL "%SOURCE_URL%" -o "%ARCHIVE%" && exit /b 0
+:download_archive_try_next
+set /a SOURCE_INDEX+=1
+goto download_archive_next_source
+
+:load_release_source
+set "SOURCE_ENTRY="
+set "SOURCE_ID="
+set "SOURCE_TEMPLATE="
+call set "SOURCE_ENTRY=%%RELEASE_SOURCE_%~1%%"
+for /f "tokens=1-3 delims=|" %%A in ("%SOURCE_ENTRY%") do (
+  set "SOURCE_ID=%%A"
+  set "SOURCE_TEMPLATE=%%C"
+)
+if not defined SOURCE_ID (set "ERROR_MESSAGE=release source entry is malformed" & exit /b 1)
+if not defined SOURCE_TEMPLATE (set "ERROR_MESSAGE=release source entry is malformed" & exit /b 1)
+exit /b 0
+
+:render_release_url
+set "SOURCE_RENDER_TEMPLATE=%~1"
+set "SOURCE_RENDER_CANONICAL=%~2"
+call set "SOURCE_RENDERED=%%SOURCE_RENDER_TEMPLATE:{url}=%SOURCE_RENDER_CANONICAL%%%"
+if /I not "%SOURCE_RENDERED%"=="%SOURCE_RENDER_TEMPLATE%" (
+  set "SOURCE_URL=%SOURCE_RENDERED%"
+  exit /b 0
+)
+call :url_encode "%SOURCE_RENDER_CANONICAL%"
+call set "SOURCE_RENDERED=%%SOURCE_RENDER_TEMPLATE:{url_query}=%SOURCE_RENDER_ENCODED%%%"
+if /I not "%SOURCE_RENDERED%"=="%SOURCE_RENDER_TEMPLATE%" (
+  set "SOURCE_URL=%SOURCE_RENDERED%"
+  exit /b 0
+)
+set "ERROR_MESSAGE=release source template is invalid"
+exit /b 1
+
+:url_encode
+set "SOURCE_RENDER_ENCODED=%~1"
+call set "SOURCE_RENDER_ENCODED=%%SOURCE_RENDER_ENCODED:%%=%%%%25%%"
+call set "SOURCE_RENDER_ENCODED=%%SOURCE_RENDER_ENCODED::=%%%%3A%%"
+call set "SOURCE_RENDER_ENCODED=%%SOURCE_RENDER_ENCODED:/=%%%%2F%%"
+call set "SOURCE_RENDER_ENCODED=%%SOURCE_RENDER_ENCODED:?=%%%%3F%%"
+call set "SOURCE_RENDER_ENCODED=%%SOURCE_RENDER_ENCODED:==%%%%3D%%"
+call set "SOURCE_RENDER_ENCODED=%%SOURCE_RENDER_ENCODED:^&=%%%%26%%"
 exit /b 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,14 @@ set -eu
 
 repository='FlanChanXwO/pixiv-cli'
 release_root="https://github.com/$repository/releases/latest/download"
+# 发布阶段会把 internal/update/release_sources.txt 注入此块。工作树模板保留直连，
+# 以便审阅中的脚本不会擅自依赖公共中继。
+# PIXIV_RELEASE_SOURCES_BEGIN
+release_sources='github-direct|{url}|{url}'
+# PIXIV_RELEASE_SOURCES_END
+if [ -n "${PIXIV_RELEASE_SOURCES:-}" ]; then
+	release_sources=$PIXIV_RELEASE_SOURCES
+fi
 user_home=${HOME:-}
 install_dir=${PIXIV_INSTALL_DIR:-${user_home:+"$user_home/.local/bin"}}
 path_mode=report
@@ -69,6 +77,9 @@ fi
 command -v curl >/dev/null 2>&1 || fail 'curl is required'
 command -v tar >/dev/null 2>&1 || fail 'tar is required'
 command -v awk >/dev/null 2>&1 || fail 'awk is required'
+command -v cmp >/dev/null 2>&1 || fail 'cmp is required'
+command -v mkfifo >/dev/null 2>&1 || fail 'mkfifo is required'
+command -v od >/dev/null 2>&1 || fail 'od is required'
 
 case "$(uname -s)" in
 Linux) target_os=linux ;;
@@ -106,9 +117,116 @@ case "$expected" in
 *[!0-9a-f]*) fail 'release checksum is not lowercase hexadecimal' ;;
 esac
 
+url_encode() {
+	printf '%s' "$1" | LC_ALL=C od -An -tx1 | awk '{ for (index = 1; index <= NF; index++) printf "%%%s", toupper($index) }'
+}
+
+render_release_url() {
+	template=$1
+	canonical_url=$2
+	case "$template" in
+	*'{url_query}'*)
+		prefix=${template%%\{url_query\}*}
+		suffix=${template#*\{url_query\}}
+		printf '%s%s%s' "$prefix" "$(url_encode "$canonical_url")" "$suffix"
+		;;
+	*'{url}'*)
+		prefix=${template%%\{url\}*}
+		suffix=${template#*\{url\}}
+		printf '%s%s%s' "$prefix" "$canonical_url" "$suffix"
+		;;
+	*) return 1 ;;
+	esac
+}
+
+select_asset_template() {
+	probe_fifo="$temporary/release-source-probes"
+	mkfifo "$probe_fifo" || fail 'cannot create release-source probe channel'
+	# 同时探测所有候选。每个候选必须逐字返回直连得到的 checksums.txt；最先完成者
+	# 成为本次下载首选，失败候选不会污染权威 checksum。
+	probe_count=0
+	probe_pids=
+	exec 3<>"$probe_fifo"
+	while IFS= read -r source_line; do
+		case "$source_line" in
+		'' | \#*) continue ;;
+		esac
+		source_id=${source_line%%|*}
+		source_rest=${source_line#*|}
+		[ "$source_rest" != "$source_line" ] || fail 'release source entry is malformed'
+		source_api=${source_rest%%|*}
+		source_template=${source_rest#*|}
+		[ "$source_template" != "$source_rest" ] || fail 'release source entry is malformed'
+		probe_url=$(render_release_url "$source_template" "$release_root/checksums.txt") || fail 'release source template is invalid'
+		(
+			probe_file="$temporary/probe-$probe_count.txt"
+			if curl -fsSL "$probe_url" -o "$probe_file" && cmp -s "$checksums" "$probe_file"; then
+				printf 'ok|%s|%s\n' "$source_id" "$source_template" >&3
+			else
+				printf 'failed|%s|%s\n' "$source_id" "$source_template" >&3
+			fi
+		) &
+		probe_pids="$probe_pids $!"
+		probe_count=$((probe_count + 1))
+	done <<EOF
+$release_sources
+EOF
+	[ "$probe_count" -gt 0 ] || fail 'release source list is empty'
+	selected_template=
+	selected_source=
+	probe_index=0
+	while [ "$probe_index" -lt "$probe_count" ]; do
+		IFS='|' read -r probe_result probe_source probe_template <&3 || fail 'release-source probe did not report a result'
+		if [ "$probe_result" = ok ] && [ -z "$selected_template" ]; then
+			selected_template=$probe_template
+			selected_source=$probe_source
+			break
+		fi
+		probe_index=$((probe_index + 1))
+	done
+	# 选出最快可用候选后立即取消尚在探测的 curl；未选中时等待所有 probe 的失败报告。
+	if [ -n "$selected_template" ]; then
+		kill $probe_pids 2>/dev/null || true
+	fi
+	for probe_pid in $probe_pids; do
+		wait "$probe_pid" 2>/dev/null || true
+	done
+	exec 3>&-
+	exec 3<&-
+	[ -n "$selected_template" ] || fail 'no release source returned the official checksums.txt'
+}
+
+select_asset_template
 archive="$temporary/$asset"
 printf 'Downloading %s...\n' "$asset"
-curl -fsSL "$release_root/$asset" -o "$archive" || fail 'cannot download the platform archive from the official release'
+download_archive_from_sources() {
+	archive_canonical_url="$release_root/$asset"
+	archive_url=$(render_release_url "$selected_template" "$archive_canonical_url") || fail 'release source template is invalid'
+	if curl -fsSL "$archive_url" -o "$archive"; then
+		return 0
+	fi
+	while IFS= read -r source_line; do
+		case "$source_line" in
+		'' | \#*) continue ;;
+		esac
+		source_id=${source_line%%|*}
+		source_rest=${source_line#*|}
+		[ "$source_rest" != "$source_line" ] || fail 'release source entry is malformed'
+		source_api=${source_rest%%|*}
+		source_template=${source_rest#*|}
+		[ "$source_template" != "$source_rest" ] || fail 'release source entry is malformed'
+		[ "$source_id" = "$selected_source" ] && continue
+		archive_url=$(render_release_url "$source_template" "$archive_canonical_url") || fail 'release source template is invalid'
+		if curl -fsSL "$archive_url" -o "$archive"; then
+			return 0
+		fi
+	done <<EOF
+$release_sources
+EOF
+	return 1
+}
+
+download_archive_from_sources || fail 'cannot download the platform archive from any release source'
 
 if command -v sha256sum >/dev/null 2>&1; then
 	actual=$(sha256sum "$archive" | awk '{ print $1 }')

--- a/scripts/installers/installers_test.go
+++ b/scripts/installers/installers_test.go
@@ -81,6 +81,44 @@ func TestInstallShChecksumFailurePreservesExistingBinary(t *testing.T) {
 	}
 }
 
+func TestInstallShSelectsFastestVerifiedSourceAndRetriesArchive(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX installer is exercised by Unix platform jobs")
+	}
+
+	fixtureDir, assetName := prepareUnixFixture(t, false)
+	fakeBin := prepareFakeCurl(t)
+	logPath := filepath.Join(t.TempDir(), "curl.log")
+	installDir := t.TempDir()
+	command := exec.Command("sh", filepath.Join("..", "install.sh"), "--install-dir", installDir, "--no-path")
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"PIXIV_INSTALLER_FIXTURES="+fixtureDir,
+		"PIXIV_INSTALLER_CURL_LOG="+logPath,
+		"PIXIV_INSTALLER_CURL_FAIL_ARCHIVE_HOST=fast.example",
+		"PIXIV_INSTALLER_CURL_FAIL_CHECKSUM_HOST=fallback.example",
+		"PIXIV_RELEASE_SOURCES=fast|-|https://fast.example/{url}\nfallback|-|https://fallback.example/{url}\ngithub-direct|{url}|{url}",
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("install with source retry: %v\n%s", err, output)
+	}
+	logBody, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logBody)
+	for _, required := range []string{
+		"https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/checksums.txt",
+		"https://fast.example/https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/checksums.txt",
+		"https://fast.example/https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/" + assetName,
+		"https://fallback.example/https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/" + assetName,
+	} {
+		if !strings.Contains(log, required) {
+			t.Fatalf("curl log missing %q:\n%s", required, log)
+		}
+	}
+}
+
 func TestInstallShAddsDefaultDirectoryToPathIdempotently(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX installer is exercised by Unix platform jobs")
@@ -417,6 +455,25 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 [ -n "$output" ] && [ -n "$url" ]
+if [ -n "${PIXIV_INSTALLER_CURL_LOG:-}" ]; then
+  printf '%s\n' "$url" >> "$PIXIV_INSTALLER_CURL_LOG"
+fi
+case "${PIXIV_INSTALLER_CURL_FAIL_ARCHIVE_HOST:-}" in
+  '') ;;
+  *)
+    case "$url" in
+      *"$PIXIV_INSTALLER_CURL_FAIL_ARCHIVE_HOST"*pixiv-cli_*.tar.gz) exit 22 ;;
+    esac
+    ;;
+esac
+case "${PIXIV_INSTALLER_CURL_FAIL_CHECKSUM_HOST:-}" in
+  '') ;;
+  *)
+    case "$url" in
+      *"$PIXIV_INSTALLER_CURL_FAIL_CHECKSUM_HOST"*/checksums.txt) exit 22 ;;
+    esac
+    ;;
+esac
 cp "$PIXIV_INSTALLER_FIXTURES/${url##*/}" "$output"
 `
 	path := filepath.Join(directory, "curl")

--- a/scripts/releaseassets/main.go
+++ b/scripts/releaseassets/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"crypto/x509"
@@ -184,6 +185,7 @@ func runFinalize(arguments []string) (err error) {
 	changelogChinese := flags.String("changelog-zh", "", "version-specific Simplified Chinese changelog path")
 	installSh := flags.String("install-sh", "", "verified install.sh path")
 	installCmd := flags.String("install-cmd", "", "verified install.cmd path")
+	releaseSourcesPath := flags.String("release-sources", "", "versioned release-source list injected into install.sh")
 	privateKeyPath := flags.String("private-key", "", "PKCS#8 PEM Ed25519 private-key path")
 	keyID := flags.String("key-id", "", "public signing-key identifier")
 	if err := flags.Parse(arguments); err != nil {
@@ -229,6 +231,19 @@ func runFinalize(arguments []string) (err error) {
 	if err := requireSecureRegularFile(*installCmd, "install.cmd"); err != nil {
 		return err
 	}
+	var releaseSources []byte
+	if *releaseSourcesPath != "" {
+		if err := requireSecureRegularFile(*releaseSourcesPath, "release sources"); err != nil {
+			return err
+		}
+		releaseSources, err = os.ReadFile(*releaseSourcesPath)
+		if err != nil {
+			return fmt.Errorf("read release sources %q: %w", *releaseSourcesPath, err)
+		}
+		if len(bytes.TrimSpace(releaseSources)) == 0 {
+			return errors.New("release sources must not be empty")
+		}
+	}
 	parent := filepath.Dir(*outputDir)
 	if err := requireSecureDirectory(parent, "output parent directory"); err != nil {
 		return err
@@ -252,7 +267,7 @@ func runFinalize(arguments []string) (err error) {
 		}
 	}()
 
-	checksums, err := copyRequiredAssets(*inputDir, stage, *version, *installSh, *installCmd)
+	checksums, err := copyRequiredAssets(*inputDir, stage, *version, *installSh, *installCmd, releaseSources)
 	if err != nil {
 		return err
 	}
@@ -276,7 +291,7 @@ func runFinalize(arguments []string) (err error) {
 	return nil
 }
 
-func copyRequiredAssets(inputDir, outputDir, version, installSh, installCmd string) ([]byte, error) {
+func copyRequiredAssets(inputDir, outputDir, version, installSh, installCmd string, releaseSources []byte) ([]byte, error) {
 	sources := make(map[string]string, len(fixedTargets)+2)
 	for _, target := range fixedTargets {
 		name := archiveName(version, target)
@@ -295,9 +310,22 @@ func copyRequiredAssets(inputDir, outputDir, version, installSh, installCmd stri
 		if err := requireRegularFile(source, "input release asset"); err != nil {
 			return nil, fmt.Errorf("%s: %w", name, err)
 		}
-		sum, err := copyRegularFile(source, filepath.Join(outputDir, name))
+		destination := filepath.Join(outputDir, name)
+		sum, err := copyRegularFile(source, destination)
 		if err != nil {
 			return nil, fmt.Errorf("copy %s: %w", name, err)
+		}
+		if name == "install.sh" && len(releaseSources) != 0 {
+			sum, err = injectReleaseSources(destination, releaseSources)
+			if err != nil {
+				return nil, fmt.Errorf("inject release sources into install.sh: %w", err)
+			}
+		}
+		if name == "install.cmd" && len(releaseSources) != 0 {
+			sum, err = injectWindowsReleaseSources(destination, releaseSources)
+			if err != nil {
+				return nil, fmt.Errorf("inject release sources into install.cmd: %w", err)
+			}
 		}
 		checksums = append(checksums, hex.EncodeToString(sum[:])...)
 		checksums = append(checksums, "  "...)
@@ -305,6 +333,102 @@ func copyRequiredAssets(inputDir, outputDir, version, installSh, installCmd stri
 		checksums = append(checksums, '\n')
 	}
 	return checksums, nil
+}
+
+const (
+	releaseSourcesBeginMarker      = "# PIXIV_RELEASE_SOURCES_BEGIN\n"
+	releaseSourcesEndMarker        = "# PIXIV_RELEASE_SOURCES_END"
+	releaseSourcesHeredoc          = "PIXIV_RELEASE_SOURCES_EOF"
+	windowsReleaseSourcesBeginLine = "rem PIXIV_RELEASE_SOURCES_BEGIN"
+	windowsReleaseSourcesEndMarker = "rem PIXIV_RELEASE_SOURCES_END"
+)
+
+func injectReleaseSources(path string, sources []byte) ([sha256.Size]byte, error) {
+	var zero [sha256.Size]byte
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return zero, fmt.Errorf("read staged installer: %w", err)
+	}
+	content := string(payload)
+	start := strings.Index(content, releaseSourcesBeginMarker)
+	if start < 0 {
+		return zero, errors.New("release-source begin marker is missing")
+	}
+	endOffset := strings.Index(content[start+len(releaseSourcesBeginMarker):], releaseSourcesEndMarker)
+	if endOffset < 0 {
+		return zero, errors.New("release-source end marker is missing")
+	}
+	end := start + len(releaseSourcesBeginMarker) + endOffset
+	trimmed := strings.TrimSuffix(string(sources), "\n")
+	if strings.Contains(trimmed, "\n"+releaseSourcesHeredoc) || strings.HasPrefix(trimmed, releaseSourcesHeredoc+"\n") || trimmed == releaseSourcesHeredoc {
+		return zero, fmt.Errorf("release sources contain reserved heredoc delimiter %q", releaseSourcesHeredoc)
+	}
+	replacement := releaseSourcesBeginMarker + "release_sources=$(cat <<'" + releaseSourcesHeredoc + "'\n" + trimmed + "\n" + releaseSourcesHeredoc + "\n)\n"
+	rendered := content[:start] + replacement + content[end:]
+	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
+		return zero, fmt.Errorf("write rendered installer: %w", err)
+	}
+	return sha256.Sum256([]byte(rendered)), nil
+}
+
+func injectWindowsReleaseSources(path string, sources []byte) ([sha256.Size]byte, error) {
+	var zero [sha256.Size]byte
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return zero, fmt.Errorf("read staged installer: %w", err)
+	}
+	content := string(payload)
+	lineEnding := "\r\n"
+	beginMarker := windowsReleaseSourcesBeginLine + lineEnding
+	if !strings.Contains(content, beginMarker) {
+		lineEnding = "\n"
+		beginMarker = windowsReleaseSourcesBeginLine + lineEnding
+	}
+	start := strings.Index(content, beginMarker)
+	if start < 0 {
+		return zero, errors.New("release-source begin marker is missing")
+	}
+	endOffset := strings.Index(content[start+len(beginMarker):], windowsReleaseSourcesEndMarker)
+	if endOffset < 0 {
+		return zero, errors.New("release-source end marker is missing")
+	}
+	entries, err := windowsReleaseSourceEntries(sources)
+	if err != nil {
+		return zero, err
+	}
+	end := start + len(beginMarker) + endOffset
+	var replacement strings.Builder
+	replacement.WriteString(beginMarker)
+	fmt.Fprintf(&replacement, "set \"RELEASE_SOURCE_COUNT=%d\"%s", len(entries), lineEnding)
+	for index, entry := range entries {
+		fmt.Fprintf(&replacement, "set \"RELEASE_SOURCE_%d=%s\"%s", index+1, entry, lineEnding)
+	}
+	rendered := content[:start] + replacement.String() + content[end:]
+	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
+		return zero, fmt.Errorf("write rendered installer: %w", err)
+	}
+	return sha256.Sum256([]byte(rendered)), nil
+}
+
+func windowsReleaseSourceEntries(sources []byte) ([]string, error) {
+	var entries []string
+	for lineNumber, line := range strings.Split(strings.ReplaceAll(string(sources), "\r\n", "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if len(strings.Split(line, "|")) != 3 {
+			return nil, fmt.Errorf("release source line %d must have three fields", lineNumber+1)
+		}
+		if strings.ContainsAny(line, "\r\n\"%") {
+			return nil, fmt.Errorf("release source line %d contains unsupported Windows batch characters", lineNumber+1)
+		}
+		entries = append(entries, line)
+	}
+	if len(entries) == 0 {
+		return nil, errors.New("release sources must contain at least one entry")
+	}
+	return entries, nil
 }
 
 func copyRegularFile(source, destination string) ([sha256.Size]byte, error) {

--- a/scripts/releaseassets/release_sources_test.go
+++ b/scripts/releaseassets/release_sources_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInjectReleaseSourcesRendersVersionedInstallerBlock(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "install.sh")
+	original := "before\n" + releaseSourcesBeginMarker + "release_sources='github-direct|{url}|{url}'\n" + releaseSourcesEndMarker + "\nafter\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sources := []byte("proxy|-|https://proxy.example/{url}\ngithub-direct|{url}|{url}\n")
+	sum, err := injectReleaseSources(path, sources)
+	if err != nil {
+		t.Fatalf("injectReleaseSources() error = %v", err)
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(payload)
+	for _, required := range []string{
+		"before\n",
+		"release_sources=$(cat <<'" + releaseSourcesHeredoc + "'",
+		"proxy|-|https://proxy.example/{url}",
+		releaseSourcesEndMarker,
+		"\nafter\n",
+	} {
+		if !strings.Contains(content, required) {
+			t.Fatalf("rendered installer missing %q:\n%s", required, content)
+		}
+	}
+	if strings.Contains(content, "release_sources='github-direct") {
+		t.Fatalf("rendered installer retained template source block:\n%s", content)
+	}
+	if want := sha256.Sum256(payload); sum != want {
+		t.Fatalf("rendered checksum = %x, want %x", sum, want)
+	}
+}
+
+func TestInjectWindowsReleaseSourcesRendersIndexedCandidates(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "install.cmd")
+	original := "before\r\n" + windowsReleaseSourcesBeginLine + "\r\nset \"RELEASE_SOURCE_COUNT=1\"\r\n" + windowsReleaseSourcesEndMarker + "\r\nafter\r\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := injectWindowsReleaseSources(path, []byte("proxy|https://proxy.example/{url}|https://proxy.example/{url}\ngithub-direct|{url}|{url}\n"))
+	if err != nil {
+		t.Fatalf("injectWindowsReleaseSources() error = %v", err)
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(payload)
+	for _, required := range []string{
+		"set \"RELEASE_SOURCE_COUNT=2\"",
+		"set \"RELEASE_SOURCE_1=proxy|https://proxy.example/{url}|https://proxy.example/{url}\"",
+		"set \"RELEASE_SOURCE_2=github-direct|{url}|{url}\"",
+		windowsReleaseSourcesEndMarker,
+	} {
+		if !strings.Contains(content, required) {
+			t.Fatalf("rendered Windows installer missing %q:\n%s", required, content)
+		}
+	}
+	if !strings.Contains(content, "\r\n") {
+		t.Fatalf("rendered Windows installer lost CRLF bytes: %q", content)
+	}
+}

--- a/scripts/releaseworkflow/publish_policy.go
+++ b/scripts/releaseworkflow/publish_policy.go
@@ -381,7 +381,7 @@ func checkSigningStep(step *yaml.Node) error {
 		}
 	}
 	run, _ := workflowpolicy.MappingValue(step, "run")
-	if err := requireRunFragments(step, "signing-secret step", "trap 'rm -f \"$key_path\"'", "go run ./scripts/releaseassets finalize", "--input-dir dist", "--output-dir release", "--install-sh scripts/install.sh", "--install-cmd scripts/install.cmd", "--private-key \"$key_path\"", "--changelog \"changelog/v${RELEASE_TAG#v}/en.md\"", "--changelog-zh \"changelog/v${RELEASE_TAG#v}/zh-CN.md\""); err != nil {
+	if err := requireRunFragments(step, "signing-secret step", "trap 'rm -f \"$key_path\"'", "go run ./scripts/releaseassets finalize", "--input-dir dist", "--output-dir release", "--install-sh scripts/install.sh", "--install-cmd scripts/install.cmd", "--release-sources internal/update/release_sources.txt", "--private-key \"$key_path\"", "--changelog \"changelog/v${RELEASE_TAG#v}/en.md\"", "--changelog-zh \"changelog/v${RELEASE_TAG#v}/zh-CN.md\""); err != nil {
 		return err
 	}
 	if strings.Contains(run.Value, "set -x") || strings.Contains(run.Value, "echo $RELEASE_SIGNING") {

--- a/scripts/releaseworkflow/publish_security_test.go
+++ b/scripts/releaseworkflow/publish_security_test.go
@@ -393,6 +393,14 @@ func TestCheckWorkflowRejectsSecurityAndQualityPolicyMutations(t *testing.T) {
 			},
 		},
 		{
+			name: "finalize release-source argument removed",
+			want: "signing-secret step must contain --release-sources internal/update/release_sources.txt",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				t.Helper()
+				removeRunFragment(t, stepWithRun(t, jobNode(t, root, "publish"), "go run ./scripts/releaseassets finalize"), "--release-sources internal/update/release_sources.txt")
+			},
+		},
+		{
 			name: "finalize Simplified Chinese changelog argument removed",
 			want: "signing-secret step must contain --changelog-zh \"changelog/v${RELEASE_TAG#v}/zh-CN.md\"",
 			mutate: func(t *testing.T, root *yaml.Node) {

--- a/skills/pixiv-cli/SKILL.md
+++ b/skills/pixiv-cli/SKILL.md
@@ -1,4 +1,11 @@
 ---
+slug: pixiv-cli
+version: 0.7.0
+displayName: Pixiv CLI
+summary: Safely operate Pixiv with the pixiv-cli binary for discovery, account actions, and downloads.
+license: MIT
+homepage: https://github.com/FlanChanXwO/pixiv-cli
+tags: [pixiv, cli, mcp]
 name: pixiv-cli
 description: Operate Pixiv through the pixiv-cli binary — search illustrations, novels, and users; inspect Pixiv artwork or user IDs/URLs; view rankings and recommendations; manage bookmarks/follows; and download works. Load only when the user explicitly mentions Pixiv or pixiv-cli, provides a pixiv.net URL or ID in a clear Pixiv context, or requests a specific Pixiv operation or `pixiv` command. Do not trigger for generic illustration, artist, image-search, or download requests without Pixiv context. Verify current syntax with `pixiv <cmd> --help`.
 ---
@@ -63,7 +70,7 @@ the installed binary's `pixiv <cmd> --help` output.
 | Read | `search` `novel search` `search-options` `detail` `ranking` `recommended` `user *` `config get/path` `version` `update --check` | Execute when the user's task requires it |
 | Account diagnosis | `auth list/check` | List only for authentication/account/fallback decisions; check only when network validation is needed |
 | Write | `bookmark add/remove` `follow add/remove` | State the target (illust/user ID) in one line before executing |
-| Disk | `download` | Confirm target directory and exact ID list before each invocation; approval never carries over; see `references/download.md` |
+| Disk | `download` | Confirm target directory and exact targets (IDs or supported Pixiv URLs) before each invocation; a user URL expands every visual work, so state that scope explicitly; approval never carries over; see `references/download.md` |
 | Interactive credential | `auth login` | Run only on explicit request while the user is present for browser OAuth |
 | Account/config state | `auth use/remove` `config set/unset` `update` (actual install) | Ask for explicit confirmation each time; approval does not carry over |
 | MCP server | `mcp` | Run only when the user explicitly asks to start it; it is a long-lived stdio JSON-RPC server, not a data command—do not auto-probe, auto-wait, or include it in preflight |
@@ -113,7 +120,7 @@ pixiv search "WORD" --rating sfw --type illust --ai-mode exclude
 pixiv search "WORD" --resolution high --aspect-ratio landscape --draw-tool "CLIP STUDIO PAINT"
 pixiv novel search "WORD" --rating sfw --min-text-length 1000 --limit 10 --json
 pixiv search-options "WORD" --json         # authenticated dynamic tool choices
-pixiv detail ILLUST_ID --json             # single artwork detail
+pixiv detail ILLUST_ID_OR_URL --json      # single artwork detail
 pixiv ranking --mode day
 pixiv recommended illust --limit 10       # kind is REQUIRED; needs auth
 pixiv recommended all --limit 10          # request all supported kinds; needs auth
@@ -126,7 +133,7 @@ pixiv bookmark add ILLUST_ID --tag TAG    # --tag repeatable; write op
 pixiv bookmark remove ILLUST_ID           # write op
 pixiv follow add USER_ID                  # write op
 pixiv follow remove USER_ID               # write op
-pixiv download ILLUST_ID... [--pages 1,3-5] [--quality original|regular|small|thumb|mini] [--download-path DIR]
+pixiv download TARGET... [--pages 1,3-5] [--quality original|regular|small|thumb|mini] [--download-path DIR]
 pixiv update --check --json               # read-only update check
 ```
 
@@ -156,17 +163,18 @@ assuming its effective value.
    the maximum result count and `0` requests all results. `--page` requires a
    positive `--limit`.
 4. **Search flags are command-scoped.** Verify `--search-by`, `--period`,
-   `--sort`, `--rating`, `--type`, `--ai-mode`, `--aspect-ratio`,
-   `--resolution`, and `--draw-tool` against `pixiv search --help`; do not infer
+   `--start-date`, `--end-date`, `--sort`, `--rating`, `--type`, `--ai-mode`, `--aspect-ratio`,
+   `--resolution`, `--draw-tool`, `--bookmark-min`, and `--bookmark-max` against `pixiv search --help`; do not infer
    undocumented aliases or attach illustration-only filters to other commands.
    `novel search` supports `--search-by`, `--sort`, `--period`, `--rating`,
    `--min-text-length`, `--max-text-length`, and `--original-only`; it does not
    support illustration AI, drawing-tool, resolution, aspect-ratio, or type filters.
 5. **Anonymous restricted search fails explicitly.** Web fallback uses only
-   reliable illustration-search filters. `r18`, `r18g`, `mature`, and `search-options`
+   reliable illustration-search filters. `r18`, `r18g`, `mature`, `--search-by tag-title-caption`,
+   bookmark-count bounds, and `search-options`
    require App authentication; do not present the failure as an empty result
    or add a Cookie workaround. `novel search` is App-only and requires authentication.
-   Bookmark-count filtering is unavailable.
+   Bookmark count is a public bookmark total, never a like count.
 6. **Extended rankings need authentication.** Valid modes are `day`,
    `day_male`, `day_female`, `week`, `week_original`, `week_rookie`, `month`,
    `day_manga`, `week_manga`, `month_manga`, `week_rookie_manga`, `day_r18`,
@@ -184,10 +192,22 @@ assuming its effective value.
 11. **Long downloads may legitimately take time.** Do not impose an arbitrary
    timeout or kill the process merely because it is slow; wait for completion,
    user cancellation, or a real error.
-12. **`--tag` has two narrow meanings.** `user bookmarks --tag TAG` filters
+12. **Tag search has query grammar.** `user bookmarks --tag TAG` filters
    bookmark listings; `bookmark add --tag TAG` adds a repeatable bookmark tag.
-   `search` has no `--tag` flag — put the tag text in its required `WORD` and
-   choose `--search-by tag-exact` when exact matching is needed.
+   `search` has no `--tag` flag — put the tag expression in its required `WORD`.
+   For a reliable boolean tag query, use `--search-by tag-exact`: `tagA tagB`
+   requires both complete tags, and uppercase `tagA OR tagB` accepts either.
+   Literal `AND` is not an operator. The default `tag-partial` also accepts the
+   verified uppercase `OR` syntax, but its fuzzy/alias/translated matches are
+   not a strict exact-tag AND. `title-caption` and App-only `tag-title-caption` have no boolean-tag contract;
+   no literal-uppercase-`OR` escape syntax is verified.
+13. **Direct URLs are intentionally narrow.** `detail` accepts only an artwork
+    ID or a `pixiv.net`/`www.pixiv.net` HTTPS `/artworks/{id}` URL (an optional
+    locale, query, or fragment is harmless). `download` also accepts `/users/{id}`
+    and `/users/{id}/artworks`, which expand every illust, manga, and ugoira for
+    that user — no novels and no implicit limit. User URL downloads require App
+    OAuth and never use Cookie, WebView, or anonymous fallback. Do not suggest
+    short links, old URLs, FANBOX, Pixivision, Sketch, or HTML scraping.
 
 ## Routing
 

--- a/skills/pixiv-cli/references/discover.md
+++ b/skills/pixiv-cli/references/discover.md
@@ -10,9 +10,17 @@ pixiv search "初音ミク" --limit 10 --json
 ```
 
 - Default search field is partial tag match (`--search-by tag-partial`); switch
-  to `--search-by tag-exact` or `--search-by title-caption` when the user asks for
-  exact tags or title/caption search. Use `--period day|week|month` to limit
-  the time range, or `--sort date_desc|date_asc` to choose the order.
+  to `--search-by tag-exact`, `--search-by title-caption`, or authenticated
+  `--search-by tag-title-caption` when the user asks for exact tags, title/caption,
+  or tags-plus-title/caption search. Use `--period day|week|month|half-year|year`
+  to limit the time range, or use inclusive `--start-date YYYY-MM-DD` and/or
+  `--end-date YYYY-MM-DD` (never together with `--period`).
+- For a reliable boolean tag query, use exact tags: `pixiv search "tagA tagB"
+  --search-by tag-exact` requires both tags, while `pixiv search "tagA OR tagB"
+  --search-by tag-exact` accepts either tag. `OR` is uppercase; literal `AND`
+  is not an operator. Partial tag search also accepts the verified uppercase
+  `OR`, but it can match partial, alias, or translated tags and is not a strict
+  exact-tag AND. `title-caption` and `tag-title-caption` have no boolean-tag contract.
 - `search` does not have a `--tag` flag. Supply tag text as the required `WORD`;
   reserve `--tag` for `user bookmarks` (filter) and `bookmark add` (repeatable
   bookmark tag).
@@ -20,12 +28,13 @@ pixiv search "初音ミク" --limit 10 --json
 - Stable filters include `--rating sfw|r18|r18g|mature|all`, `--type
   all|illust-and-ugoira|illust|manga|ugoira`, `--ai-mode all|exclude|only`,
   `--aspect-ratio all|landscape|portrait|square`, `--resolution
-  all|high|medium|low`, and exact `--draw-tool` names. Only pass restricted ratings
-  when the user explicitly asks.
+  all|high|medium|low`, exact `--draw-tool` names, and App-only `--bookmark-min N`
+  / `--bookmark-max N` public bookmark-count bounds. Only pass restricted ratings
+  or bookmark bounds when the user explicitly asks; never call bookmark count a like count.
 - Tool names are dynamic. Run authenticated `pixiv search-options "WORD"
   --json`, then pass the returned name exactly. Do not hard-code a list.
-- Anonymous Web search accepts only its reliable filters. R18/R18G/mature and
-  `search-options` require authentication; never add a Cookie workaround or
+- Anonymous Web search accepts only its reliable filters. R18/R18G/mature,
+  `tag-title-caption`, bookmark bounds, and `search-options` require authentication; never add a Cookie workaround or
   report an authentication failure as an empty result.
 - Need page 2+: `--page N` (1-based) with a positive `--limit`.
 - Local filters skip leading empty upstream batches until the first non-empty

--- a/skills/pixiv-cli/references/download.md
+++ b/skills/pixiv-cli/references/download.md
@@ -7,8 +7,9 @@ Downloads write to disk — always run the checklist first.
 1. `pixiv config get download_path` — confirm the target directory with the
    user (default `./downloads`, resolved against the *current working
    directory*, so state your cwd when confirming).
-2. Confirm the exact ID list and item count immediately before each
-   `pixiv download` invocation. Approval is single-use and never carries over
+2. Confirm the exact targets and item scope immediately before each
+   `pixiv download` invocation. A user URL means every visual work by that
+   user, with no implicit limit; approval is single-use and never carries over
    to another download command.
 3. Only override with `--download-path DIR` / `--filename-template T` when the
    user asked for a specific location or naming; these flags never persist.
@@ -18,6 +19,7 @@ Downloads write to disk — always run the checklist first.
 ```
 pixiv download 129543211
 pixiv download 129543211 130000001 130000002
+pixiv download https://www.pixiv.net/artworks/129543211
 pixiv download 129543211 --pages 1,3-5 --quality regular
 ```
 
@@ -35,6 +37,30 @@ pixiv download 129543211 --pages 1,3-5 --quality regular
 - Filename template default: `{author} - {title}_{id}`. Placeholders: `{id}`,
   `{title}`, `{author}`, `{author_id}`. Persist a new default with
   `pixiv config set filename_template "..."` (confirm first — config write).
+
+## Direct Pixiv URLs and whole-user downloads
+
+`detail` accepts an artwork ID or only a current official artwork page URL:
+`https://pixiv.net/artworks/{id}` or `https://www.pixiv.net/artworks/{id}`.
+`download` accepts those plus `https://pixiv.net/users/{id}` and
+`https://pixiv.net/users/{id}/artworks` (the `www` host and an optional locale,
+query, or fragment are also valid).
+
+```
+pixiv download https://www.pixiv.net/users/12345678
+pixiv download https://www.pixiv.net/en/users/12345678/artworks
+```
+
+- A user URL walks every `illust`, `manga`, and `ugoira` in upstream page order;
+  it does not download novels and does not add an implicit count, page, retry, or
+  timeout limit. It requires App OAuth; never add a Cookie, WebView, anonymous
+  fallback, redirect, or HTML-scraping workaround.
+- Only the listed `pixiv.net` / `www.pixiv.net` HTTPS paths are accepted. Short
+  links, old URL shapes, novels, FANBOX, Pixivision, Sketch, other hosts, and
+  other paths fail locally before the SDK or downloader opens.
+- Downloads preserve CLI argument order. They do not create a cache, database,
+  history, or cross-run de-duplication; repeated inputs are intentionally
+  processed again.
 
 ## Animated works
 
@@ -63,7 +89,12 @@ Chain from JSON rather than scraping human output:
 
 ## Reporting results
 
-- Per-ID outcomes: report which IDs succeeded and which failed, with the real
-  error for each failure. Never summarize failures away as "done".
+- The JSON report is `{items, failures}`. Each successful item includes its
+  canonical artwork URL, ID, work type, and every downloaded file's page/path;
+  each failure includes a safe URL/ID/type/message summary. A partial failure
+  exits non-zero after reporting all completed outcomes; cancellation stops
+  immediately.
+- Per-target outcomes: report which references succeeded and which failed.
+  Never summarize failures away as "done".
 - Anonymous sessions can download public works via web fallback; restricted or
   R-18 works may fail — surface the real API error, don't retry blindly.

--- a/skills/pixiv-cli/references/install.md
+++ b/skills/pixiv-cli/references/install.md
@@ -9,7 +9,7 @@ running anything.
 
 - Repository: `https://github.com/FlanChanXwO/pixiv-cli`
 - Unix installer:
-  `https://raw.githubusercontent.com/FlanChanXwO/pixiv-cli/main/scripts/install.sh`
+  `https://github.com/FlanChanXwO/pixiv-cli/releases/latest/download/install.sh`
 - Windows CMD installer:
   `https://raw.githubusercontent.com/FlanChanXwO/pixiv-cli/main/scripts/install.cmd`
 
@@ -27,8 +27,10 @@ The installer itself must select the latest stable official Release and report
    install directory to the current user's PATH; do not request administrator
    or root privileges.
 4. If `curl`, `tar`, the checksum tool, or another declared prerequisite is
-   missing, stop and ask before installing it. Never silently switch to another
-   download or extraction path.
+   missing, stop and ask before installing it. Do not manually substitute a
+   download or extraction path: the official versioned installer alone may
+   select its embedded public Release transport candidates after matching the
+   direct GitHub checksum.
 5. Never read authentication storage, import/export authentication, or request
    a Pixiv credential as part of installation.
 6. Require installer success, then run `pixiv version`. Report the installed


### PR DESCRIPTION
## Summary

- prepare the v0.7.0 bilingual changelog and product documentation
- add URL-aware search/download and public Release-source acceleration with verified update/install paths
- publish the tag-matched `pixiv-cli` product skill to SkillHub after each GitHub Release

## Validation

- `go test ./...`
- `go vet ./...`
- `pre-commit run --all-files`
- `sh scripts/test-release-workflow.sh`
- `skillhub --skip-self-upgrade publish skills/pixiv-cli --host https://api.skillhub.cn --version 0.7.0 --dry-run --json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * `detail` 和 `download` 支持直接使用 Pixiv 作品 URL及用户作品 URL。
  * 搜索新增关键词、日期范围和收藏数区间筛选。
  * 下载结果提供成功项与失败项明细，并支持部分失败后继续处理。
  * 更新器和安装器支持多来源探测、校验及失败回退。
  * 发布版本可自动提交至 SkillHub。

* **文档**
  * 更新中英文、日文安装指南、命令参考、MCP/SDK 文档及 v0.7.0 更新日志。
  * 补充 URL 输入、认证要求、下载范围和校验流程说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->