### PR TITLE
fix(ci): accept SkillHub review status

### DIFF
--- a/.github/workflows/publish-skillhub.yml
+++ b/.github/workflows/publish-skillhub.yml
@@ -99,11 +99,11 @@ jobs:
               result = json.load(source)
 
           skill_id = result.get("skillId")
-          status = result.get("status")
-          if not skill_id or not status:
-              raise SystemExit("SkillHub accepted the request without skillId or status")
+          review_status = result.get("reviewStatus") or result.get("status")
+          if result.get("ok") is not True or not skill_id or not review_status:
+              raise SystemExit("SkillHub accepted the request without skillId or review status")
 
-          print(f"SkillHub submission confirmed: skillId={skill_id} status={status}")
+          print(f"SkillHub submission confirmed: skillId={skill_id} reviewStatus={review_status}")
           public_url = result.get("publicUrl")
           if public_url:
               print(f"SkillHub URL: {public_url}")

--- a/changelog/unreleased/en.md
+++ b/changelog/unreleased/en.md
@@ -3,3 +3,4 @@
 ## Fixed
 
 - Trigger the automatic SkillHub publication from a successful Release workflow instead of its GitHub Release event, because releases created with `github.token` do not recursively emit that event to Actions.
+- Accept SkillHub's community `reviewStatus` response field when confirming an accepted submission, so a successful publish is not reported as failed.

--- a/changelog/unreleased/zh-CN.md
+++ b/changelog/unreleased/zh-CN.md
@@ -3,3 +3,4 @@
 ## 修复
 
 - 自动 SkillHub 发布现在由成功结束的 Release workflow 触发，而非 GitHub Release event；后者由 `github.token` 创建时不会递归触发 Actions。
+- 确认 SkillHub 社区提交时现在识别其 `reviewStatus` 返回字段，避免已成功发布被误报为失败。


### PR DESCRIPTION
## Summary

- recognize SkillHub community API `reviewStatus` as the accepted-submission state
- require `ok=true`, `skillId`, and a review status before reporting workflow success
- cover the observed response shape in the bilingual unreleased changelog

## Validation

- response-shape parser regression using SkillHub `skillId=120070`, `reviewStatus=pending`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-skillhub.yml")'`\n- `skillhub --skip-self-upgrade publish skills/pixiv-cli --host https://api.skillhub.cn --version 0.7.0 --dry-run --json`\n- `go test ./scripts/documentation ./scripts/releaseworkflow -count=1`\n- `sh scripts/test-release-workflow.sh`

## Summary by Sourcery

确保 SkillHub 发布工作流仅在 API 响应表明提交已被接受且包含必需字段时才报告成功。

Bug Fixes:
- 将 SkillHub 社区 API 的 `reviewStatus` 字段视为权威的“已接受提交”状态，以避免将实际成功的发布误报为失败。
- 只有在 SkillHub API 返回 `ok=true`、`skillId`，并且包含审核状态（review status）时，才将发布工作流视为成功。

Documentation:
- 在尚未发布的英文和中文更新日志中记录更新后的 SkillHub 响应处理语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure SkillHub publish workflow only reports success when the API response indicates an accepted submission with required fields.

Bug Fixes:
- Treat SkillHub community API reviewStatus field as the authoritative accepted-submission state to avoid misreporting successful publishes as failures.
- Require ok=true, skillId, and a review status from the SkillHub API before considering the publish workflow successful.

Documentation:
- Document the updated SkillHub response handling semantics in the unreleased English and Chinese changelogs.

</details>