### PR TITLE
fix(ci): trigger SkillHub after release workflow

### DIFF
--- a/.github/workflows/publish-skillhub.yml
+++ b/.github/workflows/publish-skillhub.yml
@@ -1,9 +1,14 @@
 name: Publish SkillHub skill
 
 on:
-  release:
+  # Release is created with github.token, which intentionally cannot trigger a
+  # second `release` workflow. workflow_run is the safe handoff after all
+  # release and Homebrew gates finish.
+  workflow_run:
+    workflows:
+      - Release
     types:
-      - published
+      - completed
   workflow_dispatch:
     inputs:
       release_tag:
@@ -11,11 +16,11 @@ on:
         required: true
         type: string
 
-# Release events load this workflow from the default branch. The checkout below is
-# nevertheless pinned to the immutable release tag, so the submitted Skill always
-# matches the GitHub Release rather than a later main commit.
+# workflow_run definitions are loaded from the default branch. The checkout below
+# is nevertheless pinned to the immutable release tag, so the submitted Skill
+# always matches the GitHub Release rather than a later main commit.
 env:
-  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }}
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.workflow_run.head_branch }}
   SKILLHUB_HOST: https://api.skillhub.cn
 
 permissions: {}
@@ -23,6 +28,10 @@ permissions: {}
 jobs:
   publish:
     name: Publish pixiv-cli to SkillHub
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/changelog/unreleased/en.md
+++ b/changelog/unreleased/en.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+## Fixed
+
+- Trigger the automatic SkillHub publication from a successful Release workflow instead of its GitHub Release event, because releases created with `github.token` do not recursively emit that event to Actions.

--- a/changelog/unreleased/zh-CN.md
+++ b/changelog/unreleased/zh-CN.md
@@ -1,1 +1,5 @@
 # 未发布
+
+## 修复
+
+- 自动 SkillHub 发布现在由成功结束的 Release workflow 触发，而非 GitHub Release event；后者由 `github.token` 创建时不会递归触发 Actions。

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -549,8 +549,10 @@ workflow artifact 读取、生成或记录 deploy key。
 当前 Release 不会进行 Apple notarization 或 Windows Authenticode。直接下载仍可能被 Gatekeeper
 或 SmartScreen 拦截/提示；这是需要在用户文档中保留的系统信誉边界，不能通过文档或脚本绕过。
 
-已公开的 GitHub Release 还会触发 `.github/workflows/publish-skillhub.yml`。该工作流只 checkout
-不可变 release tag，并确认该 tag 属于默认分支、对应 GitHub Release 已公开且版本满足 SemVer 后，才对
+成功结束的 `Release` workflow 会触发 `.github/workflows/publish-skillhub.yml`。GitHub 以
+`github.token` 创建 Release 时不会递归触发 `release` event，因此不能将该 event 用作可靠的自动化
+交接。SkillHub workflow 只 checkout 不可变 release tag，并确认该 tag 属于默认分支、对应 GitHub Release
+已公开且版本满足 SemVer 后，才对
 `skills/pixiv-cli/` 运行 SkillHub CLI 的 dry-run 和提交。`SKILLHUB_TOKEN` 仅进入最后的提交步骤，CLI
 必须返回 `skillId` 和审核状态；这证明 SkillHub 已接收提交，但平台审核完成前公开详情页可能仍不可见。
 若该独立发布失败，可通过同一 workflow 的 `workflow_dispatch` 输入既有发布 tag 恢复，不能用 main 的


### PR DESCRIPTION
## Summary

- trigger SkillHub publication from a successful `Release` workflow rather than a `release` event
- retain immutable-tag, published-Release, and source-branch verification
- document the `github.token` non-recursive event boundary

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-skillhub.yml")'`\n- `skillhub --skip-self-upgrade publish skills/pixiv-cli --host https://api.skillhub.cn --version 0.7.0 --dry-run --json`\n- `go test ./scripts/documentation ./scripts/releaseworkflow -count=1`\n- `sh scripts/test-release-workflow.sh`

## Summary by Sourcery

从已完成的 Release 工作流而不是 GitHub Release 事件触发 SkillHub 发布，同时保留标签和分支的安全检查，并记录事件边界行为。

Bug Fixes:
- 通过从 GitHub Release 事件切换为成功的 Release `workflow_run` 触发，确保自动 SkillHub 发布可靠运行。

Enhancements:
- 添加条件保护，仅在 Release 工作流在有版本标记的发布分支上成功完成时进行发布。
- 明确维护者文档中关于 Release 和 SkillHub 工作流的说明，包括基于 `github.token` 驱动的 Release 事件的非递归特性。

Documentation:
- 更新维护者开发指南，描述新的 SkillHub 工作流触发行为及其事件边界。
- 在英文和中文的未发布变更日志中新增关于 SkillHub 触发变更的条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Trigger SkillHub publication from the completed Release workflow instead of the GitHub Release event, preserving tag and branch safety checks and documenting the event boundary behavior.

Bug Fixes:
- Ensure automatic SkillHub publication runs reliably by switching from the GitHub Release event to a successful Release workflow_run trigger.

Enhancements:
- Add conditional guards to only publish when the Release workflow completes successfully on versioned release branches.
- Clarify maintainer documentation about Release and SkillHub workflows, including the non-recursive nature of github.token-driven release events.

Documentation:
- Update maintainer development guide to describe the new SkillHub workflow trigger behavior and event boundary.
- Add unreleased changelog entries in English and Chinese for the SkillHub trigger change.

</details>