### PR TITLE
fix(ci): skip unchanged SkillHub publication

### DIFF
--- a/.github/workflows/publish-skillhub.yml
+++ b/.github/workflows/publish-skillhub.yml
@@ -42,6 +42,7 @@ jobs:
           persist-credentials: false
           ref: ${{ env.RELEASE_TAG }}
       - name: Verify the published release tag belongs to the default branch
+        id: skill_change
         shell: bash
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -59,9 +60,25 @@ jobs:
           test "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.draft')" = false
           test -n "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.published_at')"
           go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"
+          previous_tag="$(
+            git tag --merged "$RELEASE_TAG" --list 'v[0-9]*' --sort=-v:refname |
+              while IFS= read -r tag; do
+                if [ "$tag" != "$RELEASE_TAG" ]; then
+                  printf '%s\n' "$tag"
+                  break
+                fi
+              done
+          )"
+          if [ -n "$previous_tag" ] && git diff --quiet "$previous_tag" "$RELEASE_TAG" -- skills/pixiv-cli; then
+            printf '%s\n' 'publish=false' >> "$GITHUB_OUTPUT"
+            printf 'Skill unchanged since %s; skipping SkillHub publication.\n' "$previous_tag"
+          else
+            printf '%s\n' 'publish=true' >> "$GITHUB_OUTPUT"
+          fi
       # The vendor installer runs before this workflow makes SKILLHUB_TOKEN available.
       # Its CLI is only used after the immutable tag and local metadata have passed.
       - name: Install the official SkillHub CLI without credentials
+        if: steps.skill_change.outputs.publish == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -70,15 +87,16 @@ jobs:
           bash "$installer" --cli-only
           "$HOME/.local/bin/skillhub" --skip-self-upgrade --version
       - name: Dry-run the exact tagged product skill
+        if: steps.skill_change.outputs.publish == 'true'
         shell: bash
         run: |
           set -euo pipefail
           "$HOME/.local/bin/skillhub" --skip-self-upgrade publish skills/pixiv-cli \
             --host "$SKILLHUB_HOST" \
-            --version "${RELEASE_TAG#v}" \
             --dry-run \
             --json
       - name: Publish and confirm the SkillHub submission
+        if: steps.skill_change.outputs.publish == 'true'
         shell: bash
         env:
           SKILLHUB_TOKEN: ${{ secrets.SKILLHUB_TOKEN }}
@@ -88,7 +106,6 @@ jobs:
           response="$RUNNER_TEMP/skillhub-publish.json"
           "$HOME/.local/bin/skillhub" --skip-self-upgrade publish skills/pixiv-cli \
             --host "$SKILLHUB_HOST" \
-            --version "${RELEASE_TAG#v}" \
             --changelog "Synchronized with Pixiv CLI $RELEASE_TAG" \
             --json | tee "$response"
           python3 - "$response" <<'PY'

--- a/.github/workflows/publish-skillhub.yml
+++ b/.github/workflows/publish-skillhub.yml
@@ -60,20 +60,35 @@ jobs:
           test "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.draft')" = false
           test -n "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.published_at')"
           go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"
-          previous_tag="$(
-            git tag --merged "$RELEASE_TAG" --list 'v[0-9]*' --sort=-v:refname |
-              while IFS= read -r tag; do
-                if [ "$tag" != "$RELEASE_TAG" ]; then
-                  printf '%s\n' "$tag"
-                  break
-                fi
-              done
-          )"
-          if [ -n "$previous_tag" ] && git diff --quiet "$previous_tag" "$RELEASE_TAG" -- skills/pixiv-cli; then
-            printf '%s\n' 'publish=false' >> "$GITHUB_OUTPUT"
-            printf 'Skill unchanged since %s; skipping SkillHub publication.\n' "$previous_tag"
-          else
+          previous_tag=
+          while IFS= read -r tag; do
+            if [ "$tag" != "$RELEASE_TAG" ] && go run ./scripts/releaseassets validate --version "${tag#v}" >/dev/null 2>&1; then
+              previous_tag=$tag
+              break
+            fi
+          done <<EOF
+          $(git tag --merged "$RELEASE_TAG" --list 'v[0-9]*' --sort=-v:refname)
+          EOF
+          if [ -z "$previous_tag" ]; then
             printf '%s\n' 'publish=true' >> "$GITHUB_OUTPUT"
+          else
+            set +e
+            git diff --quiet "$previous_tag" "$RELEASE_TAG" -- skills/pixiv-cli
+            diff_status=$?
+            set -e
+            case "$diff_status" in
+              0)
+                printf '%s\n' 'publish=false' >> "$GITHUB_OUTPUT"
+                printf 'Skill unchanged since %s; skipping SkillHub publication.\n' "$previous_tag"
+                ;;
+              1)
+                printf '%s\n' 'publish=true' >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                printf 'cannot compare Skill changes from %s to %s\n' "$previous_tag" "$RELEASE_TAG" >&2
+                exit "$diff_status"
+                ;;
+            esac
           fi
       # The vendor installer runs before this workflow makes SKILLHUB_TOKEN available.
       # Its CLI is only used after the immutable tag and local metadata have passed.

--- a/changelog/unreleased/en.md
+++ b/changelog/unreleased/en.md
@@ -4,3 +4,4 @@
 
 - Trigger the automatic SkillHub publication from a successful Release workflow instead of its GitHub Release event, because releases created with `github.token` do not recursively emit that event to Actions.
 - Accept SkillHub's community `reviewStatus` response field when confirming an accepted submission, so a successful publish is not reported as failed.
+- Skip SkillHub publication when `skills/pixiv-cli/` is unchanged from the preceding release tag, and let the Skill's own frontmatter version advance independently from the CLI release version.

--- a/changelog/unreleased/zh-CN.md
+++ b/changelog/unreleased/zh-CN.md
@@ -4,3 +4,4 @@
 
 - 自动 SkillHub 发布现在由成功结束的 Release workflow 触发，而非 GitHub Release event；后者由 `github.token` 创建时不会递归触发 Actions。
 - 确认 SkillHub 社区提交时现在识别其 `reviewStatus` 返回字段，避免已成功发布被误报为失败。
+- 若 `skills/pixiv-cli/` 与上一个 release tag 相比没有变化，则跳过 SkillHub 提交；Skill 的 frontmatter 版本独立于 CLI Release 版本，仅在 Skill 实际变化时递增。

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -553,8 +553,10 @@ workflow artifact 读取、生成或记录 deploy key。
 `github.token` 创建 Release 时不会递归触发 `release` event，因此不能将该 event 用作可靠的自动化
 交接。SkillHub workflow 只 checkout 不可变 release tag，并确认该 tag 属于默认分支、对应 GitHub Release
 已公开且版本满足 SemVer 后，才对
-`skills/pixiv-cli/` 运行 SkillHub CLI 的 dry-run 和提交。`SKILLHUB_TOKEN` 仅进入最后的提交步骤，CLI
-必须返回 `skillId` 和审核状态；这证明 SkillHub 已接收提交，但平台审核完成前公开详情页可能仍不可见。
+`skills/pixiv-cli/` 与前一个已合并的语义版本 tag 比较。目录未变化时工作流成功跳过；目录变化时才运行
+SkillHub CLI 的 dry-run 和提交，并使用 `SKILL.md` 内的独立 SemVer，而非 CLI Release tag。`SKILLHUB_TOKEN`
+仅进入最后的提交步骤，CLI 必须返回 `skillId` 和审核状态；这证明 SkillHub 已接收提交，但平台审核完成前
+公开详情页可能仍不可见。
 若该独立发布失败，可通过同一 workflow 的 `workflow_dispatch` 输入既有发布 tag 恢复，不能用 main 的
 后续内容替代该 tag。
 

--- a/scripts/installers/installers_test.go
+++ b/scripts/installers/installers_test.go
@@ -89,6 +89,11 @@ func TestInstallShSelectsFastestVerifiedSourceAndRetriesArchive(t *testing.T) {
 	fixtureDir, assetName := prepareUnixFixture(t, false)
 	fakeBin := prepareFakeCurl(t)
 	logPath := filepath.Join(t.TempDir(), "curl.log")
+	fastChecksumReady := filepath.Join(t.TempDir(), "fast-checksum-ready")
+	fastChecksumGateArmed := filepath.Join(t.TempDir(), "fast-checksum-gate-armed")
+	if output, err := exec.Command("mkfifo", fastChecksumReady).CombinedOutput(); err != nil {
+		t.Fatalf("create fast checksum fixture gate: %v\n%s", err, output)
+	}
 	installDir := t.TempDir()
 	command := exec.Command("sh", filepath.Join("..", "install.sh"), "--install-dir", installDir, "--no-path")
 	command.Env = append(os.Environ(),
@@ -97,9 +102,12 @@ func TestInstallShSelectsFastestVerifiedSourceAndRetriesArchive(t *testing.T) {
 		"PIXIV_INSTALLER_CURL_LOG="+logPath,
 		"PIXIV_INSTALLER_CURL_FAIL_ARCHIVE_HOST=fast.example",
 		"PIXIV_INSTALLER_CURL_FAIL_CHECKSUM_HOST=fallback.example",
-		// fixture 让直连 checksum 在 fast source 返回之后才完成，避免并发 probe 的
-		// scheduler 偶然顺序掩盖“最快已验证候选被优先选中”的用户可见契约。
-		"PIXIV_INSTALLER_CURL_DELAY_CHECKSUM_URL_PREFIX=https://github.com/",
+		// fast checksum 的成功写入会放行直连 checksum，避免并发 probe 的 scheduler
+		// 偶然顺序掩盖“最快已验证候选被优先选中”的用户可见契约。
+		"PIXIV_INSTALLER_CURL_WAIT_CHECKSUM_URL_PREFIX=https://github.com/",
+		"PIXIV_INSTALLER_CURL_SIGNAL_CHECKSUM_URL_PREFIX=https://fast.example/",
+		"PIXIV_INSTALLER_CURL_CHECKSUM_GATE="+fastChecksumReady,
+		"PIXIV_INSTALLER_CURL_CHECKSUM_GATE_STATE="+fastChecksumGateArmed,
 		"PIXIV_RELEASE_SOURCES=fast|-|https://fast.example/{url}\nfallback|-|https://fallback.example/{url}\ngithub-direct|{url}|{url}",
 	)
 	if output, err := command.CombinedOutput(); err != nil {
@@ -477,18 +485,32 @@ case "${PIXIV_INSTALLER_CURL_FAIL_CHECKSUM_HOST:-}" in
     esac
     ;;
 esac
-case "${PIXIV_INSTALLER_CURL_DELAY_CHECKSUM_URL_PREFIX:-}" in
+case "${PIXIV_INSTALLER_CURL_WAIT_CHECKSUM_URL_PREFIX:-}" in
   '') ;;
   *)
     case "$url" in
-      "$PIXIV_INSTALLER_CURL_DELAY_CHECKSUM_URL_PREFIX"*checksums.txt)
-        # 仅 fixture：让测试能确定地观察到 fast source 的优先选择。
-        sleep 1
+      "$PIXIV_INSTALLER_CURL_WAIT_CHECKSUM_URL_PREFIX"*checksums.txt)
+        # 首个直连请求是安装器的权威 checksum；随后才让并发的直连 probe
+        # 等待 fast checksum 成功，以免其抢占 FIFO 结果。
+        if [ -e "$PIXIV_INSTALLER_CURL_CHECKSUM_GATE_STATE" ]; then
+          IFS= read -r _ < "$PIXIV_INSTALLER_CURL_CHECKSUM_GATE"
+        fi
+        : > "$PIXIV_INSTALLER_CURL_CHECKSUM_GATE_STATE"
         ;;
     esac
     ;;
 esac
 cp "$PIXIV_INSTALLER_FIXTURES/${url##*/}" "$output"
+case "${PIXIV_INSTALLER_CURL_SIGNAL_CHECKSUM_URL_PREFIX:-}" in
+  '') ;;
+  *)
+    case "$url" in
+      "$PIXIV_INSTALLER_CURL_SIGNAL_CHECKSUM_URL_PREFIX"*checksums.txt)
+        printf '%s\n' ready > "$PIXIV_INSTALLER_CURL_CHECKSUM_GATE"
+        ;;
+    esac
+    ;;
+esac
 `
 	path := filepath.Join(directory, "curl")
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {

--- a/scripts/installers/installers_test.go
+++ b/scripts/installers/installers_test.go
@@ -97,6 +97,9 @@ func TestInstallShSelectsFastestVerifiedSourceAndRetriesArchive(t *testing.T) {
 		"PIXIV_INSTALLER_CURL_LOG="+logPath,
 		"PIXIV_INSTALLER_CURL_FAIL_ARCHIVE_HOST=fast.example",
 		"PIXIV_INSTALLER_CURL_FAIL_CHECKSUM_HOST=fallback.example",
+		// fixture 让直连 checksum 在 fast source 返回之后才完成，避免并发 probe 的
+		// scheduler 偶然顺序掩盖“最快已验证候选被优先选中”的用户可见契约。
+		"PIXIV_INSTALLER_CURL_DELAY_CHECKSUM_URL_PREFIX=https://github.com/",
 		"PIXIV_RELEASE_SOURCES=fast|-|https://fast.example/{url}\nfallback|-|https://fallback.example/{url}\ngithub-direct|{url}|{url}",
 	)
 	if output, err := command.CombinedOutput(); err != nil {
@@ -471,6 +474,17 @@ case "${PIXIV_INSTALLER_CURL_FAIL_CHECKSUM_HOST:-}" in
   *)
     case "$url" in
       *"$PIXIV_INSTALLER_CURL_FAIL_CHECKSUM_HOST"*/checksums.txt) exit 22 ;;
+    esac
+    ;;
+esac
+case "${PIXIV_INSTALLER_CURL_DELAY_CHECKSUM_URL_PREFIX:-}" in
+  '') ;;
+  *)
+    case "$url" in
+      "$PIXIV_INSTALLER_CURL_DELAY_CHECKSUM_URL_PREFIX"*checksums.txt)
+        # 仅 fixture：让测试能确定地观察到 fast source 的优先选择。
+        sleep 1
+        ;;
     esac
     ;;
 esac


### PR DESCRIPTION
## Summary

- publish the product skill only when `skills/pixiv-cli/` changed since the preceding release tag
- use the Skill frontmatter SemVer instead of the CLI release tag
- document the independent Skill release cadence

## Validation

- tag-diff check: `v0.6.0..v0.7.0` detected a Skill change
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-skillhub.yml")'`\n- `skillhub --skip-self-upgrade publish skills/pixiv-cli --host https://api.skillhub.cn --dry-run --json`\n- `go test ./scripts/documentation ./scripts/releaseworkflow -count=1`\n- `sh scripts/test-release-workflow.sh`

## Summary by Sourcery

在发布标签之间检测到 pixiv CLI 技能目录的变更后，才允许发布到 SkillHub，并使工作流与该技能自身的版本语义保持一致。

新功能：
- 引入条件化的 SkillHub 发布流程，仅当自上一个合并的语义版本标签以来 `skills/pixiv-cli/` 发生变更时才运行。

增强项：
- 在发布到 SkillHub 时，使用 `SKILL.md` 中技能前置说明（frontmatter）里的语义版本，而不是 CLI 的发布标签。
- 在维护者文档和更新日志中记录 pixiv CLI 技能独立的发布节奏及其变更检测行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate SkillHub publication on detected changes to the pixiv CLI skill directory between release tags and align the workflow with the skill’s own versioning semantics.

New Features:
- Introduce conditional SkillHub publishing that only runs when `skills/pixiv-cli/` has changed since the preceding merged semantic version tag.

Enhancements:
- Use the Skill frontmatter semantic version from `SKILL.md` instead of the CLI release tag when publishing to SkillHub.
- Document the independent release cadence and change-detection behavior for the pixiv CLI Skill in maintainer docs and changelog.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 当 Skill 内容自上次发布以来没有变化时，将自动跳过重复发布，减少无效提交。
  * Skill 的版本号将独立于 CLI 版本，仅在 Skill 实际更新时递增。
* **文档**
  * 补充发布流程说明，包括跳过条件、发布确认状态及审核期间的展示限制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->