### PR TITLE
docs(search): clarify Pixiv Premium requirement

### DIFF
--- a/changelog/v0.7.0/en.md
+++ b/changelog/v0.7.0/en.md
@@ -5,7 +5,7 @@
 - Release-binary updates and versioned installer assets now carry a static, tested free GitHub Release-source list. They probe viable routes locally, support path and query-parameter proxy templates, and never fetch a remote mirror list.
 - Existing `detail` and `download` inputs now accept strict official Pixiv artwork URLs; `download` also accepts authenticated user profile and artworks URLs to walk every illustration, manga, and ugoira without downloading novels.
 - MCP `illust_detail` accepts exactly one of an ID or URL, and `download` accepts URLs. Illustration query tools now return typed structured results alongside compact text summaries.
-- Illustration `search` and MCP `search_illust` now support official App `keyword` search (tags, titles, and captions), inclusive explicit date bounds, public bookmark-count bounds, and the `half-year` / `year` quick date ranges. App-only filters fail explicitly without App OAuth; no cookie fallback is introduced.
+- Illustration `search` and MCP `search_illust` now support official App `keyword` search (tags, titles, and captions), inclusive explicit date bounds, public bookmark-count bounds, and the `half-year` / `year` quick date ranges. Bookmark-count bounds require both App OAuth and an active Pixiv Premium membership. App-only filters fail explicitly without App OAuth; no cookie fallback is introduced.
 - Each published GitHub Release now submits the matching tagged `pixiv-cli` product skill to SkillHub. The submission is validated locally first and the workflow requires the returned SkillHub `skillId` and review status before succeeding.
 
 ## Changed

--- a/changelog/v0.7.0/zh-CN.md
+++ b/changelog/v0.7.0/zh-CN.md
@@ -5,7 +5,7 @@
 - Release binary 更新与版本化安装器资产现在携带静态、已测试的免费 GitHub Release-source 列表；它们在本机探测可用路由，支持路径式和查询参数式代理模板，且绝不远程拉取镜像列表。
 - 现有 `detail` 与 `download` 输入现在接受严格的官方 Pixiv 作品 URL；`download` 也接受已认证作者主页和作品页 URL，以遍历全部插画、漫画和 ugoira，但不下载小说。
 - MCP `illust_detail` 现在恰好接受 ID 或 URL 之一，`download` 接受 URL；插画查询 tool 会在紧凑文本摘要之外返回 typed structured result。
-- 插画 `search` 与 MCP `search_illust` 现支持官方 App 的 `keyword` 搜索（标签、标题、说明文字）、包含边界的显式日期、公开收藏数边界，以及 `half-year` / `year` 快捷日期范围。没有 App OAuth 时，App 专属筛选会明确失败；未引入 Cookie fallback。
+- 插画 `search` 与 MCP `search_illust` 现支持官方 App 的 `keyword` 搜索（标签、标题、说明文字）、包含边界的显式日期、公开收藏数边界，以及 `half-year` / `year` 快捷日期范围。收藏数边界同时需要 App OAuth 与有效的 Pixiv 高级会员。没有 App OAuth 时，App 专属筛选会明确失败；未引入 Cookie fallback。
 - 每个已公开 GitHub Release 现在都会向 SkillHub 提交同一 tag 对应的 `pixiv-cli` 产品 skill。提交前会先在本地校验，工作流必须取得 SkillHub 返回的 `skillId` 与审核状态才会成功。
 
 ## 变更

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -385,7 +385,7 @@ used.
 | `search` | `--aspect-ratio` | `all` | Aspect ratio: `all`, `landscape`, `portrait`, or `square`. |
 | `search` | `--resolution` | `all` | Resolution: `all`, `high`, `medium`, or `low`; both dimensions are respectively `>=3000`, `1000..2999`, or `<=999`. |
 | `search` | `--draw-tool` | empty | Exact upstream drawing-tool name; obtain current values with authenticated `search-options`. |
-| `search` | `--bookmark-min` / `--bookmark-max` | empty | Inclusive non-negative public bookmark-count bounds. Require App OAuth; `min` cannot exceed `max`. |
+| `search` | `--bookmark-min` / `--bookmark-max` | empty | Inclusive non-negative public bookmark-count bounds. Require App OAuth and an active Pixiv Premium membership; `min` cannot exceed `max`. |
 | `novel search` | `--min-text-length` | `0` | Minimum text length in characters; `0` disables the bound. |
 | `novel search` | `--max-text-length` | `0` | Maximum text length in characters; `0` disables the bound; it cannot be lower than a non-zero minimum. |
 | `novel search` | `--original-only` | `false` | Keeps only novels marked original by Pixiv. |
@@ -415,7 +415,7 @@ different filter set. When local filters skip leading empty upstream batches, CL
 non-empty logical batch or the upstream ends. With a positive `--limit` or `--page`, the CLI fills logical
 results across batches until it collects enough matching works, the upstream has no next batch, or a repeated
 cursor is detected; `--limit 0` walks the entire filtered stream; omitting `--limit` reads one upstream batch while
-still skipping leading empty batches. App also applies explicit date and bookmark-count bounds. Bookmark count is not a
+still skipping leading empty batches. App also applies explicit date and Pixiv Premium-only bookmark-count bounds. Bookmark count is not a
 like-count field and must not be labeled as likes.
 Artwork JSON/text include a stable page URL `https://www.pixiv.net/artworks/{id}` as the first field/line.
 
@@ -513,7 +513,7 @@ Differences in the anonymous fallback:
 - Anonymous `search` only applies filters that Web API can express reliably. Resolution, aspect ratio, drawing
   tool, and content type are translated to Web parameters; AI filtering uses returned artwork fields.
 - `rating=r18`, `r18g`, `mature`, `--search-by tag-title-caption`, or bookmark-count bounds fail before an anonymous
-  request with an authentication requirement rather than pretending the result is empty. `rating=all` means only content visible anonymously.
+  request with an authentication requirement rather than pretending the result is empty. Bookmark-count bounds additionally require Pixiv Premium. `rating=all` means only content visible anonymously.
 - `search-options` is App-only and explicitly unsupported without a refresh token. Search does not read or store
   browser cookies such as `PHPSESSID`, and never converts a refresh token into a Web session.
 - `novel search` is App-only and returns an authentication requirement without a refresh token.

--- a/docs/en/mcp-tools.md
+++ b/docs/en/mcp-tools.md
@@ -92,12 +92,12 @@ the safe business-error text; `download` partial failures set `isError=true`.
 - `search_target`: `partial_match_for_tags|exact_match_for_tags|title_and_caption|keyword`; `keyword` searches tags, titles, and captions and requires App OAuth.
 - `duration`: `within_last_day|within_last_week|within_last_month|within_half_year|within_year`; it cannot be combined with date bounds. The two long values are expanded locally into an inclusive Tokyo date range.
 - `start_date` / `end_date`: inclusive `YYYY-MM-DD` bounds. Either is allowed, but a supplied start cannot be later than end.
-- `bookmark_min` / `bookmark_max`: inclusive non-negative public bookmark-count bounds; the minimum cannot exceed the maximum and both require App OAuth.
+- `bookmark_min` / `bookmark_max`: inclusive non-negative public bookmark-count bounds; the minimum cannot exceed the maximum and both require App OAuth plus an active Pixiv Premium membership.
 
 With a refresh token, App performs resolution, aspect ratio, tool, content type, and AI exclusion filtering;
 rating and AI-only filtering use public SDK normalized App fields. App failures never fall back to Web. Anonymous
 Web applies only verified filters; `r18|r18g|mature`, `search_target=keyword`, and bookmark-count bounds fail before
-the request with an authentication requirement.
+the request with an authentication requirement. Pixiv additionally requires Premium membership for bookmark-count bounds.
 
 For authenticated `search_illust`, tag `search_target` values preserve the verified Pixiv App query grammar in
 `word`: with `exact_match_for_tags`, `tagA tagB` requires both complete tags and uppercase `tagA OR tagB` accepts

--- a/docs/en/sdk.md
+++ b/docs/en/sdk.md
@@ -145,20 +145,20 @@ manage their own PKCE and state. Use `StartLogin` when the SDK should manage the
 | `AspectRatio` | `all`, `landscape`, `portrait`, `square` |
 | `Resolution` | `all`, `high`, `medium`, `low`; both dimensions must respectively be `>=3000`, `1000..2999`, or `<=999` |
 | `Tool` | Exact upstream drawing-tool value; no fuzzy matching |
-| `BookmarkMin` / `BookmarkMax` | Optional inclusive non-negative public bookmark-count bounds; `Min` cannot exceed `Max` |
+| `BookmarkMin` / `BookmarkMax` | Optional inclusive non-negative public bookmark-count bounds; require App OAuth and an active Pixiv Premium membership; `Min` cannot exceed `Max` |
 
 Zero enum values normalize to `all`; `Tool` is trimmed. Unknown values return `invalid_argument` before any
 upstream request. `SearchIllustRequest.Target` also accepts `keyword` for tags, titles, and captions; `Duration`
 accepts `within_last_day|within_last_week|within_last_month`; `StartDate` and `EndDate`
 are optional inclusive `YYYY-MM-DD` bounds. A date range cannot be combined with `Duration`, and a supplied start
 cannot be later than end. The authenticated adapter maps resolution, aspect ratio, tool, content type, AI exclusion,
-date bounds, and bookmark bounds to App server parameters. Rating and AI-only filtering use normalized fields from
+date bounds, and Pixiv Premium-only bookmark bounds to App server parameters. Rating and AI-only filtering use normalized fields from
 the current App batch.
 `Illust.Tools []string` preserves upstream order and values and is unrelated to bookmark-count filtering.
 
 `SearchIllustOptions(ctx, SearchIllustOptionsRequest{Word: word})` requires a non-empty word and App
 authentication. It returns `SearchIllustOptionsResult{Tools []string}` in upstream order; a missing list becomes a
-non-nil empty slice. Premium bookmark tiers are not exposed.
+non-nil empty slice. It does not expose whether the authenticated account has Pixiv Premium eligibility for bookmark-count bounds.
 
 ### Novel search and user-search source
 

--- a/docs/ja/cli-reference.md
+++ b/docs/ja/cli-reference.md
@@ -306,7 +306,7 @@ allowlist、MIME 推測、暗黙置換は行いません。
 | `search` | `--aspect-ratio` | `all` | `all`, `landscape`, `portrait`, `square`。 |
 | `search` | `--resolution` | `all` | `all`, `high`, `medium`, `low`。両辺がそれぞれ `>=3000`, `1000..2999`, `<=999`。 |
 | `search` | `--draw-tool` | empty | upstream の正確な制作ツール名。認証済み `search-options` で取得します。 |
-| `search` | `--bookmark-min` / `--bookmark-max` | empty | 包含境界の非負 public bookmark 数。App OAuth が必要で、`min` は `max` を超えられません。 |
+| `search` | `--bookmark-min` / `--bookmark-max` | empty | 包含境界の非負 public bookmark 数。App OAuth と有効な Pixiv Premium 会員資格が必要で、`min` は `max` を超えられません。 |
 | `novel search` | `--min-text-length` | `0` | 本文の最小文字数。`0` は下限を無効にします。 |
 | `novel search` | `--max-text-length` | `0` | 本文の最大文字数。`0` は上限を無効にし、非ゼロの下限より小さくできません。 |
 | `novel search` | `--original-only` | `false` | Pixiv がオリジナルと表示した小説だけを残します。 |
@@ -334,7 +334,7 @@ refresh token がある `search` は常に App API を使います。App は解�
 Web に fallback しません。filter は opaque cursor に binding され、別条件へ再利用できません。ローカル filter が
 連続 empty upstream batch を飛ばす場合、CLI/MCP は最初の非 empty 論理 batch か upstream 終端まで続けます。
 正数 `--limit`/`--page` は filter 後の論理結果を跨 batch で埋め、`--limit 0` は全件走査、`--limit` なしでも
-先頭 empty batch は skip します。App は明示 date と bookmark-count の境界も処理します。bookmark count は like-count
+先頭 empty batch は skip します。App は明示 date と Pixiv Premium 限定の bookmark-count の境界も処理します。bookmark count は like-count
 フィールドではなく、like と表記してはいけません。作品 JSON/text は
 `https://www.pixiv.net/artworks/{id}` を先頭フィールド/先頭行として含めます。
 
@@ -410,7 +410,7 @@ token source がなく `web_fallback_enabled=true` の場合、CLI の `search`�
 server error を自動 fallback しません。
 
 - 匿名 `search` は Web が確実に表現できる filter だけを使用します。AI は返却 field で判定します。
-- `rating=r18|r18g|mature`、`--search-by tag-title-caption`、または bookmark-count filter は request 前に認証要求として失敗し、空結果に見せません。`all` は匿名で見える範囲です。
+- `rating=r18|r18g|mature`、`--search-by tag-title-caption`、または bookmark-count filter は request 前に認証要求として失敗し、空結果に見せません。bookmark-count filter には Pixiv Premium も必要です。`all` は匿名で見える範囲です。
 - `search-options` は App 専用です。Cookie を読み取らず、refresh token を Web session に変換しません。
 - `novel search` は App 専用で、refresh token がなければ認証要求として失敗します。
 - 拡張 ranking mode（`day_manga`、`week_manga`、`month_manga`、`week_rookie_manga`、`day_r18`、

--- a/docs/ja/mcp-tools.md
+++ b/docs/ja/mcp-tools.md
@@ -79,11 +79,12 @@ structured output を返します。`delivery` は正規化済みの `local_path
 - `aspect_ratio`：`all|landscape|portrait|square`。
 - `resolution`：`all|high|medium|low`。両 dimension がそれぞれ `>=3000`、`1000..2999`、`<=999` です。
 - `tool`：fuzzy matching をしない、上流の drawing-tool value そのもの。
+- `bookmark_min` / `bookmark_max`：包含境界の非負 public bookmark 数。`min` は `max` を超えられず、App OAuth と有効な Pixiv Premium 会員資格が必要です。
 
 refresh token がある場合、resolution、aspect ratio、tool、content type、AI exclusion は App が実施します。rating と
 AI-only の filter は public SDK が正規化済み App field で実施します。App の失敗は Web に fallback しません。匿名 Web は
-検証済みの filter のみを適用し、`r18|r18g|mature` は request 前に authentication requirement で失敗します。
-`search_illust_options` は App 専用です。いずれの search tool も cookie または bookmark-count filter を受け取りません。
+検証済みの filter のみを適用し、`r18|r18g|mature` と bookmark-count filter は request 前に authentication requirement で失敗します。
+`search_illust_options` は App 専用です。いずれの search tool も cookie を受け取りません。Pixiv は bookmark-count filter に Premium 会員資格も要求します。
 
 `search_novel.rating` は `all|sfw|r18|r18g|mature` を使用します。`min_text_length` と `max_text_length` は非負の
 character bound で、`0` は対応する bound を無効にします。非ゼロの maximum が minimum 未満なら validation error です。

--- a/docs/ja/sdk.md
+++ b/docs/ja/sdk.md
@@ -132,15 +132,16 @@ format は unencrypted な point-in-time backup であり、live sync ではあ�
 | `AspectRatio` | `all`、`landscape`、`portrait`、`square` |
 | `Resolution` | `all`、`high`、`medium`、`low`。両 dimension が順に `>=3000`、`1000..2999`、`<=999` です。 |
 | `Tool` | fuzzy matching をしない、上流の drawing-tool value。 |
+| `BookmarkMin` / `BookmarkMax` | 任意の包含境界の非負 public bookmark 数。App OAuth と有効な Pixiv Premium 会員資格が必要で、`Min` は `Max` を超えられません。 |
 
 zero enum value は `all` に正規化され、`Tool` は trim されます。unknown value は upstream request 前に
 `invalid_argument` を返します。認証済み adapter は resolution、aspect ratio、tool、content type、AI exclusion を App server
-parameter に変換します。rating と AI-only filter は current App batch の正規化 field を使用します。`Illust.Tools []string` は
+parameter と Pixiv Premium 限定の bookmark-count parameter に変換します。rating と AI-only filter は current App batch の正規化 field を使用します。`Illust.Tools []string` は
 upstream の order と value を保持し、bookmark-count filter とは関係ありません。
 
 `SearchIllustOptions(ctx, SearchIllustOptionsRequest{Word: word})` は non-empty word と App authentication が必要です。
 戻り値は upstream order の `SearchIllustOptionsResult{Tools []string}` であり、list がない場合は non-nil empty slice です。
-premium bookmark tier は公開しません。
+認証済み account が bookmark-count filter 用の Pixiv Premium 資格を持つかどうかは公開しません。
 
 ### Novel search と user-search source
 

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -310,7 +310,7 @@ CLI 使用 Cobra/pflag，选项可以写在位置参数前后，例如 `pixiv au
 | `search` | `--aspect-ratio` | `all` | 横纵比：`all`、`landscape`、`portrait` 或 `square`。 |
 | `search` | `--resolution` | `all` | 分辨率：`all`、`high`、`medium` 或 `low`；宽高两个维度分别都需满足 `>=3000`、`1000..2999` 或 `<=999`。 |
 | `search` | `--draw-tool` | 空 | 上游绘图工具的精确名称；用已认证的 `search-options` 查询当前值。 |
-| `search` | `--bookmark-min` / `--bookmark-max` | 空 | 包含边界的非负公开收藏数；需要 App OAuth，且最小值不能大于最大值。 |
+| `search` | `--bookmark-min` / `--bookmark-max` | 空 | 包含边界的非负公开收藏数；需要 App OAuth 和有效的 Pixiv 高级会员，且最小值不能大于最大值。 |
 | `novel search` | `--min-text-length` | `0` | 正文最少字符数；`0` 关闭下界。 |
 | `novel search` | `--max-text-length` | `0` | 正文最多字符数；`0` 关闭上界，且不能小于非零下界。 |
 | `novel search` | `--original-only` | `false` | 仅保留 Pixiv 标记为原创的小说。 |
@@ -333,7 +333,7 @@ CLI 使用 Cobra/pflag，选项可以写在位置参数前后，例如 `pixiv au
 | `detail` | `ILLUST_ID_OR_URL` | 必填 | 正整数作品 ID，或受支持的 Pixiv 作品 URL。 |
 | `download` | `TARGET...` | 必填 | 作品 ID、作品 URL，或受支持的用户主页/作品页 URL。 |
 
-有 refresh token 时，`search` 始终使用 App API。分辨率、横纵比、工具、作品类型和 `ai-mode=exclude` 由 App 筛选，分级和 `ai-mode=only` 对 App 返回批次筛选；App 失败不会回落 Web。全部筛选都会绑定 opaque cursor，cursor 不能用于不同筛选组合。本地筛选跳过连续空上游批次时，CLI/MCP 会补拉到首个非空逻辑批次或真正结束。指定正数 `--limit` 或 `--page` 时，按过滤后的逻辑结果跨批填满；`--limit 0` 遍历全部过滤结果；未指定 `--limit` 时读取一个上游批次，但会跳过前导空批。App 还会执行显式日期与收藏数边界；收藏数不是点赞字段，不得文案为点赞。作品 JSON/文本包含稳定作品页 URL `https://www.pixiv.net/artworks/{id}`，作为首字段/每件作品第一行。
+有 refresh token 时，`search` 始终使用 App API。分辨率、横纵比、工具、作品类型和 `ai-mode=exclude` 由 App 筛选，分级和 `ai-mode=only` 对 App 返回批次筛选；App 失败不会回落 Web。全部筛选都会绑定 opaque cursor，cursor 不能用于不同筛选组合。本地筛选跳过连续空上游批次时，CLI/MCP 会补拉到首个非空逻辑批次或真正结束。指定正数 `--limit` 或 `--page` 时，按过滤后的逻辑结果跨批填满；`--limit 0` 遍历全部过滤结果；未指定 `--limit` 时读取一个上游批次，但会跳过前导空批。App 还会执行显式日期与仅限 Pixiv 高级会员的收藏数边界；收藏数不是点赞字段，不得文案为点赞。作品 JSON/文本包含稳定作品页 URL `https://www.pixiv.net/artworks/{id}`，作为首字段/每件作品第一行。
 
 ### 插画标签查询语法
 
@@ -405,7 +405,7 @@ App JSON 读取在首次 429 且 `Retry-After` 有效时按命令 context 等待
 匿名 fallback 的差异：
 
 - 匿名 `search` 只执行 Web API 能可靠表达的筛选。分辨率、横纵比、绘图工具和作品类型会转译为 Web 参数；AI 筛选使用返回的作品字段。
-- `rating=r18`、`r18g`、`mature`、`--search-by tag-title-caption` 或收藏数边界会在匿名请求前明确返回需要认证，而不会伪装成空结果；`rating=all` 只表示匿名可见范围。
+- `rating=r18`、`r18g`、`mature`、`--search-by tag-title-caption` 或收藏数边界会在匿名请求前明确返回需要认证，而不会伪装成空结果；收藏数边界还需要 Pixiv 高级会员；`rating=all` 只表示匿名可见范围。
 - `search-options` 仅支持 App API，无 refresh token 时明确返回 unsupported。搜索不会读取或保存 `PHPSESSID` 等浏览器 Cookie，也不会把 refresh token 转换成 Web session。
 - `novel search` 仅支持 App API；无 refresh token 时明确返回需要认证。
 - 九个扩展排行榜 mode（`day_manga`、`week_manga`、`month_manga`、`week_rookie_manga`、`day_r18`、

--- a/docs/zh-CN/mcp-tools.md
+++ b/docs/zh-CN/mcp-tools.md
@@ -70,11 +70,11 @@ SDK cursor 不出现在 MCP 参数或输出。列表工具统一使用逻辑 `pa
 - `search_target`：`partial_match_for_tags|exact_match_for_tags|title_and_caption|keyword`；`keyword` 搜索标签、标题、说明文字，且需要 App OAuth。
 - `duration`：`within_last_day|within_last_week|within_last_month|within_half_year|within_year`；不能和日期边界同用。两个长周期会在本地展开为包含边界的东京日期区间。
 - `start_date` / `end_date`：包含边界的 `YYYY-MM-DD`；可只给一端，两端都有时起始不得晚于结束。
-- `bookmark_min` / `bookmark_max`：包含边界的非负公开收藏数；最小值不能大于最大值，且都需要 App OAuth。
+- `bookmark_min` / `bookmark_max`：包含边界的非负公开收藏数；最小值不能大于最大值，且都需要 App OAuth 和有效的 Pixiv 高级会员。
 
 有 refresh token 时，分辨率、横纵比、工具、作品类型和 `ai_mode=exclude` 由 App 服务端筛选，
 `rating` 与 `ai_mode=only` 由 public SDK 基于 App 返回字段筛选；App 失败不回落 Web。无 token 的匿名
-Web 路径只执行已验证可靠的筛选；`rating=r18|r18g|mature`、`search_target=keyword` 和收藏数边界在请求前返回需要登录，不伪装成空结果。
+Web 路径只执行已验证可靠的筛选；`rating=r18|r18g|mature`、`search_target=keyword` 和收藏数边界在请求前返回需要登录，不伪装成空结果。Pixiv 对收藏数边界还要求高级会员。
 `search_illust_options` 只走 App API。所有搜索 tool 都不接受 Cookie。
 
 对认证态 `search_illust`，标签 `search_target` 会在 `word` 中保留已验证的 Pixiv App 查询语法：

--- a/docs/zh-CN/sdk.md
+++ b/docs/zh-CN/sdk.md
@@ -93,18 +93,18 @@ auth store，不读取 `PIXIV_REFRESH_TOKEN` 或 runtime config，不刷新、�
 | `AspectRatio` | `all`、`landscape`、`portrait`、`square` |
 | `Resolution` | `all`、`high`、`medium`、`low`；三档分别要求宽高均 `>=3000`、均在 `1000..2999`、均 `<=999` |
 | `Tool` | 上游绘图工具原值；不做模糊匹配 |
-| `BookmarkMin` / `BookmarkMax` | 可选、包含边界的非负公开收藏数；`Min` 不得大于 `Max` |
+| `BookmarkMin` / `BookmarkMax` | 可选、包含边界的非负公开收藏数；需要 App OAuth 和有效的 Pixiv 高级会员；`Min` 不得大于 `Max` |
 
 枚举零值规范化为 `all`，`Tool` 会去除首尾空白；未知枚举返回 `invalid_argument`，不会发起上游
 请求。`SearchIllustRequest.Target` 还接受搜索标签、标题、说明文字的 `keyword`；`Duration` 接受
 `within_last_day|within_last_week|within_last_month`；`StartDate`、`EndDate` 是可选、包含边界的
 `YYYY-MM-DD`。日期区间不能与 `Duration` 同用，且起始不得晚于结束。认证路径把分辨率、横纵比、工具、作品类型、`exclude` AI、
-日期边界和收藏数边界翻译为 App 服务端参数；分级与 `only` AI 再基于当前 App 批次的规范化字段筛选。`Illust.Tools []string` 保留 App 返回的工具顺序和
+日期边界和仅限 Pixiv 高级会员的收藏数边界翻译为 App 服务端参数；分级与 `only` AI 再基于当前 App 批次的规范化字段筛选。`Illust.Tools []string` 保留 App 返回的工具顺序和
 原值；该字段不是收藏数筛选。
 
 `SearchIllustOptions(ctx, SearchIllustOptionsRequest{Word: word})` 需要非空关键词和 App 认证，返回
 `SearchIllustOptionsResult{Tools []string}`。工具列表保持上游顺序与原值；上游未提供列表时返回非
-`nil` 空切片。该操作不公开 Premium 收藏数档位。
+`nil` 空切片。该操作不公开已认证账号是否具有 Pixiv 高级会员的收藏数筛选资格。
 
 ### 小说搜索与用户搜索来源
 

--- a/skills/pixiv-cli/SKILL.md
+++ b/skills/pixiv-cli/SKILL.md
@@ -172,8 +172,8 @@ assuming its effective value.
 5. **Anonymous restricted search fails explicitly.** Web fallback uses only
    reliable illustration-search filters. `r18`, `r18g`, `mature`, `--search-by tag-title-caption`,
    bookmark-count bounds, and `search-options`
-   require App authentication; do not present the failure as an empty result
-   or add a Cookie workaround. `novel search` is App-only and requires authentication.
+   require App authentication; bookmark-count bounds additionally require Pixiv Premium. Do not
+   present the failure as an empty result or add a Cookie workaround. `novel search` is App-only and requires authentication.
    Bookmark count is a public bookmark total, never a like count.
 6. **Extended rankings need authentication.** Valid modes are `day`,
    `day_male`, `day_female`, `week`, `week_original`, `week_rookie`, `month`,

--- a/skills/pixiv-cli/references/discover.md
+++ b/skills/pixiv-cli/references/discover.md
@@ -28,14 +28,16 @@ pixiv search "初音ミク" --limit 10 --json
 - Stable filters include `--rating sfw|r18|r18g|mature|all`, `--type
   all|illust-and-ugoira|illust|manga|ugoira`, `--ai-mode all|exclude|only`,
   `--aspect-ratio all|landscape|portrait|square`, `--resolution
-  all|high|medium|low`, exact `--draw-tool` names, and App-only `--bookmark-min N`
-  / `--bookmark-max N` public bookmark-count bounds. Only pass restricted ratings
-  or bookmark bounds when the user explicitly asks; never call bookmark count a like count.
+  all|high|medium|low`, exact `--draw-tool` names, and App-only, Pixiv Premium-only
+  `--bookmark-min N` / `--bookmark-max N` public bookmark-count bounds. Only pass restricted
+  ratings or bookmark bounds when the user explicitly asks; say that Pixiv Premium is required
+  for bookmark bounds, and never call bookmark count a like count.
 - Tool names are dynamic. Run authenticated `pixiv search-options "WORD"
   --json`, then pass the returned name exactly. Do not hard-code a list.
 - Anonymous Web search accepts only its reliable filters. R18/R18G/mature,
-  `tag-title-caption`, bookmark bounds, and `search-options` require authentication; never add a Cookie workaround or
-  report an authentication failure as an empty result.
+  `tag-title-caption`, bookmark bounds, and `search-options` require authentication; bookmark
+  bounds also require Pixiv Premium. Never add a Cookie workaround or report an authentication
+  failure as an empty result.
 - Need page 2+: `--page N` (1-based) with a positive `--limit`.
 - Local filters skip leading empty upstream batches until the first non-empty
   logical batch or true end. `--limit N` fills filtered results across batches;


### PR DESCRIPTION
## Summary

- Clarify that illustration bookmark-count bounds require both App OAuth and active Pixiv Premium.
- Correct the Japanese MCP contract and update the product Skill guidance.
- Amend the v0.7.0 bilingual changelog; the published Release body will be synchronized after merge.

## Validation

- `go test ./scripts/documentation -count=1`
- `pre-commit run --all-files`

## Summary by Sourcery

在所有支持的语言中，澄清关于在 CLI、SDK、MCP 和技能文档中使用书签数量搜索过滤器时的 Pixiv Premium 要求。

Documentation:
- 更新 CLI 参考文档，说明插画书签数量上下限搜索需要同时具备 App OAuth 授权以及有效的 Pixiv Premium 会员资格。
- 在 SDK 文档中澄清，书签数量上下限参数被映射为仅限 Pixiv Premium 的参数，并且搜索选项本身不会暴露是否符合 Premium 资格的信息。
- 调整 MCP 工具文档，记录书签数量过滤器还需要 Pixiv Premium 这一额外条件，并且移除对 cookie/书签过滤的接受说明。
- 修订 pixiv-cli 技能指引，描述匿名进行书签数量范围搜索时的明确失败行为，并说明其对 Pixiv Premium 的需求。
- 修改 v0.7.0 多语言更新日志中的相关条目，标注书签数量上下限搜索需要 Pixiv Premium。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify Pixiv Premium requirements for bookmark-count search filters across CLI, SDK, MCP, and skill documentation in all supported languages.

Documentation:
- Update CLI references to state that illustration bookmark-count bounds require both App OAuth and an active Pixiv Premium membership.
- Clarify SDK docs that bookmark-count bounds are mapped as Pixiv Premium-only parameters and that Premium eligibility is not exposed by search options.
- Adjust MCP tool docs to document Pixiv Premium as an additional requirement for bookmark-count filters and remove cookie/bookmark filter acceptance.
- Revise pixiv-cli skill guidance to describe explicit failures for anonymous bookmark-bound searches and their Pixiv Premium requirement.
- Amend the v0.7.0 multilingual changelog entries to note the Pixiv Premium requirement for bookmark-count bounds.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 插画搜索支持官方 App 关键词搜索（标签、标题和简介）。
  - 支持包含边界的日期范围及 `half-year`、`year` 快捷范围。
  - 支持公开收藏数范围筛选。

- **文档**
  - 明确收藏数筛选需 App OAuth 和有效 Pixiv Premium。
  - 未满足认证或会员要求时将明确返回失败，不再伪装为空结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->