### PR TITLE
feat(release): add auditable bilingual release notes

### DIFF
--- a/.agents/skills/pixiv-cli-release-notes/SKILL.md
+++ b/.agents/skills/pixiv-cli-release-notes/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: pixiv-cli-release-notes
+description: Manage pixiv-cli feature PR release-note metadata, bilingual release-prep notes, historical GitHub Release synchronization, and an approved version release. Use whenever work is moving from a completed feature branch toward a PR, merge, changelog, tag, GitHub Release, SkillHub, or ClawHub publication; use it even when the request only mentions “prepare a release” or “update release notes”.
+---
+
+# pixiv-cli release notes and release workflow
+
+Use this Skill for the repository release lifecycle. Read `docs/maintainers/development.md` before acting; it is the durable policy reference.
+
+## Authorization boundary
+
+Offer a SemVer recommendation after reviewing the merged scope. A recommendation is information, not permission.
+
+Before creating a release-prep PR, merging it, creating or pushing a tag, dispatching release publication, or running `sync-history --apply`, obtain one explicit message in the current session that names:
+
+- the exact version;
+- the intended commit/tag range or historical versions; and
+- the expected impact, including breaking changes when applicable.
+
+Record that authorization in the release-prep PR description or the task summary. A general request to publish, an issue, or another contributor's merge does not supply this confirmation.
+
+## Feature PR contract
+
+1. Inspect the affected CLI, MCP, SDK, configuration, docs, and product Skill surfaces.
+2. Run the repo-local `pixiv-cli-review` Skill and focused tests. Repair release-note metadata, links, formatting, version metadata, or workflow-policy failures when the evidence is clear. Pause for a decision on behavior, security, or scope disputes.
+3. Ensure the PR body contains exactly one declaration from `.github/PULL_REQUEST_TEMPLATE.md`:
+
+   ```text
+   <!-- release-note
+   category: Added|Changed|Fixed|Security|Documentation|Maintenance|None
+   breaking: true|false
+   summary: One user-facing release summary.
+   none_reason: Required only for None.
+   -->
+   ```
+
+4. Confirm the required Quality check passes. Request a GitHub review only when the caller explicitly provides `--reviewer USER_OR_TEAM`; otherwise use the repository's required CI and any existing review requirements.
+5. Create and monitor the feature PR, then merge only with the caller's approval and the repository gate satisfied.
+
+Feature PRs carry the declaration and documentation changes. They leave `changelog/unreleased/` untouched; final bilingual prose belongs to the later release-prep PR.
+
+## Prepare a release
+
+1. Fetch tags and audit the candidate range:
+
+   ```bash
+   go run ./scripts/releasenotes audit \
+     --repo FlanChanXwO/pixiv-cli \
+     --from vPREVIOUS \
+     --to COMMIT_OR_TAG \
+     --output /tmp/pixiv-cli-release-audit.json
+   ```
+
+   Inspect direct-commit exceptions, missing declarations, first external contributors, and the recommended bump. Historical direct commits use their real commit links; never infer a PR number.
+
+2. Present the proposed version, grouped user outcomes, source range, contributor list, and breaking-change assessment. Wait for the explicit authorization described above.
+3. Create a reviewed JSON plan with bilingual text and source URLs. A source can appear once in a grouped outcome; all sources must be GitHub PR or commit links for this repository. Example:
+
+   ```json
+   {
+     "entries": [
+       {
+         "category": "Added",
+         "english": "Add APNG downloads.",
+         "zh_cn": "新增 APNG 下载。",
+         "sources": ["https://github.com/FlanChanXwO/pixiv-cli/pull/42"]
+       }
+     ]
+   }
+   ```
+
+4. Preview the generated files, review them, then write the release-prep change explicitly:
+
+   ```bash
+   go run ./scripts/releasenotes prepare \
+     --version X.Y.Z --previous vPREVIOUS --date YYYY-MM-DD \
+     --plan /tmp/pixiv-cli-release-plan.json \
+     --audit /tmp/pixiv-cli-release-audit.json
+
+   go run ./scripts/releasenotes prepare \
+     --version X.Y.Z --previous vPREVIOUS --date YYYY-MM-DD \
+     --plan /tmp/pixiv-cli-release-plan.json \
+     --audit /tmp/pixiv-cli-release-audit.json --apply
+   ```
+
+5. Run the offline validation and documentation tests, create the release-prep PR, and monitor required CI/reviews:
+
+   ```bash
+   go run ./scripts/releasenotes validate \
+     --version X.Y.Z --dir changelog/vX.Y.Z --previous vPREVIOUS \
+     --audit /tmp/pixiv-cli-release-audit.json
+   go test ./scripts/documentation -count=1
+   ```
+
+## Tag and publication
+
+After the authorized release-prep PR is merged, confirm the default branch contains its merge commit. Create and push only the authorized `vX.Y.Z` tag. Monitor the Release workflow through GitHub CLI until GitHub Release, assets, SkillHub, and ClawHub handoffs report their final status. Verify:
+
+- the GitHub Release body renders the tag's English and Simplified Chinese notes through `scripts/releaseassets finalize`;
+- every expected asset and checksum/signature artifact is present;
+- SkillHub and ClawHub report the matching product-skill publication or a documented unchanged-skill skip.
+
+Report links and exact evidence. A publication failure outside release-note metadata, mapping, format, version metadata, or workflow policy requires a pause with the failing evidence.
+
+## Historical releases
+
+Use a dry-run for each historical version first:
+
+```bash
+go run ./scripts/releasenotes sync-history \
+  --repo FlanChanXwO/pixiv-cli --version X.Y.Z --dir changelog/vX.Y.Z
+```
+
+With the current-session authorization for the named historical versions, add `--apply`. Existing Releases receive an exact-body update only. A missing historical Release is created with its existing tag and no assets; verify the returned body equals the local render.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,13 +14,24 @@
 go test ./...
 ```
 
+## Release note declaration
+
+<!-- This required metadata is validated by the Quality gate. It is used only after merge to prepare the bilingual release notes; do not edit changelog/unreleased in a feature PR. Select exactly one category: Added, Changed, Fixed, Security, Documentation, Maintenance, or None. Set breaking to true only when the change requires a major-version release. None requires a concrete reason. -->
+
+<!-- release-note
+category:
+breaking:
+summary:
+none_reason:
+-->
+
 ## Checklist
 
 - [ ] The change is focused and linked to an issue when appropriate.
 - [ ] I added or updated focused tests for changed behavior.
 - [ ] I ran the relevant tests and recorded the results above.
 - [ ] I updated the required CLI, MCP, SDK, README, maintainer, and product-skill documentation.
-- [ ] I updated both unreleased changelog files for user-visible changes, compatibility effects, removals, or security effects.
+- [ ] I completed the required release-note declaration above; `None` has a concrete reason when selected.
 - [ ] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence.
 - [ ] I did not add refresh tokens, cookies, authorization codes, proxy credentials, private URLs, downloaded works, local state, or private API responses.
 - [ ] I updated migration guidance for every breaking change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: '1.26.3'
+      - name: Validate pull request release-note declaration
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: go run ./scripts/releasenotes pr-validate --event "$GITHUB_EVENT_PATH"
       - name: Test documentation contracts
         if: ${{ needs.classify_changes.outputs.docs_only == 'true' }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,11 +388,51 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # 在进入受保护的 publish job 前，以 tag 内不可变说明、GitHub PR 关联和实际提交范围交叉核对发布来源。
+  release_notes_audit:
+    name: Audit release notes provenance
+    needs: build_production
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ env.RELEASE_TAG }}
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version: '1.26.3'
+      - name: Audit release-note sources and validate the bilingual tag notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          previous_tag=$(git tag --merged "$RELEASE_TAG^" --sort=-version:refname | head -n 1)
+          test -n "$previous_tag"
+          audit_report="$RUNNER_TEMP/release-notes-audit.json"
+          go run ./scripts/releasenotes audit \
+            --repo "$GITHUB_REPOSITORY" \
+            --from "$previous_tag" \
+            --to "$RELEASE_TAG" \
+            --require-classified \
+            --output "$audit_report"
+          go run ./scripts/releasenotes validate \
+            --version "${RELEASE_TAG#v}" \
+            --dir "changelog/$RELEASE_TAG" \
+            --previous "$previous_tag" \
+            --audit "$audit_report"
+
   # 在不声明 environment 的 job 中验证 tag 所指提交属于默认分支，避免 protected
   # release Environment 的 secret 在 ancestry shell gate 之前进入同一 job 生命周期。
   verify_release_source:
     name: Verify release source trust
-    needs: build_production
+    needs:
+      - build_production
+      - release_notes_audit
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ PIXIV_E2E_WEB_API=1 PIXIV_WEB_API_PROXY=http://127.0.0.1:7890 go test ./e2e -run
 - MCP 模式 stdout 保留给 JSON-RPC；操作日志写用户主目录 `~/.pixiv-cli/logs`（Windows 为 `%USERPROFILE%\.pixiv-cli\logs`）的按日纯文本 `YYYY-MM-DD.txt`，终端默认无日志痕迹。
 - 不新增无依据的固定超时、截断、条数限制、重试上限、静默 fallback 或隐藏降级。确需新增时，必须有证据、代码注释、测试或文档说明。
 - 修改 CLI/MCP tool、配置键、环境变量、输出语义、下载/认证/代理流程时，同步更新现有 locale 的 README、CLI reference 或对应 `docs/<locale>/`；涉及命令语义时同步检查 `skills/pixiv-cli/`。
-- 用户可感知的新增、修复、变更、废弃、移除或安全影响，同步更新 `changelog/unreleased/en.md` 与 `changelog/unreleased/zh-CN.md`；纯内部重构、测试和文档清理可不记。
+- 功能 PR 以 `.github/PULL_REQUEST_TEMPLATE.md` 的 release-note 声明记录用户可感知的新增、修复、变更、废弃、移除或安全影响；合并后的 release-prep PR 使用 `scripts/releasenotes` 生成 `changelog/vX.Y.Z/` 双语说明。`changelog/unreleased/` 保留为 release-prep 入口；纯内部重构、测试和文档清理可选择 `None` 并说明理由。
 - 代码改动必须补充或更新聚焦测试，并运行相关回归；不能测试时说明原因和风险。
 
 ## 文档路由

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Update documentation in the same pull request when changing a command, flag, SDK
 - Keep `README.md`, `README.zh-CN.md`, and `README.ja.md` behaviorally aligned.
 - Keep all existing locale versions under `docs/<locale>/` behaviorally aligned; never use untranslated placeholder content.
 - Update localized SDK/MCP contracts or `docs/maintainers/` according to their documented responsibility.
-- Record user-visible additions, fixes, changes, deprecations, removals, and security effects in both the [English unreleased notes](changelog/unreleased/en.md) and the [Simplified Chinese unreleased notes](changelog/unreleased/zh-CN.md). At release time, move the paired notes into the matching version directory and update the [changelog index](changelog/README.md).
+- Complete the required release-note declaration in the pull-request template for every contribution. Choose `Added`, `Changed`, `Fixed`, `Security`, `Documentation`, `Maintenance`, or `None`; `None` includes a concrete reason. After merge, the release-prep PR groups reviewed outcomes into matching English and Simplified Chinese version notes, with inline PR or direct-commit sources and a Full Changelog link. See the [release-note workflow](docs/maintainers/development.md#release-notes-and-publication) for the exact process.
 - Check `skills/pixiv-cli/` when CLI commands, flags, or safety semantics change.
 
 Keep stable rules in one authoritative document and link to them elsewhere instead of copying large sections.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -61,7 +61,7 @@ Native library 校验、opt-in 真实 API 测试、发布门禁和平台细节�
 - 保持 `README.md`、`README.zh-CN.md` 与 `README.ja.md` 的行为语义对应。
 - 保持 `docs/<locale>/` 下已有语言版本的行为语义对应；不得用未翻译占位内容冒充对应语言。
 - 按文件职责更新 localized SDK/MCP contract 或 `docs/maintainers/`。
-- 用户可感知的新增、修复、变更、废弃、移除或安全影响必须同时写入[英文未发布说明](changelog/unreleased/en.md)与[简体中文未发布说明](changelog/unreleased/zh-CN.md)。正式发布时，将这对文件移入对应版本目录，并更新[更新日志索引](changelog/README.zh-CN.md)。
+- 每个贡献都要完成 PR 模板中的 release-note 声明，分类为 `Added`、`Changed`、`Fixed`、`Security`、`Documentation`、`Maintenance` 或 `None`；选择 `None` 时说明具体理由。合并后由 release-prep PR 将已审核结果归并为英文与简体中文版本说明，并在每个条目内标注 PR 或历史 direct commit 来源及完整变更链接。具体流程见[发布说明与发布](docs/maintainers/development.md#release-notes-and-publication)。
 - CLI 命令、flag 或安全语义变化时检查 `skills/pixiv-cli/`。
 
 稳定规则只在一个权威文档中定义，其他位置应链接过去，避免复制大段内容。

--- a/README.ja.md
+++ b/README.ja.md
@@ -19,6 +19,7 @@
 - **統一された機能** — CLI・MCP・SDK から Pixiv の検索、詳細、ランキング、おすすめ、ユーザー、ブックマーク、フォロー、ダウンロード、うごイラを利用できます。
 - **フィードと合成可能な Record パイプライン** — canonical NDJSON でフィードを取得し、Record をローカルで filter して action へ渡せます。
 - **ローカル account pool** — 読み取り処理に適格なローカル account を選択し、pagination と download preparation で Pixiv の `Retry-After` に従います。
+- **分かりやすいアカウントログイン** — `pixiv auth login` で browser OAuth を完了し、`auth list`、`auth use`、`auth check` でローカルの複数アカウントを管理・確認できます。
 - **GIF と APNG のうごイラ出力** — GIF を既定にしつつ、CLI・MCP・SDK から APNG を明示指定できます。
 - **キャッシュ対応 download** — `.pixiv-cache` metadata を永続的に再検証し、検証済み partial を `Range` と `If-Range` で再開し、完了 file を atomic に置き換えます。
 - **認証済み App API の探索** — R18 detail、pages、ugoira metadata、全 16 ranking mode を App API で取得します。
@@ -54,14 +55,14 @@ curl.exe -fsSLo "%TEMP%\pixiv-install.cmd" https://raw.githubusercontent.com/Fla
 ```text
 Install the latest stable pixiv-cli from https://github.com/FlanChanXwO/pixiv-cli for this machine: inspect the repository's scripts/install.sh or scripts/install.cmd first, choose the script matching the detected OS and architecture (the Windows path must use cmd.exe and must not invoke PowerShell), download only official GitHub Release assets, require the published SHA-256 check to pass before replacing anything, install per-user without administrator or root privileges, add only the chosen install directory to the user PATH, ask before installing any missing prerequisite, never read or output Pixiv credentials, verify with pixiv version, and report the installed version plus every file and PATH change.
 
-Also install the product skill that matches the same stable release tag (not main): download the full skills/pixiv-cli/ directory from that tag into the agent skills directory the user confirms. Do not guess the skills path and do not follow the main branch for skill content.
+Also install the pixiv-cli Skill that matches the same stable release tag (not main): download the full skills/pixiv-cli/ directory from that tag into the agent skills directory the user confirms. Do not guess the skills path and do not follow the main branch for skill content.
 ```
 
-### SkillHub から product Skill をインストールする
+### SkillHub から pixiv-cli Skill をインストールする
 
 SkillHub に対応した Agent は、公開済みの [`pixiv-cli` Skill](https://www.skillhub.cn/skills/pixiv-cli) を SkillHub から直接インストールできます。Skill には独自の version があり、インストール済み CLI の使い方を案内します。command の syntax は常に `pixiv <cmd> --help` を最終的な根拠にしてください。
 
-### ClawHub から product Skill をインストールする
+### ClawHub から pixiv-cli Skill をインストールする
 
 ClawHub を使う Agent は、公開済みの [`pixiv-cli` Skill](https://clawhub.ai/flanchanxwo/skills/pixiv-cli) を `clawhub install pixiv-cli` でインストールできます。unversioned latest を追わず、CLI release と同じ公開 Skill version に固定してください。
 
@@ -162,6 +163,10 @@ download, err := client.Download(ctx, "https://www.pixiv.net/artworks/123456")
 ## 認証と token の安全性
 
 推奨設定は `pixiv auth login` です。Pixiv App OAuth の raw refresh token を UID ごとにローカル account store へ保存します。
+
+### アカウント情報に関する注意
+
+アカウント名、UID、membership status の表示、現在選択されているローカル account は、ローカル store と Pixiv response に基づく操作補助情報です。account の所有権・利用権限・現在の Pixiv status を証明するものとしては扱わず、重要な情報は Pixiv で確認し、管理権限のある account だけを使用してください。
 
 macOS、desktop Linux、Windows は on-demand persistent `pixiv://` callback handler を使い、local login と明示設定した cross-machine relay をサポートします。relay は `pixiv://account/login` callback を受け付けます。GUI のない SSH server は既存の `--no-open --addr` と local `ssh -L` tunnel を使うか、documented relay server/client setting を設定します。詳細は [CLI リファレンス](docs/ja/cli-reference.md#refresh-token-の取得) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **One capability surface** — search, details, rankings, recommendations, users, bookmarks, follows, downloads, and ugoira across CLI, MCP, and SDK.
 - **Feeds and composable Record pipelines** — retrieve feeds as canonical NDJSON, filter them locally, and pass records into actions.
 - **Local account pools** — select eligible local accounts for read workloads and honor Pixiv `Retry-After` responses during pagination and download preparation.
+- **Guided account sign-in** — complete browser OAuth with `pixiv auth login`, then use `auth list`, `auth use`, and `auth check` to manage local multi-account access.
 - **GIF and APNG ugoira output** — keep GIF as the default or explicitly request APNG through the CLI, MCP, or SDK.
 - **Cache-aware downloads** — revalidate persistent `.pixiv-cache` metadata, resume verified partial data with `Range` and `If-Range`, and atomically replace completed files.
 - **Authenticated App API discovery** — read R18 details, pages, ugoira metadata, and all 16 ranking modes through the App API.
@@ -58,14 +59,14 @@ Copy this single prompt into Codex, Claude Code, Cursor, or another local AI age
 ```text
 Install the latest stable pixiv-cli from https://github.com/FlanChanXwO/pixiv-cli for this machine: inspect the repository's scripts/install.sh or scripts/install.cmd first, choose the script matching the detected OS and architecture (the Windows path must use cmd.exe and must not invoke PowerShell), download only official GitHub Release assets, require the published SHA-256 check to pass before replacing anything, install per-user without administrator or root privileges, add only the chosen install directory to the user PATH, ask before installing any missing prerequisite, never read or output Pixiv credentials, verify with pixiv version, and report the installed version plus every file and PATH change.
 
-Also install the product skill that matches the same stable release tag (not main): download the full skills/pixiv-cli/ directory from that tag into the agent skills directory the user confirms. Do not guess the skills path and do not follow the main branch for skill content.
+Also install the `pixiv-cli` Skill that matches the same stable release tag (not main): download the full skills/pixiv-cli/ directory from that tag into the agent skills directory the user confirms. Do not guess the skills path and do not follow the main branch for skill content.
 ```
 
-### Install the product Skill from SkillHub
+### Install the pixiv-cli Skill from SkillHub
 
 Agents with SkillHub support can install the published [`pixiv-cli` Skill](https://www.skillhub.cn/skills/pixiv-cli) directly from SkillHub. The Skill has its own version and teaches the installed CLI; always use `pixiv <cmd> --help` as the final source of command syntax.
 
-### Install the product Skill from ClawHub
+### Install the pixiv-cli Skill from ClawHub
 
 Agents using ClawHub can install the published [`pixiv-cli` Skill](https://clawhub.ai/flanchanxwo/skills/pixiv-cli) with `clawhub install pixiv-cli`; pin the installed skill to the matching published release version rather than following an unversioned latest tag.
 
@@ -166,6 +167,10 @@ Import `github.com/FlanChanXwO/pixiv-cli/pixiv`. `Download`/`DownloadAll` use do
 ## Authentication and token safety
 
 `pixiv auth login` is the recommended setup. It saves raw Pixiv App OAuth refresh tokens by UID in the local account store.
+
+### Account information disclaimer
+
+Account names, IDs, membership signals, and the active local-account selection are convenience information from the local store and Pixiv responses. Treat them as convenience data rather than proof of account ownership, entitlement, or current Pixiv status. Verify important account details in Pixiv and use only accounts you are authorized to manage.
 
 On macOS, desktop Linux, and Windows, an on-demand persistent `pixiv://` callback handler supports local login and an explicitly configured cross-machine relay. The relay accepts the `pixiv://account/login` callback. For a headless SSH server, use the existing `--no-open --addr` flow with a local `ssh -L` tunnel, or configure the documented relay server/client settings. See the [CLI reference](docs/en/cli-reference.md#getting-a-refresh-token).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,7 @@
 - **一致的能力面**——CLI、MCP 与 SDK 均可完成搜索、详情、排行、推荐、用户、收藏、关注、下载和 ugoira 处理。
 - **信息流与组合式 Record 管道**——以标准 NDJSON 获取信息流，在本地筛选 Record，并把结果传给后续 action。
 - **本地账号池**——为读取型任务选择符合条件的本地账号，并在分页和下载准备阶段遵循 Pixiv 的 `Retry-After` 响应。
+- **易用的账号登录流程**——运行 `pixiv auth login` 即可在浏览器完成 OAuth，随后可使用 `auth list`、`auth use` 和 `auth check` 管理和确认本地多账号。
 - **GIF 与 APNG ugoira 输出**——GIF 为默认格式，也可通过 CLI、MCP 或 SDK 显式请求 APNG。
 - **缓存感知下载**——持久重验证 `.pixiv-cache` 元数据，以 `Range` 和 `If-Range` 安全续传已验证的残片，并原子替换完成文件。
 - **认证 App API 发现能力**——通过 App API 读取 R18 详情、分页、ugoira metadata 和全部 16 种排行榜。
@@ -56,16 +57,16 @@ binary，并在修改 PATH 前完成用户级安装。可用 `--no-path` 保持 
 ```text
 请为这台机器安装 https://github.com/FlanChanXwO/pixiv-cli 的最新 stable 版本：先审阅仓库中的 scripts/install.sh 或 scripts/install.cmd，再根据检测到的操作系统与架构选择对应脚本（Windows 必须使用 cmd.exe，禁止调用 PowerShell），只下载官方 GitHub Release 资产，只有发布的 SHA-256 校验通过后才能替换文件，使用无需管理员或 root 权限的用户级目录，只把选定安装目录加入用户 PATH，缺少任何前置工具时先征求同意，绝不读取或输出 Pixiv 凭据，最后运行 pixiv version 验证，并报告安装版本及全部文件和 PATH 变更。
 
-同时安装与该 stable 发布 tag 完全一致的产品 skill（不要跟随 main）：把该 tag 下的完整 skills/pixiv-cli/ 目录安装到用户确认的 Agent skills 目录。不要猜测 skills 路径，也不要用 main 上的 skill 内容。
+同时安装与该 stable 发布 tag 完全一致的 `pixiv-cli` Skill（不要跟随 main）：把该 tag 下的完整 skills/pixiv-cli/ 目录安装到用户确认的 Agent skills 目录。不要猜测 skills 路径，也不要用 main 上的 skill 内容。
 ```
 
-### 通过 SkillHub 安装产品 Skill
+### 通过 SkillHub 安装 pixiv-cli Skill
 
-支持 SkillHub 的 Agent 可直接从 [SkillHub 的 `pixiv-cli` Skill 页面](https://www.skillhub.cn/skills/pixiv-cli) 安装已发布的产品 Skill。Skill 有独立版本并用于指导已安装的 CLI；命令语法始终以 `pixiv <cmd> --help` 为最终依据。
+支持 SkillHub 的 Agent 可直接从 [SkillHub 的 `pixiv-cli` Skill 页面](https://www.skillhub.cn/skills/pixiv-cli) 安装已发布的 `pixiv-cli` Skill。Skill 有独立版本并用于指导已安装的 CLI；命令语法始终以 `pixiv <cmd> --help` 为最终依据。
 
-### 通过 ClawHub 安装产品 Skill
+### 通过 ClawHub 安装 pixiv-cli Skill
 
-使用 ClawHub 的 Agent 可从 [ClawHub 的 `pixiv-cli` Skill 页面](https://clawhub.ai/flanchanxwo/skills/pixiv-cli) 执行 `clawhub install pixiv-cli` 安装已发布的产品 Skill；请固定到与 CLI 发布相同的 Skill 版本，不要跟随未固定的 latest。
+使用 ClawHub 的 Agent 可从 [ClawHub 的 `pixiv-cli` Skill 页面](https://clawhub.ai/flanchanxwo/skills/pixiv-cli) 执行 `clawhub install pixiv-cli` 安装已发布的 `pixiv-cli` Skill；请固定到与 CLI 发布相同的 Skill 版本，不要跟随未固定的 latest。
 
 ### Homebrew（macOS 与 Linux 推荐）
 
@@ -164,6 +165,10 @@ download, err := client.Download(ctx, "https://www.pixiv.net/artworks/123456")
 ## 认证与 token 安全
 
 推荐使用 `pixiv auth login` 完成配置。它把原始 Pixiv App OAuth refresh token 按 UID 保存在本地账号 store。
+
+### 账号信息免责声明
+
+账号名称、UID、会员状态提示和当前本地账号选择来自本地存储与 Pixiv 响应，仅用于操作便利；它们不构成账号归属、权限或当前 Pixiv 状态的证明。请在 Pixiv 核对重要账号信息，并且只管理已获授权的账号。
 
 macOS、桌面 Linux 与 Windows 使用按需持久的 `pixiv://` callback handler，既支持本地登录，也支持显式配置的跨机器 relay；relay 接收 `pixiv://account/login` callback。无 GUI SSH 服务器仍可使用现有的 `--no-open --addr` 与本机 `ssh -L` tunnel，或配置文档中的 relay server/client 设置。详见 [CLI 参考手册](docs/zh-CN/cli-reference.md#获取-refresh-token)。
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,7 +1,9 @@
 # Changelog
 
 This directory contains the versioned release notes. Each release has matching English and Simplified Chinese files.
-GitHub Release bodies present the two versions together, with English first and Simplified Chinese second.
+GitHub Release bodies present the two versions together, with English first and Simplified Chinese second. Entries are
+grouped by user outcome and carry inline PR or historical direct-commit sources; empty standard sections are omitted.
+`unreleased/` is the release-prep staging area, while feature PRs declare their category and summary in the PR template.
 
 | Version | Date | Release notes |
 | --- | --- | --- |
@@ -15,10 +17,12 @@ GitHub Release bodies present the two versions together, with English first and 
 | [v0.4.5](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.4...v0.4.5) | 2026-07-20 | [English](v0.4.5/en.md) · [简体中文](v0.4.5/zh-CN.md) |
 | [v0.4.4](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.3...v0.4.4) | 2026-07-19 | [English](v0.4.4/en.md) · [简体中文](v0.4.4/zh-CN.md) |
 | [v0.4.3](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.2...v0.4.3) | 2026-07-19 | [English](v0.4.3/en.md) · [简体中文](v0.4.3/zh-CN.md) |
-| [v0.4.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.2) | 2026-07-19 | [English](v0.4.2/en.md) · [简体中文](v0.4.2/zh-CN.md) |
+| [v0.4.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.1...v0.4.2) | 2026-07-19 | [English](v0.4.2/en.md) · [简体中文](v0.4.2/zh-CN.md) |
+| [v0.4.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.0...v0.4.1) | 2026-07-19 | [English](v0.4.1/en.md) · [简体中文](v0.4.1/zh-CN.md) |
+| [v0.4.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.0) | 2026-07-19 | [English](v0.4.0/en.md) · [简体中文](v0.4.0/zh-CN.md) |
 | [v0.3.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.2.0...v0.3.0) | 2026-07-15 | [English](v0.3.0/en.md) · [简体中文](v0.3.0/zh-CN.md) |
 | [v0.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.1...v0.2.0) | 2026-07-13 | [English](v0.2.0/en.md) · [简体中文](v0.2.0/zh-CN.md) |
 | [v0.1.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.0...v0.1.1) | 2026-07-13 | [English](v0.1.1/en.md) · [简体中文](v0.1.1/zh-CN.md) |
-| [v0.1.0](https://github.com/FlanChanXwO/pixiv-cli/releases/tag/v0.1.0) | 2026-07-13 | [English](v0.1.0/en.md) · [简体中文](v0.1.0/zh-CN.md) |
+| [v0.1.0](https://github.com/FlanChanXwO/pixiv-cli/commits/v0.1.0) | 2026-07-13 | [English](v0.1.0/en.md) · [简体中文](v0.1.0/zh-CN.md) |
 
 The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -1,6 +1,6 @@
 # 更新日志
 
-本目录按版本存放发布说明。每个版本均有对应的英文和简体中文文件；英文版本用作 GitHub Release 正文。
+本目录按版本存放发布说明。每个版本均有对应的英文和简体中文文件；GitHub Release 正文先显示英文，再显示简体中文。条目按用户结果归并，内联标注 PR 或历史 direct commit 来源；空的标准章节不输出。`unreleased/` 是 release-prep 暂存区，功能 PR 在模板中声明分类和摘要。
 
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
@@ -14,10 +14,12 @@
 | [v0.4.5](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.4...v0.4.5) | 2026-07-20 | [English](v0.4.5/en.md) · [简体中文](v0.4.5/zh-CN.md) |
 | [v0.4.4](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.3...v0.4.4) | 2026-07-19 | [English](v0.4.4/en.md) · [简体中文](v0.4.4/zh-CN.md) |
 | [v0.4.3](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.2...v0.4.3) | 2026-07-19 | [English](v0.4.3/en.md) · [简体中文](v0.4.3/zh-CN.md) |
-| [v0.4.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.2) | 2026-07-19 | [English](v0.4.2/en.md) · [简体中文](v0.4.2/zh-CN.md) |
+| [v0.4.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.1...v0.4.2) | 2026-07-19 | [English](v0.4.2/en.md) · [简体中文](v0.4.2/zh-CN.md) |
+| [v0.4.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.0...v0.4.1) | 2026-07-19 | [English](v0.4.1/en.md) · [简体中文](v0.4.1/zh-CN.md) |
+| [v0.4.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.0) | 2026-07-19 | [English](v0.4.0/en.md) · [简体中文](v0.4.0/zh-CN.md) |
 | [v0.3.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.2.0...v0.3.0) | 2026-07-15 | [English](v0.3.0/en.md) · [简体中文](v0.3.0/zh-CN.md) |
 | [v0.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.1...v0.2.0) | 2026-07-13 | [English](v0.2.0/en.md) · [简体中文](v0.2.0/zh-CN.md) |
 | [v0.1.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.0...v0.1.1) | 2026-07-13 | [English](v0.1.1/en.md) · [简体中文](v0.1.1/zh-CN.md) |
-| [v0.1.0](https://github.com/FlanChanXwO/pixiv-cli/releases/tag/v0.1.0) | 2026-07-13 | [English](v0.1.0/en.md) · [简体中文](v0.1.0/zh-CN.md) |
+| [v0.1.0](https://github.com/FlanChanXwO/pixiv-cli/commits/v0.1.0) | 2026-07-13 | [English](v0.1.0/en.md) · [简体中文](v0.1.0/zh-CN.md) |
 
 格式遵循 [Keep a Changelog 1.1.0](https://keepachangelog.com/zh-CN/1.1.0/) 与 [语义化版本](https://semver.org/spec/v2.0.0.html)。

--- a/changelog/unreleased/en.md
+++ b/changelog/unreleased/en.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+> Release-prep staging area. Feature PRs provide their category and summary in the PR template; the approved release-prep plan groups those sources into the next versioned notes.
+
 ## Changed
 
 - Documentation-only pull requests and `main` pushes now run the documentation contract check instead of the full Linux quality gate and six-platform packaged-binary smoke. Any source, dependency, script, or workflow change still runs the complete validation set.

--- a/changelog/unreleased/zh-CN.md
+++ b/changelog/unreleased/zh-CN.md
@@ -1,5 +1,7 @@
 # 未发布
 
+> 此处是 release-prep 暂存区。功能 PR 在模板中提供分类和摘要；经审核的 release-prep plan 会将这些来源归并到下一个版本说明。
+
 ## 变更
 
 - 仅文档的 Pull Request 与 `main` push 现只运行文档契约检查，不再运行完整 Linux 质量门禁和六平台已打包二进制 smoke；任何源码、依赖、脚本或 workflow 改动仍会执行完整验证集。

--- a/changelog/v0.1.0/en.md
+++ b/changelog/v0.1.0/en.md
@@ -1,27 +1,24 @@
 # v0.1.0 — 2026-07-13
 
+## Breaking changes
+
+- Made Pixiv UID the local auth-account identity and expanded browser OAuth callback handoff. ([`3bf5fc4`](https://github.com/FlanChanXwO/pixiv-cli/commit/3bf5fc4), [`53ad400`](https://github.com/FlanChanXwO/pixiv-cli/commit/53ad400))
+
 ## Added
 
-- Introduced project-level release notes, `sh scripts/build.sh`, `pixiv version [--json]`, and `pixiv update [--check] [--prerelease] [--proxy URL]` for Homebrew, exact-tag `go install`, and signed Release-binary update paths. Development builds reject updates.
-- Added an opt-out `update_check_enabled` stable-update hint. Successful normal CLI commands check at most once per 24 hours, wait at most three seconds, and never pollute JSON/MCP stdout or change the business-command exit code.
-- Added the built-in Rust ugoira GIF/APNG encoder so production downloads no longer require `ffmpeg`.
-- Added committed Rust static libraries, manifests, source-digest verification, six-platform native build/smoke evidence, fixed six-target release assets, checksum/Ed25519 signatures, and Homebrew stable/beta formula rendering and verification.
-
-## Changed
-
-- **Breaking:** local auth accounts are identified by Pixiv UID rather than custom names. `auth add/login` no longer accepts an account name; `auth use/remove/check` use UID, and `--uid` replaces `--profile`.
-- **Breaking:** `auth.json` now uses `default_user_id` and `accounts[].user_id/username`. Existing `default_account/accounts[].name` files require fresh authentication.
-- Browser login keeps a terminal-paste fallback for official callbacks, `pixiv://` URLs, or raw authorization codes. It accepts official callback and `pixiv://account/login` code handoff while retaining strict local-loopback state validation.
-- On macOS, login can register a local `pixiv://` helper and open the default browser to reuse an existing Pixiv session. It relays only the final callback to the current CLI loopback and retains explicit manual recovery if no callback is available.
+- Added verified release updates, installation-source detection, and automatic update notices. ([`1101530`](https://github.com/FlanChanXwO/pixiv-cli/commit/1101530), [`3176147`](https://github.com/FlanChanXwO/pixiv-cli/commit/3176147), [`75872cd`](https://github.com/FlanChanXwO/pixiv-cli/commit/75872cd), [`a279985`](https://github.com/FlanChanXwO/pixiv-cli/commit/a279985), [`c4e7737`](https://github.com/FlanChanXwO/pixiv-cli/commit/c4e7737))
+- Added built-in Rust ugoira GIF/APNG encoding and the supported native build inputs. ([`235a017`](https://github.com/FlanChanXwO/pixiv-cli/commit/235a017), [`e5bc6a9`](https://github.com/FlanChanXwO/pixiv-cli/commit/e5bc6a9))
 
 ## Fixed
 
-- Fixed Linux Rust `libm` linkage and Windows checkout/text handling for Rust sources, Cargo vendor data, licenses, and source-digest inputs. Windows uses LLD-backed Clang with the necessary Rust import libraries, and release ZIP creation uses preinstalled 7-Zip.
+- Stabilized cross-platform Rust linking, source verification, archive creation, and update replacement. ([`0a36d3d`](https://github.com/FlanChanXwO/pixiv-cli/commit/0a36d3d), [`4a315a0`](https://github.com/FlanChanXwO/pixiv-cli/commit/4a315a0), [`a092dd8`](https://github.com/FlanChanXwO/pixiv-cli/commit/a092dd8), [`ab03362`](https://github.com/FlanChanXwO/pixiv-cli/commit/ab03362))
 
 ## Security
 
-- Established protected release infrastructure with isolated Ed25519 signing and Homebrew tap credentials; private keys stay in the protected Environment and recovery Keychain copy.
-- Added fail-closed native-evidence and release-workflow policies for pinned actions, minimal permissions, required job ancestry, canonical immutable source checkouts, and strict publication-channel mapping.
-- Kept Homebrew deployment credentials confined to the final protected push step and validated the complete vendored Rust dependency closure in an empty Cargo cache.
-- Added a rotatable embedded Ed25519 public-key trust root and signature/checksum/version verification before installer replacement. Release sources, selected archives, extraction paths, cancellation, cache permissions, and symlink targets are validated conservatively.
-- v0.1.0 does not include Apple notarization or Windows Authenticode; directly downloaded binaries may still trigger Gatekeeper or SmartScreen.
+- Added signed multi-platform release verification, protected release publication, and safe archive and cache handling. ([`d4036cf`](https://github.com/FlanChanXwO/pixiv-cli/commit/d4036cf), [`7c04d19`](https://github.com/FlanChanXwO/pixiv-cli/commit/7c04d19), [`79568f9`](https://github.com/FlanChanXwO/pixiv-cli/commit/79568f9), [`e1ee586`](https://github.com/FlanChanXwO/pixiv-cli/commit/e1ee586))
+
+## Maintenance
+
+- Reorganized the CLI and public package boundaries and established Homebrew release verification. ([`1e3005b`](https://github.com/FlanChanXwO/pixiv-cli/commit/1e3005b), [`2cff4b6`](https://github.com/FlanChanXwO/pixiv-cli/commit/2cff4b6), [`87442be`](https://github.com/FlanChanXwO/pixiv-cli/commit/87442be), [`c732bd2`](https://github.com/FlanChanXwO/pixiv-cli/commit/c732bd2))
+
+**Full Changelog**: [v0.1.0 commits](https://github.com/FlanChanXwO/pixiv-cli/commits/v0.1.0)

--- a/changelog/v0.1.0/zh-CN.md
+++ b/changelog/v0.1.0/zh-CN.md
@@ -1,33 +1,24 @@
 # v0.1.0 — 2026-07-13
 
+## 破坏性变更
+
+- 以 Pixiv UID 作为本地认证账号标识，并扩展浏览器 OAuth 回调交接。 ([`3bf5fc4`](https://github.com/FlanChanXwO/pixiv-cli/commit/3bf5fc4), [`53ad400`](https://github.com/FlanChanXwO/pixiv-cli/commit/53ad400))
+
 ## 新增
 
-- 新增项目级 changelog，集中记录用户可见变化、兼容性说明和发布准备事项。
-- 新增 POSIX sh 构建脚本 `sh scripts/build.sh`，默认将二进制输出到 `build/`。
-- 新增 `pixiv version [--json]` 与根 `pixiv --version`；JSON 输出包含 `version`、`commit`、`build_date`。
-- 新增 `pixiv update [--check] [--prerelease] [--proxy URL]`，支持 Homebrew stable/beta、精确 tag `go install` 与签名 Release binary 策略；开发构建拒绝更新。
-- 新增可关闭的 `update_check_enabled` 自动 stable 更新提示；普通 CLI 成功后最多每 24 小时检查一次，自动检查最多等待 3 秒，且不会污染 JSON/MCP stdout 或改变业务命令退出码。
-- 新增内置 Rust ugoira GIF/APNG encoder；生产下载路径不再依赖 `ffmpeg`。
-- 新增经六平台 native runner build/smoke 与统一 source digest 验证的 committed Rust staticlibs 和 `manifest.json`，供受支持的 source build 与精确 tag `go install` 使用。
-- 新增固定 six-target Release asset 格式、checksum/Ed25519 签名、Homebrew formula renderer 与六 native runner workflow。
-- 新增 Homebrew stable `pixiv-cli` 与 beta `pixiv-cli-beta` formula 模板；两者冲突并同装 `pixiv`，不依赖 `ffmpeg`。
-- Release workflow 现把同一份已发布 checksum 渲染为 stable/beta Homebrew formula，在 macOS/Linux 双架构真实安装并核对版本后，才以独立 deploy key 向 public tap 推送唯一对应 formula。
-
-## 变更
-
-- Breaking: 本地 auth 账号从自定义账号名改为 Pixiv UID；`auth add/login` 不再接收账号名，`auth use/remove/check` 使用 UID，`--uid` 取代 `--profile` 作为主选择参数。
-- Breaking: `auth.json` schema 改为 `default_user_id` 与 `accounts[].user_id/username`；旧 `default_account/accounts[].name` 文件需要重新 `pixiv auth add` 或 `pixiv auth login`。
-- `pixiv auth login` 默认打开浏览器时也保留终端粘贴兜底，可直接粘贴 callback URL、`pixiv://...` URL 或原始 authorization code；接受 Pixiv 官方 callback URL 与 `pixiv://account/login` 缺省 OAuth state 的授权码回填，同时继续要求本地 loopback callback 携带正确 state。
-- `pixiv auth login` 在 macOS 默认会优先注册本地 `pixiv://` callback helper 并打开默认浏览器，以复用已有 Pixiv 登录态；helper 把最终 callback URL 转交给本轮 CLI loopback，并在 helper 不可用、状态不可读或 Pixiv 未生成 callback 时提供手动回填路径。
+- 新增已验证的发布更新、安装来源识别和自动更新提示。 ([`1101530`](https://github.com/FlanChanXwO/pixiv-cli/commit/1101530), [`3176147`](https://github.com/FlanChanXwO/pixiv-cli/commit/3176147), [`75872cd`](https://github.com/FlanChanXwO/pixiv-cli/commit/75872cd), [`a279985`](https://github.com/FlanChanXwO/pixiv-cli/commit/a279985), [`c4e7737`](https://github.com/FlanChanXwO/pixiv-cli/commit/c4e7737))
+- 新增内置 Rust ugoira GIF/APNG 编码及受支持的原生构建输入。 ([`235a017`](https://github.com/FlanChanXwO/pixiv-cli/commit/235a017), [`e5bc6a9`](https://github.com/FlanChanXwO/pixiv-cli/commit/e5bc6a9))
 
 ## 修复
 
-- 修复 Linux 原生 Rust staticlib 的 `libm` 链接，以及 Windows checkout 对 first-party crate、Cargo vendor、本地 locked dependency 和生成 license bundle 的文本转换，使六平台保持同一 Rust source identity；Windows cgo 使用 Rust import libraries 和 LLD-backed Clang 链接 `*-pc-windows-msvc` staticlib，release `.zip` 使用预装 7-Zip，避免 Git Bash 缺少 `zip`。
+- 稳定跨平台 Rust 链接、源码验证、归档创建和更新替换。 ([`0a36d3d`](https://github.com/FlanChanXwO/pixiv-cli/commit/0a36d3d), [`4a315a0`](https://github.com/FlanChanXwO/pixiv-cli/commit/4a315a0), [`a092dd8`](https://github.com/FlanChanXwO/pixiv-cli/commit/a092dd8), [`ab03362`](https://github.com/FlanChanXwO/pixiv-cli/commit/ab03362))
 
 ## 安全
 
-- 发布基础设施使用公开 source/tap 仓库、受保护 `release` Environment、隔离的 Ed25519 签名与 tap deploy credentials；私钥仅位于该 Environment 与 macOS Keychain 恢复副本。
-- native-evidence 与 release workflow policy 均 fail-closed，检查 action full-SHA pin、最小权限、精确 trigger/runner matrix、required job/ancestry gate、canonical immutable source checkout 与 stable/prerelease 发布通道映射。
-- Homebrew tap secret 仅可进入最终 protected deploy job 的最后 push step；Rust ugoira crates.io 依赖以完整 locked `vendor/` 闭包及 Cargo checksum 审计，并在空 Cargo cache 中验证。
-- 受支持 binary 内置可轮换的 Ed25519 public-key trust root；安装器在替换前验证签名 checksum、archive SHA-256 与下载 binary version，并严格验证 GitHub HTTPS 来源、archive path、取消、cache 权限与软链接目标。
-- v0.1.0 不含 Apple notarization 或 Windows Authenticode；直接下载仍可能显示 Gatekeeper/SmartScreen 提示。
+- 新增签名多平台发布验证、受保护发布流程和安全归档与缓存处理。 ([`d4036cf`](https://github.com/FlanChanXwO/pixiv-cli/commit/d4036cf), [`7c04d19`](https://github.com/FlanChanXwO/pixiv-cli/commit/7c04d19), [`79568f9`](https://github.com/FlanChanXwO/pixiv-cli/commit/79568f9), [`e1ee586`](https://github.com/FlanChanXwO/pixiv-cli/commit/e1ee586))
+
+## 维护
+
+- 重组 CLI 与公开包边界，并建立 Homebrew 发布验证。 ([`1e3005b`](https://github.com/FlanChanXwO/pixiv-cli/commit/1e3005b), [`2cff4b6`](https://github.com/FlanChanXwO/pixiv-cli/commit/2cff4b6), [`87442be`](https://github.com/FlanChanXwO/pixiv-cli/commit/87442be), [`c732bd2`](https://github.com/FlanChanXwO/pixiv-cli/commit/c732bd2))
+
+**完整变更**：[v0.1.0 commits](https://github.com/FlanChanXwO/pixiv-cli/commits/v0.1.0)

--- a/changelog/v0.1.1/en.md
+++ b/changelog/v0.1.1/en.md
@@ -2,8 +2,11 @@
 
 ## Fixed
 
-- Correctly recognizes a directly downloaded Release binary when no expected `GOBIN`/`GOPATH/bin/pixiv` exists, allowing `pixiv update --check` to run.
-- Fixed Windows release linking between MinGW GCC and the MSVC Rust static library. Six-platform Go tests, race/vet/pre-commit checks, and final builds use audited cgo linkers; Windows uses LLD-backed Clang.
-- Made login-test callback fixtures race-safe and isolated tests that must not invoke real macOS URL handlers or AppleScript.
-- Added an audited recovery route for a failed first publication of an immutable tag. Recovery remains tied to the original tag, uses separate test/production runners, and rebuilds production assets from a clean checkout.
-- Corrected Windows recovery-gate assumptions around ACLs, `.exe`, CRLF, sharing, and paths while retaining static policy restrictions and immutable-tag-only production builds.
+- Recognized directly downloaded release binaries and stabilized Windows release linking and checkout handling. ([`8f7169a`](https://github.com/FlanChanXwO/pixiv-cli/commit/8f7169a), [`c5eef2c`](https://github.com/FlanChanXwO/pixiv-cli/commit/c5eef2c))
+- Added a Windows-safe immutable-tag publication recovery route with isolated test and production builds. ([`557beb0`](https://github.com/FlanChanXwO/pixiv-cli/commit/557beb0), [`86697e9`](https://github.com/FlanChanXwO/pixiv-cli/commit/86697e9), [`c295394`](https://github.com/FlanChanXwO/pixiv-cli/commit/c295394))
+
+## Maintenance
+
+- Hardened recovery workflow tests and their cross-platform fixture handling. ([`2490f03`](https://github.com/FlanChanXwO/pixiv-cli/commit/2490f03), [`f7926ae`](https://github.com/FlanChanXwO/pixiv-cli/commit/f7926ae))
+
+**Full Changelog**: [v0.1.0...v0.1.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.0...v0.1.1)

--- a/changelog/v0.1.1/zh-CN.md
+++ b/changelog/v0.1.1/zh-CN.md
@@ -2,8 +2,11 @@
 
 ## 修复
 
-- 修复直接下载的 Release binary 在本机不存在预期 `GOBIN`/`GOPATH/bin/pixiv` 时，把该正常安装来源判定为错误而无法执行 `pixiv update --check` 的问题；不存在的 go install 目标现在会正确归类为 Release，其他路径解析错误仍会原样报告。
-- 修复 Release workflow 在 Windows 上以 MinGW GCC 链接 MSVC Rust staticlib 的错误；六平台 Go 测试、race、vet、pre-commit 与最终构建现在统一使用各自受审计的 cgo linker，Windows 固定为 LLD-backed Clang。
-- 修复登录测试夹具对回调 URL 列表的并发读写，并隔离不应访问真实 macOS URL handler/AppleScript 的场景，避免 race detector 报错或冷 runner 因系统 helper 副作用耗尽显式测试等待窗口。
-- 新增不可变 tag 首次发布在创建 Release 前失败时的受审计恢复入口；恢复仍绑定原 tag，测试门禁与生产资产使用独立 runner，后者以 clean checkout 重建工作树和 staticlib，禁止默认分支测试 overlay 或其进程环境混入 binary、许可证或归档。
-- 修复恢复测试门在 Windows runner 上对 ACL、`.exe`、CRLF、文件共享和路径转义的错误假设；覆盖路径受静态 policy 限制，生产资产仍只由不可变 tag 源码构建。
+- 识别直接下载的发布二进制，并稳定 Windows 发布链接和 checkout 处理。 ([`8f7169a`](https://github.com/FlanChanXwO/pixiv-cli/commit/8f7169a), [`c5eef2c`](https://github.com/FlanChanXwO/pixiv-cli/commit/c5eef2c))
+- 新增 Windows 安全的不可变 tag 发布恢复路径，并隔离测试与生产构建。 ([`557beb0`](https://github.com/FlanChanXwO/pixiv-cli/commit/557beb0), [`86697e9`](https://github.com/FlanChanXwO/pixiv-cli/commit/86697e9), [`c295394`](https://github.com/FlanChanXwO/pixiv-cli/commit/c295394))
+
+## 维护
+
+- 强化恢复工作流测试及其跨平台 fixture 处理。 ([`2490f03`](https://github.com/FlanChanXwO/pixiv-cli/commit/2490f03), [`f7926ae`](https://github.com/FlanChanXwO/pixiv-cli/commit/f7926ae))
+
+**完整变更**：[v0.1.0...v0.1.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.0...v0.1.1)

--- a/changelog/v0.2.0/en.md
+++ b/changelog/v0.2.0/en.md
@@ -2,12 +2,10 @@
 
 ## Added
 
-- Added the public Go SDK: concrete `*pixiv.Client`, stable models, typed errors, opaque cursors, account/config handling, and policy-constrained resource streams.
-- Added `pixiv user artworks/bookmarks/following [USER_ID]`, bookmark add/remove, follow add/remove, matching MCP tools, paged user lists, and structured output.
-- Added injectable `slog` diagnostics with `log_level` / `log_format` and `PIXIV_LOG_LEVEL` / `PIXIV_LOG_FORMAT` overrides.
-- Added Linux quality gates and six-platform packaged-binary smoke tests that stay offline and use no Pixiv credentials or live upstream network.
+- Added the public Go SDK, account and configuration APIs, user/bookmark/follow workflows, matching MCP tools, structured diagnostics, offline six-platform quality coverage, and the page/limit App API contract. ([#1](https://github.com/FlanChanXwO/pixiv-cli/pull/1))
 
-## Changed
+## Security
 
-- List commands use `--limit` and logical `--page`; `--offset` was deprecated and SDK cursors are not exposed by CLI/MCP.
-- A configured refresh token routes requests through the App API; failed calls return their classified error. Web serves anonymous allowlisted reads and explicit metadata enrichment.
+- Kept release publication behind the protected workflow. ([#2](https://github.com/FlanChanXwO/pixiv-cli/pull/2))
+
+**Full Changelog**: [v0.1.1...v0.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.1...v0.2.0)

--- a/changelog/v0.2.0/zh-CN.md
+++ b/changelog/v0.2.0/zh-CN.md
@@ -2,13 +2,10 @@
 
 ## 新增
 
-- 新增公开 Go SDK；提供具体 `*pixiv.Client`、稳定模型、类型化错误、opaque cursor、账号/config 与受策略限制的资源流访问。
-- 新增 `pixiv user artworks/bookmarks/following [USER_ID]`；新增 `bookmark add/remove` 与 `follow add/remove`。
-- MCP 新增 `user_artworks`、分页用户列表、收藏/关注写操作及 structured output。
-- 新增可注入的 `slog` 诊断日志与 `log_level`/`log_format` 配置，支持 `PIXIV_LOG_LEVEL`/`PIXIV_LOG_FORMAT` 覆盖。
-- 新增 Linux quality gate 与六平台已打包 binary smoke；它们离线验证 CLI、config 与 MCP stdio，不使用 Pixiv 凭据或真实上游网络。
+- 新增公开 Go SDK、账号与配置 API、用户/收藏/关注流程、对应 MCP 工具、结构化诊断、离线六平台质量覆盖和 page/limit App API 契约。 ([#1](https://github.com/FlanChanXwO/pixiv-cli/pull/1))
 
-## 变更
+## 安全
 
-- 列表 CLI 改用 `--limit` 和逻辑 `--page`；`--offset` 已废弃。CLI/MCP 不暴露 SDK cursor。
-- 有 refresh token 时 App API 失败不再自动回落 Web；Web 仅用于无 token 的匿名白名单读操作和明确 metadata enrichment。
+- 将发布操作保留在受保护工作流之后。 ([#2](https://github.com/FlanChanXwO/pixiv-cli/pull/2))
+
+**完整变更**：[v0.1.1...v0.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.1.1...v0.2.0)

--- a/changelog/v0.3.0/en.md
+++ b/changelog/v0.3.0/en.md
@@ -1,21 +1,15 @@
 # v0.3.0 — 2026-07-15
 
-## Changed
+## Breaking changes
 
-- **Breaking:** the public Go SDK moved to `github.com/FlanChanXwO/pixiv-cli/pixiv`; no compatibility package remains at the former import path.
-- **Breaking:** authentication accepts raw Pixiv App API refresh tokens.
-- **Breaking:** `pixiv recommended` requires one of `all|illust|manga|novel|user`; `all` returns the four personalized streams atomically.
+- Moved the public SDK to its stable import path and added explicit App API recommendation, detail, and raw refresh-token contracts. ([#7](https://github.com/FlanChanXwO/pixiv-cli/pull/7))
 
 ## Added
 
-- Added MCP `recommended` with a required kind and independent pagination per stream for `all`, plus MCP `user_detail` and `pixiv user detail USER_ID` with stable structured/JSON detail output.
-- Added local `--rating`, `--type`, and `--ai-type` search filters. When a page or limit is requested, matching results continue through the opaque cursor.
+- Added local illustration search filters for rating, type, and AI mode. ([#3](https://github.com/FlanChanXwO/pixiv-cli/pull/3))
 
 ## Fixed
 
-- Accepted `offset=0` in real App API recommendation cursors, correctly decoded user-detail publicity, clarified the browser login callback page, reduced non-JSON login success to one line, defaulted diagnostics to `warn`, and added an identifying User-Agent for GitHub Release update checks.
+- Stabilized v0.2 release recovery, update-request identification, cursor decoding, and browser login feedback. ([#4](https://github.com/FlanChanXwO/pixiv-cli/pull/4), [#5](https://github.com/FlanChanXwO/pixiv-cli/pull/5), [#6](https://github.com/FlanChanXwO/pixiv-cli/pull/6))
 
-## Security
-
-- `auth login` uses the current loopback, controlled `pixiv://` helper, and an explicitly manual paste path.
-- SDK, CLI, MCP, environment variables, and stored accounts validate credential input before OAuth and redact it in diagnostics.
+**Full Changelog**: [v0.2.0...v0.3.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.2.0...v0.3.0)

--- a/changelog/v0.3.0/zh-CN.md
+++ b/changelog/v0.3.0/zh-CN.md
@@ -1,27 +1,15 @@
 # v0.3.0 — 2026-07-15
 
-## 变更
+## 破坏性变更
 
-- Breaking: 公开 Go SDK 已迁移至 `github.com/FlanChanXwO/pixiv-cli/pixiv`；旧导入路径不保留兼容 package。
-- Breaking: 认证入口使用原始 Pixiv App API refresh token。
-- Breaking: `pixiv recommended` 现要求 `all|illust|manga|novel|user` kind；`all` 原子返回四类个性化推荐。
+- 将公开 SDK 迁移到稳定导入路径，并新增明确的 App API 推荐、详情和原始 refresh token 契约。 ([#7](https://github.com/FlanChanXwO/pixiv-cli/pull/7))
 
 ## 新增
 
-- MCP 新增 `recommended`：以必填 kind 返回插画、漫画、小说或作者推荐；`all` 以每流独立分页的 structured output 返回四类推荐。
-- MCP 新增 `user_detail`，以必填 `user_id` 返回完整稳定的用户详情 structured output。
-- 新增 `pixiv user detail USER_ID`；可用 `--json` 输出完整、稳定的用户详情 SDK envelope。
-- `pixiv search` 新增 `--rating`、`--type` 与 `--ai-type` 本地结果过滤；带 `--limit`/`--page` 时会按匹配结果继续读取 opaque cursor。
+- 新增 rating、类型和 AI 模式的本地图像搜索筛选。 ([#3](https://github.com/FlanChanXwO/pixiv-cli/pull/3))
 
 ## 修复
 
-- 修复真实 App API 四类推荐的 `next_url` 返回 `offset=0` 时被误判为 malformed 的问题；opaque cursor 继续保持种类、查询与账号来源隔离。
-- 修复 App API 用户详情把 `profile_publicity` 的 `public`/`private` wire 值误判为 malformed 的问题；公开 SDK 继续稳定输出 bool。
-- `auth login` 的浏览器 callback 页现在明确提示“授权已收到、正在回到 CLI 完成登录”；非 JSON 的登录成功输出精简为单行。
-- 默认日志级别改为 `warn`，避免普通 CLI 成功命令把 INFO 操作诊断写入 stderr；显式 `info` 配置和环境覆盖保持不变。
-- 修复显式与自动更新检查未向 GitHub Releases API 发送项目识别性 `User-Agent` 而可能收到 HTTP 403 的兼容性问题。
+- 稳定 v0.2 发布恢复、更新请求识别、cursor 解码和浏览器登录反馈。 ([#4](https://github.com/FlanChanXwO/pixiv-cli/pull/4), [#5](https://github.com/FlanChanXwO/pixiv-cli/pull/5), [#6](https://github.com/FlanChanXwO/pixiv-cli/pull/6))
 
-## 安全
-
-- `auth login` 使用本轮 loopback、受控 `pixiv://` helper 和显式手动回填。
-- SDK、CLI、MCP、环境变量和已存账号在 OAuth 请求前校验凭据输入，并对诊断内容脱敏。
+**完整变更**：[v0.2.0...v0.3.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.2.0...v0.3.0)

--- a/changelog/v0.4.0/en.md
+++ b/changelog/v0.4.0/en.md
@@ -1,0 +1,23 @@
+# v0.4.0 — 2026-07-19
+
+## Breaking changes
+
+- Replaced the legacy `auth add` and `auth token` entry points with secure import/export flows, and made authenticated search use the App API contract. ([#14](https://github.com/FlanChanXwO/pixiv-cli/pull/14))
+
+## Added
+
+- Added standalone macOS/Linux and Windows installers, versioned offline auth bundles, complete search filters across the SDK/CLI/MCP surfaces, multilingual public documentation, and the `pixiv-cli` product skill. ([#14](https://github.com/FlanChanXwO/pixiv-cli/pull/14))
+
+## Fixed
+
+- Pinned native Rust provenance and narrowed the v0.3 recovery overlay so an immutable release tag is rebuilt from the reviewed source set. ([#8](https://github.com/FlanChanXwO/pixiv-cli/pull/8), [#9](https://github.com/FlanChanXwO/pixiv-cli/pull/9))
+
+## Documentation
+
+- Consolidated SDK documentation and completed the final v0.3 audit trail used by this release preparation. ([#10](https://github.com/FlanChanXwO/pixiv-cli/pull/10), [#11](https://github.com/FlanChanXwO/pixiv-cli/pull/11), [#13](https://github.com/FlanChanXwO/pixiv-cli/pull/13))
+
+## Maintenance
+
+- Established the Linux `GLIBC_2.35` release baseline and closed the release review findings. ([#12](https://github.com/FlanChanXwO/pixiv-cli/pull/12), [#14](https://github.com/FlanChanXwO/pixiv-cli/pull/14))
+
+**Full Changelog**: [v0.3.0...v0.4.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.0)

--- a/changelog/v0.4.0/zh-CN.md
+++ b/changelog/v0.4.0/zh-CN.md
@@ -1,0 +1,23 @@
+# v0.4.0 — 2026-07-19
+
+## 破坏性变更
+
+- 以安全的导入/导出流程替代旧版 `auth add` 与 `auth token`，并让已认证搜索遵循 App API 契约。([#14](https://github.com/FlanChanXwO/pixiv-cli/pull/14))
+
+## 新增
+
+- 新增 macOS/Linux 与 Windows 独立安装器、版本化离线认证 bundle、覆盖 SDK/CLI/MCP 的完整搜索筛选、多语言公开文档和 `pixiv-cli` 产品 Skill。([#14](https://github.com/FlanChanXwO/pixiv-cli/pull/14))
+
+## 修复
+
+- 固定原生 Rust provenance，并收窄 v0.3 恢复 overlay，使不可变发布 tag 从经审核的源码集合重新构建。([#8](https://github.com/FlanChanXwO/pixiv-cli/pull/8), [#9](https://github.com/FlanChanXwO/pixiv-cli/pull/9))
+
+## 文档
+
+- 整合 SDK 文档，并完成本次发布准备使用的 v0.3 最终审计记录。([#10](https://github.com/FlanChanXwO/pixiv-cli/pull/10), [#11](https://github.com/FlanChanXwO/pixiv-cli/pull/11), [#13](https://github.com/FlanChanXwO/pixiv-cli/pull/13))
+
+## 维护
+
+- 确立 Linux `GLIBC_2.35` 发布基线，并处理发布审查发现。([#12](https://github.com/FlanChanXwO/pixiv-cli/pull/12), [#14](https://github.com/FlanChanXwO/pixiv-cli/pull/14))
+
+**完整变更**：[v0.3.0...v0.4.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.0)

--- a/changelog/v0.4.1/en.md
+++ b/changelog/v0.4.1/en.md
@@ -1,0 +1,11 @@
+# v0.4.1 — 2026-07-19
+
+## Fixed
+
+- Stabilized the Windows safety checks required by the release build after the earlier tag stopped before publication. ([#15](https://github.com/FlanChanXwO/pixiv-cli/pull/15))
+
+## Maintenance
+
+- Prepared the corrected immutable tag for the complete v0.4 feature set. ([#16](https://github.com/FlanChanXwO/pixiv-cli/pull/16))
+
+**Full Changelog**: [v0.4.0...v0.4.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.0...v0.4.1)

--- a/changelog/v0.4.1/zh-CN.md
+++ b/changelog/v0.4.1/zh-CN.md
@@ -1,0 +1,11 @@
+# v0.4.1 — 2026-07-19
+
+## 修复
+
+- 稳定发布构建所需的 Windows 安全检查；此前 tag 在公开发布前停止。([#15](https://github.com/FlanChanXwO/pixiv-cli/pull/15))
+
+## 维护
+
+- 为完整 v0.4 功能集准备修正后的不可变 tag。([#16](https://github.com/FlanChanXwO/pixiv-cli/pull/16))
+
+**完整变更**：[v0.4.0...v0.4.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.0...v0.4.1)

--- a/changelog/v0.4.2/en.md
+++ b/changelog/v0.4.2/en.md
@@ -1,29 +1,19 @@
 # v0.4.2 — 2026-07-19
 
+## Breaking changes
+
+- Removed legacy auth and token inputs and established the App API-first authenticated search contract. ([#14](https://github.com/FlanChanXwO/pixiv-cli/pull/14))
+
 ## Added
 
-- Added `scripts/install.sh` and PowerShell-free `scripts/install.cmd`. They select the current OS/architecture archive from the latest stable release, verify the published SHA-256 and staged binary, and perform a non-admin per-user installation. Both scripts are published and signed as fixed release assets.
-- Added `pixiv auth import` / `auth export` and public SDK auth-bundle APIs for hidden TTY/raw-stdin token import, single-token or versioned-bundle export, and atomic offline restore.
-- Illustration search gained rating, type, AI, aspect-ratio, resolution, and drawing-tool filters; the public SDK adds `SearchIllustFilters`, `SearchIllustOptions`, and `Illust.Tools`, while authenticated `pixiv search-options WORD` exposes available tools.
-- MCP `search_illust` gained the matching filters and `search_illust_options`; typed upstream and local-state error classification now reports safe transport/configuration causes without exposing URLs, hosts, certificates, or credentials.
-- Added the English `pixiv-cli` product skill and reorganized public documentation into English, Simplified Chinese, and Japanese entry points with maintainers' material under `docs/maintainers/`.
-
-## Changed
-
-- **Breaking:** removed `pixiv auth add`, `pixiv auth token`, and `--token` without aliases. Use `auth import`; only `auth export [UID]` and `auth export --all` without `--output` may intentionally write a secret to stdout.
-- Auth import reports redacted `{user_id,username,status}` account records and has a fixed bundle schema. Offline bundle restore merges by UID, preserves a non-empty local default, rejects token/proxy combinations, and never refreshes or calls the network.
-- With a refresh token, searches always use App API and never fall back to Web. Anonymous Web search applies only reliable filters; R18/R18G/mature content and dynamic search options explicitly require login.
-- `pixiv search --r18` remained a deprecated alias for `--rating r18` in this release; it no longer edits the search word and conflicts with a different explicit rating.
+- Added standalone installers, secure auth import/export bundles, complete illustration search filters, matching MCP tools, and the product skill with multilingual public documentation. ([#14](https://github.com/FlanChanXwO/pixiv-cli/pull/14))
 
 ## Fixed
 
-- Preserved CRLF for `install.cmd`, built Linux release assets on Ubuntu 22.04, and gate-checked GNU symbol requirements so Linux amd64/arm64 assets do not exceed the public `GLIBC_2.35` baseline.
-- Made bundle JSON decoding canonical-key-only; corrected AI semantics (`AIType == 2`); redacted legacy MCP operation diagnostics; normalized unsafe download-derived filename extensions; emitted all MCP tags; and stabilized known ranking-mode titles.
-- Removed hidden 60-second HTTP-client timeouts in favor of caller-context lifetime, unified configured transport handling, and made config/auth writes durable and atomic with typed commit outcomes and platform-appropriate permission/ACL handling.
-- Preserved real business errors for MCP download failures, rejected invalid random-download counts rather than silently changing them, and retained safe error classification for refresh-token initialization and execution failures.
+- Preserved Windows installer line endings and the Linux release ABI baseline. ([#17](https://github.com/FlanChanXwO/pixiv-cli/pull/17))
 
-## Security
+## Maintenance
 
-- Installer and updater paths accept only exact official GitHub release sources and fail before replacement on missing, duplicate, malformed, or mismatched checksums and on failed staged-binary checks. PATH changes remain opt-in and no installer reads Pixiv auth state.
-- Secret export is local-only and secret output is restricted to the documented raw-token or bundle forms. File export uses dedicated owner-only handling; restore reports whether a write was committed, not committed, or unresolved.
-- Hardened Rust/native evidence provenance, macOS OAuth helper temporary-source handling, graph input path validation, ugoira ZIP frame allocation limits, proxy redaction, and release-workflow SemVer and secret-reference policy parsing.
+- Prepared the corrected v0.4.2 release metadata after the earlier unpublished tags. ([#18](https://github.com/FlanChanXwO/pixiv-cli/pull/18))
+
+**Full Changelog**: [v0.4.1...v0.4.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.1...v0.4.2)

--- a/changelog/v0.4.2/zh-CN.md
+++ b/changelog/v0.4.2/zh-CN.md
@@ -1,30 +1,19 @@
 # v0.4.2 — 2026-07-19
 
+## 破坏性变更
+
+- 移除旧版认证和 token 输入，并确立 App API 优先的已认证搜索契约。 ([#14](https://github.com/FlanChanXwO/pixiv-cli/pull/14))
+
 ## 新增
 
-- 新增 `scripts/install.sh` 与不依赖 PowerShell 的 `scripts/install.cmd`：自动选择最新 stable Release 的当前 OS/arch archive，先验证发布 SHA-256 和暂存 binary，再执行无管理员权限的用户级安装；Release 以固定名称发布两个脚本并把它们纳入签名 checksum 集合，现有 locale 的 README 同步提供可复制的安装命令与 AI Agent 安装 prompt。
-- 新增 `pixiv auth import [REFRESH_TOKEN]` 与 `pixiv auth export [UID] [--all] [--output PATH] [--force]`：支持隐藏 TTY/raw stdin direct token import、单账号 raw export、全部账号 versioned bundle export，以及 `--file PATH|-` 离线原子 restore。
-- 公开 Go SDK 新增 `AuthExportSelection`、versioned auth bundle model/strict codec、`ExportAuthBundle`、`RestoreAuthBundle`、`AuthRestoreResult` 与 `LocalWriteCommitOutcome`，供调用方实现 point-in-time secret backup 与可分类的离线恢复。
-- 插画搜索新增稳定的分级、作品类型、AI、横纵比、分辨率与绘图工具筛选；CLI 新增 `--ai-mode`、`--aspect-ratio`、`--resolution` 与 `--tool`，`--type` 支持 `illust-and-ugoira`/`manga` 并保留 `comics` alias。SDK 新增 `SearchIllustFilters`、`SearchIllustOptions` 与 `Illust.Tools`；需 App 认证的 `pixiv search-options WORD` 动态列出绘图工具。
-- MCP `search_illust` 新增同样的六个筛选字段，并新增需认证、返回 `{tools,text}` 的 `search_illust_options`；公开 SDK 的 `upstream_unavailable` 与本地 snapshot 错误新增安全的 transport/local-state 分类，诊断不暴露 URL、主机、证书或凭据。
-- 新增面向 AI Agent、全英文的 `pixiv-cli` skill；README 扩展为英文、简体中文与日语入口，公共文档按 `docs/<locale>/` 组织，架构、开发、ADR 与 Agent 规则集中到 `docs/maintainers/`。
-
-## 变更
-
-- Breaking: 删除 `pixiv auth add`、`pixiv auth token` 与 `--token`，不保留 alias/stub；direct token 入口统一为 `auth import`，显式 secret stdout 统一为不带 `--output` 的 `auth export [UID]` 或 `auth export --all`。
-- `auth import` 的 direct 与 bundle 成功报告统一使用不含 secret 的 `{user_id,username,status}`；bundle JSON 固定为 `{accounts,default_user_id}`。`auth import --file` 严格解码未加密 bundle、按 UID merge 并原子保存，保留本地已有 default，仅空 store 采用 bundle default；拒绝 token/proxy 组合，不刷新、不联网。
-- 有 refresh token 的搜索始终使用 App API，失败不回落 Web；无 token 的 Web 搜索只执行可靠筛选，R18/R18G/mature 与动态搜索选项明确要求登录。分级与仅 AI 在 SDK 筛选，其余新增筛选优先由 App 服务端执行；不提供收藏数筛选。
-- Deprecated `pixiv search --r18` 在本版本仅作为 `--rating r18` 的 alias，不再向关键词追加 `R-18`；可与相同显式 rating 同用，与其他 rating 冲突。
+- 新增独立安装器、安全认证导入/导出 bundle、完整图像搜索筛选、对应 MCP 工具以及含多语言公开文档的产品 Skill。 ([#14](https://github.com/FlanChanXwO/pixiv-cli/pull/14))
 
 ## 修复
 
-- 修复 Windows `install.cmd` 在 `core.autocrlf=false` checkout 时的 CRLF 问题；Linux amd64/arm64 后续统一在 Ubuntu 22.04 构建，并在 release、native evidence 与 packaged smoke 中检查 ELF GNU version requirement，任何高于公开 `GLIBC_2.35` 基线的依赖均 fail closed。
-- 严格限制 auth bundle JSON 只接受 canonical key；修复 `AIType==2` 的 AI 语义；统一 legacy MCP 的脱敏 operation diagnostics；清理下载 URL 衍生扩展名；完整输出 MCP tags；稳定已知排行榜 mode 标题。
-- 移除 App API/OAuth/代理快照中的隐藏 60 秒请求 timeout，改由调用 context 控制；统一专用 transport；加固 `config.toml`/`auth.json` 原子写入、同步、权限/ACL 与 typed commit outcome。
-- MCP 下载失败保留原业务错误并返回规范空数组；随机下载不再静默改写无效 count；refresh-token 初始化与执行失败保留安全分类。
+- 保留 Windows 安装器换行符并保持 Linux 发布 ABI 基线。 ([#17](https://github.com/FlanChanXwO/pixiv-cli/pull/17))
 
-## 安全
+## 维护
 
-- 安装器只使用固定官方 GitHub Release 来源，checksum 缺失、重复、格式异常、SHA-256 不匹配或暂存 binary 预检失败均在替换前终止；默认用户级安装不提权，PATH 修改必须显式请求，且不读取 Pixiv 认证状态。
-- 只有不带 `--output` 的 `auth export [UID]` 与 `auth export --all` 可以输出 secret；export 全程 local-only，文件导出使用独立 secret writer，restore 精确报告 `not_committed`、`committed` 或 `unknown`。
-- 加固 native-evidence toolchain provenance、macOS OAuth helper 临时源码、图谱输入路径、ugoira ZIP 帧内存上限、代理错误脱敏，以及 Release workflow SemVer 与 secret-reference policy 解析。
+- 在此前未公开的 tag 之后准备修正后的 v0.4.2 发布元数据。 ([#18](https://github.com/FlanChanXwO/pixiv-cli/pull/18))
+
+**完整变更**：[v0.4.1...v0.4.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.1...v0.4.2)

--- a/changelog/v0.4.3/en.md
+++ b/changelog/v0.4.3/en.md
@@ -2,4 +2,10 @@
 
 ## Fixed
 
-- Linux Homebrew release validation no longer uses `/var/tmp`, avoiding `EINVAL` that could prevent the staging formula from installing. Linux uses a runner-private temporary directory; macOS and the public formula path are unchanged.
+- Moved Linux Homebrew validation to a runner-private temporary directory so staging installation avoids EINVAL failures. ([#19](https://github.com/FlanChanXwO/pixiv-cli/pull/19))
+
+## Maintenance
+
+- Prepared the v0.4.3 release metadata. ([#20](https://github.com/FlanChanXwO/pixiv-cli/pull/20))
+
+**Full Changelog**: [v0.4.2...v0.4.3](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.2...v0.4.3)

--- a/changelog/v0.4.3/zh-CN.md
+++ b/changelog/v0.4.3/zh-CN.md
@@ -2,4 +2,10 @@
 
 ## 修复
 
-- 修复 Linux Homebrew Release validation 使用 `/var/tmp` 时可能触发 `EINVAL`、导致 staging formula 无法安装的问题；该验证步骤现仅在 Linux 使用 runner 私有临时目录，macOS 与公开 formula 路径保持不变。
+- 将 Linux Homebrew 验证移至 runner 私有临时目录，使 staging 安装避开 EINVAL 失败。 ([#19](https://github.com/FlanChanXwO/pixiv-cli/pull/19))
+
+## 维护
+
+- 准备 v0.4.3 发布元数据。 ([#20](https://github.com/FlanChanXwO/pixiv-cli/pull/20))
+
+**完整变更**：[v0.4.2...v0.4.3](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.2...v0.4.3)

--- a/changelog/v0.4.4/en.md
+++ b/changelog/v0.4.4/en.md
@@ -2,4 +2,10 @@
 
 ## Fixed
 
-- Linux Homebrew release validation keeps build paths inside the Homebrew prefix to avoid cross-filesystem `FileUtils EINVAL` failures.
+- Kept Linux Homebrew staging build paths inside the Homebrew prefix to avoid cross-filesystem FileUtils EINVAL failures. ([#21](https://github.com/FlanChanXwO/pixiv-cli/pull/21))
+
+## Maintenance
+
+- Prepared the v0.4.4 release metadata. ([#22](https://github.com/FlanChanXwO/pixiv-cli/pull/22))
+
+**Full Changelog**: [v0.4.3...v0.4.4](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.3...v0.4.4)

--- a/changelog/v0.4.4/zh-CN.md
+++ b/changelog/v0.4.4/zh-CN.md
@@ -2,4 +2,10 @@
 
 ## 修复
 
-- Linux Homebrew release validation 将 buildpath 保持在 Homebrew prefix 内，避免跨文件系统触发 `FileUtils EINVAL`。
+- 将 Linux Homebrew staging 构建路径保留在 Homebrew 前缀内，以避开跨文件系统的 FileUtils EINVAL 失败。 ([#21](https://github.com/FlanChanXwO/pixiv-cli/pull/21))
+
+## 维护
+
+- 准备 v0.4.4 发布元数据。 ([#22](https://github.com/FlanChanXwO/pixiv-cli/pull/22))
+
+**完整变更**：[v0.4.3...v0.4.4](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.3...v0.4.4)

--- a/changelog/v0.4.5/en.md
+++ b/changelog/v0.4.5/en.md
@@ -2,4 +2,10 @@
 
 ## Fixed
 
-- Linux Homebrew hosted staging verification now runs a real local staging-tap `brew install` inside a short-lived, digest-pinned `homebrew/brew` container. It avoids the hosted Linuxbrew `Resource` cleanup `EINVAL` while keeping a read-only formula mount, no secrets, a local-only tap, and an exact installed-version check. The container is discarded with `--rm`; macOS and end-user Homebrew installs are unchanged. The GitHub prepublish workflow passed this check on all four Homebrew platform/architecture combinations using published v0.4.4 assets.
+- Made Linux Homebrew staging verification install a real local staging tap in a short-lived pinned container, retaining build paths, resources, and source debug symbols inside the supported prefix. ([#23](https://github.com/FlanChanXwO/pixiv-cli/pull/23), [#25](https://github.com/FlanChanXwO/pixiv-cli/pull/25), [#26](https://github.com/FlanChanXwO/pixiv-cli/pull/26), [#27](https://github.com/FlanChanXwO/pixiv-cli/pull/27))
+
+## Maintenance
+
+- Added pre-publication Release verification and prepared the v0.4.5 metadata. ([#24](https://github.com/FlanChanXwO/pixiv-cli/pull/24), [#28](https://github.com/FlanChanXwO/pixiv-cli/pull/28))
+
+**Full Changelog**: [v0.4.4...v0.4.5](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.4...v0.4.5)

--- a/changelog/v0.4.5/zh-CN.md
+++ b/changelog/v0.4.5/zh-CN.md
@@ -2,4 +2,10 @@
 
 ## 修复
 
-- Linux Homebrew hosted staging verification 现在会在以不可变 digest 固定的短生命周期 `homebrew/brew` 容器中运行真实的本地 staging-tap `brew install`。这避免了 hosted Linuxbrew `Resource` staging cleanup `EINVAL`，同时保留只读 formula mount、无 secret、本地专用 tap 和精确的安装版本校验。固定的 Homebrew 4.6 镜像不带 `brew trust` 或独立 `python3`，因此 trust 仍只在原生 macOS 路径执行，容器则在安装后使用内置 Ruby JSON parser。Linux 容器 tap 在本地创建、只接收只读挂载内容，并通过 `--rm` 丢弃。macOS 与终端用户的 Homebrew 安装不变。GitHub prepublish workflow 已使用发布的 v0.4.4 资产通过四种 Homebrew 平台/架构组合的验证。
+- 让 Linux Homebrew staging 验证在短生命周期的固定容器内安装真实本地 staging tap，并将构建路径、资源和源码调试符号保留在受支持前缀内。 ([#23](https://github.com/FlanChanXwO/pixiv-cli/pull/23), [#25](https://github.com/FlanChanXwO/pixiv-cli/pull/25), [#26](https://github.com/FlanChanXwO/pixiv-cli/pull/26), [#27](https://github.com/FlanChanXwO/pixiv-cli/pull/27))
+
+## 维护
+
+- 新增发布前 Release 验证并准备 v0.4.5 元数据。 ([#24](https://github.com/FlanChanXwO/pixiv-cli/pull/24), [#28](https://github.com/FlanChanXwO/pixiv-cli/pull/28))
+
+**完整变更**：[v0.4.4...v0.4.5](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.4...v0.4.5)

--- a/changelog/v0.5.0/en.md
+++ b/changelog/v0.5.0/en.md
@@ -1,30 +1,23 @@
 # v0.5.0 — 2026-07-22
 
+## Breaking changes
+
+- Standardized CLI and MCP language, search inputs, diagnostics, and local-file MCP download delivery. ([`27c151b`](https://github.com/FlanChanXwO/pixiv-cli/commit/27c151b), [`7249b1d`](https://github.com/FlanChanXwO/pixiv-cli/commit/7249b1d), [`8502851`](https://github.com/FlanChanXwO/pixiv-cli/commit/8502851))
+
 ## Added
 
-- CLI and MCP operation summaries are written as daily JSONL files under the user state directory at `pixiv/logs`. Logs retain seven days by default, clean up only recognized historical files, stay silent in the terminal, and contain only redacted operation summaries. Exceptional non-authentication upstream failures can point CLI users to the log directory; login failures and expired tokens do not.
-- MCP `download` and `download_random_from_recommendation` now accept `pages` and `quality`, sharing the CLI download options.
-- Downloads support 1-based `--pages` (`1,3-5`) and `--quality original|regular|small|thumb|mini`; the default remains all original pages. Ugoira rejects derived qualities and page selection. The public SDK exposes `ParsePageSpec`, `DownloadQuality`, and `DownloadOptions`.
-- Artwork models and all CLI/MCP output forms now include the stable artwork `url` (`https://www.pixiv.net/artworks/${id}`).
-- Public `UgoiraMetadata` adds paired, non-empty `download_url` and `download_quality` (`medium|original`). `zip_urls.original` is emitted only when an original ZIP was actually obtained; the downloader, CLI, and MCP use the verified resource.
-- Illustration ranking supports all 16 App API modes, including four manga and five R18 modes. CLI `--mode`, MCP stable labels, and public SDK constants support them; the newly added modes explicitly require authentication.
-
-## Changed
-
-- CLI prompts, OAuth completion pages, log-directory hints, and fixed help examples are English. Artwork metadata and user input are unchanged.
-- **Breaking:** fixed MCP status, error, and display text is English; structured data, Pixiv metadata, and user input are unchanged.
-- **Breaking:** removed `pixiv search --search-target`, `--target`, `--duration`, and `--tool` without aliases. Use `--search-by tag-partial|tag-exact|title-caption`, `--period day|week|month`, and `--draw-tool`; the public `--limit` default no longer exposes internal sentinel `-1`.
-- **Breaking:** `--download-path` and `--filename-template` are accepted only by `pixiv download`; other commands now reject these previously ignored no-op flags.
-- **Breaking:** diagnostics are written to the user state directory instead of stderr; MCP stdout remains JSON-RPC only.
-- **Breaking:** MCP download returns only local `path`, `file_uri`, `mime_type`, page number, and size. `delivery=image_content` and `get_thumbnail_base64` were removed; agents should send the local file through host attachment support or share the artwork URL.
-- **Breaking:** removed MCP wire fields `search_r18`, `user_id_to_check`, `max_bookmark_id`, `offset`, and `include_thumbnail`; lists and search use `user_id`, `rating`, and `page`/`limit`.
-- **Breaking:** removed CLI compatibility inputs `--ai-type`, `--r18`, `--profile`, `--offset`, and `search --type comics`. Use `--ai-mode`, `--rating r18`, `--uid`, `--page`/`--limit`, and `--type manga`.
+- Added daily redacted operation logs, page and quality download options, canonical artwork URLs, verified ugoira metadata, and all App API ranking modes. ([`907fe1b`](https://github.com/FlanChanXwO/pixiv-cli/commit/907fe1b), [`ecfc1ee`](https://github.com/FlanChanXwO/pixiv-cli/commit/ecfc1ee), [`bc00211`](https://github.com/FlanChanXwO/pixiv-cli/commit/bc00211))
 
 ## Fixed
 
-- Closed daily JSONL log files when a CLI command or MCP session ends, allowing Windows state-directory cleanup immediately after return.
-- Authenticated illustration detail, pages, and ugoira metadata now use only successful App API data, preventing R18 403/404 failures caused by anonymous Web enrichment. Multi-page works use `meta_pages`; single pages are derived canonically; missing or mismatched App data returns an explicit upstream-response error rather than a partial result.
-- Idempotent App API JSON reads recover once from an initial HTTP 429 with a valid `Retry-After`, waiting through the caller context. Invalid headers, a second 429, writes, and resource downloads retain the real error and are never replayed; retry logs omit URLs, headers, and credentials.
-- The macOS `pixiv://` helper now opens a local bridge page and shows a centered final success/failure page after OAuth completes. Callback data is held only briefly in a URL fragment and removed before submission, failures do not reveal sensitive reasons, and the CLI success message starts on a new line.
-- Search now fetches through consecutive empty upstream batches created by local filters, fills `--limit N`/`limit`, traverses for `0`, and applies `--page`/`page` after filtering.
-- App artwork AI detection prioritizes `illust_ai_type` while accepting legacy `ai_type`; local AI classification remains `AIType == 2`.
+- Restored authenticated R18 reads, made search filtering and login completion reliable, and closed log writers at command completion. ([`8a172da`](https://github.com/FlanChanXwO/pixiv-cli/commit/8a172da), [`1030531`](https://github.com/FlanChanXwO/pixiv-cli/commit/1030531), [`1e01b74`](https://github.com/FlanChanXwO/pixiv-cli/commit/1e01b74), [`79c14ac`](https://github.com/FlanChanXwO/pixiv-cli/commit/79c14ac))
+
+## Documentation
+
+- Updated CLI, MCP, and product-skill documentation for the App API search and UX changes. ([`1ffad53`](https://github.com/FlanChanXwO/pixiv-cli/commit/1ffad53))
+
+## Maintenance
+
+- Moved end-to-end coverage to its top-level layout and prepared the v0.5 release metadata. ([`02fe9f5`](https://github.com/FlanChanXwO/pixiv-cli/commit/02fe9f5), [`3053df6`](https://github.com/FlanChanXwO/pixiv-cli/commit/3053df6))
+
+**Full Changelog**: [v0.4.5...v0.5.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.5...v0.5.0)

--- a/changelog/v0.5.0/zh-CN.md
+++ b/changelog/v0.5.0/zh-CN.md
@@ -1,30 +1,23 @@
 # v0.5.0 — 2026-07-22
 
+## 破坏性变更
+
+- 统一 CLI 与 MCP 文案、搜索输入、诊断和本地文件 MCP 下载交付。 ([`27c151b`](https://github.com/FlanChanXwO/pixiv-cli/commit/27c151b), [`7249b1d`](https://github.com/FlanChanXwO/pixiv-cli/commit/7249b1d), [`8502851`](https://github.com/FlanChanXwO/pixiv-cli/commit/8502851))
+
 ## 新增
 
-- CLI/MCP 操作摘要写入用户 state 目录下 `pixiv/logs` 的按日 JSONL（默认保留 7 天，仅清理可识别的历史日志文件）；终端默认不再输出日志痕迹。日志只记录脱敏操作摘要，不含 token、查询串、绝对路径、上游 body 或原始错误。目录创建/轮转/清理失败时静默继续。仅上游不可用、上游错误、响应畸形、限流等特殊非认证故障会在 CLI 错误中提示日志目录；登录失败与 token 过期不提示。
-- MCP `download` / `download_random_from_recommendation` 支持 `pages` 与 `quality`，与 CLI 共用下载选项。
-- 下载新增 `--pages`（1-based，支持 `1,3-5`）与 `--quality original|regular|small|thumb|mini`；默认仍下载全部原图。Ugoira 对派生质量或页选择返回 unsupported。public SDK 暴露 `ParsePageSpec`/`DownloadQuality`/`DownloadOptions`。
-- 所有作品模型、CLI JSON/文本与 MCP 结构化/文本输出增加作品页 `url`（`https://www.pixiv.net/artworks/${id}`），JSON 为 public Illust 首字段，文本输出放在每件作品第一行。
-- 公开 SDK 的 `UgoiraMetadata` 新增成对且非空的 `download_url`/`download_quality`（`medium|original`）；`zip_urls.original` 仅在真正取得 original ZIP 时输出。下载器、CLI 与 MCP 统一使用该已验证资源。
-- 插画排行榜扩展为 16 个 App API mode：新增四个 manga 与五个 R18 mode；CLI `--mode`、MCP 稳定标签和 SDK 常量同步支持，新增 mode 明确要求认证。
-
-## 变更
-
-- CLI terminal prompts, OAuth completion pages, log-directory hints, and fixed help examples now use English. Artwork metadata and user-supplied query text remain unchanged.
-- Breaking: MCP fixed status, error, and display text now uses English. Structured output, Pixiv metadata, and user-supplied text remain unchanged.
-- Breaking: `pixiv search --search-target`, `--target`, `--duration`, and `--tool` have been removed without aliases. Use `--search-by tag-partial|tag-exact|title-caption`, `--period day|week|month`, and `--draw-tool`; the user-facing `--limit` default no longer exposes the internal `-1` sentinel.
-- Breaking: `--download-path` and `--filename-template` are now accepted only by `pixiv download`. All other data, user, bookmark, and follow commands reject the previously ignored flags instead of silently accepting a no-op.
-- Breaking: CLI/MCP 诊断日志改写用户 state 目录文件，不再默认输出到 stderr；MCP stdout 仍仅用于 JSON-RPC。
-- Breaking: MCP 下载仅返回本地 `path`/`file_uri`/`mime_type`/页号/大小；移除 `delivery=image_content` 内嵌图片与 `get_thumbnail_base64` 工具。Agent 应使用宿主本地附件能力发送文件；宿主不支持时仅分享作品 URL。
-- Breaking: 移除 MCP 旧 wire 字段 `search_r18`、`user_id_to_check`、`max_bookmark_id`、`offset`、`include_thumbnail`；列表与搜索统一使用规范字段 `user_id`、`rating`、`page`/`limit`。
-- Breaking: 移除 CLI 兼容入口 `--ai-type`、`--r18`、`--profile`、`--offset` 与 `search --type comics`；请分别使用 `--ai-mode`、`--rating r18`、`--uid`、`--page`/`--limit` 与 `--type manga`。
+- 新增每日脱敏操作日志、页面与质量下载选项、规范作品 URL、已验证 ugoira metadata 和全部 App API 排行模式。 ([`907fe1b`](https://github.com/FlanChanXwO/pixiv-cli/commit/907fe1b), [`ecfc1ee`](https://github.com/FlanChanXwO/pixiv-cli/commit/ecfc1ee), [`bc00211`](https://github.com/FlanChanXwO/pixiv-cli/commit/bc00211))
 
 ## 修复
 
-- 修复 CLI 命令与 MCP 会话结束后未关闭按日 JSONL 日志文件的问题；Windows 现可在命令返回后清理用户 state 临时目录，不再依赖进程退出释放文件句柄。
-- 修复认证态作品详情、分页和 ugoira metadata 在 App API 成功后仍访问匿名 Web 补全、致使 R18 作品遭遇 403/404 的问题。认证路径现只使用 App 数据；多页直接读取 `meta_pages`，单页派生规范页面，缺失或不一致明确返回上游响应错误，不伪装 partial result。
-- 修复 App API 幂等 JSON 读取限流恢复：仅首次 HTTP 429 且 `Retry-After` 有效时按调用方 context 等待并重试一次；无效 header、第二次 429、写操作和资源下载均保留真实错误且不重放，安全 info 日志不含 URL、header 或凭据。
-- 修复 macOS `pixiv://` helper 在后台吞掉 loopback 最终响应、导致浏览器停留在 Pixiv 白色 relay 页的问题。helper 现打开本地桥接页，并在 OAuth 真正完成后显示居中的最终成功/失败页；callback 仅短暂位于 URL fragment，提交前即从地址栏和历史中清除，失败页不泄露敏感原因；CLI 成功提示前增加一个空行。
-- 搜索在本地筛选产生连续空上游批次时，CLI/MCP 会补拉到首个非空逻辑批次；`--limit N`/`limit` 填满逻辑结果，`--limit 0`/`limit=0` 遍历全部，`--page`/`page` 按过滤后结果分页。
-- App 作品 AI 字段优先读取 `illust_ai_type`，并兼容旧 `ai_type`；本地 AI 判定仍固定 `AIType==2`。
+- 恢复已认证 R18 读取，使搜索筛选与登录完成更可靠，并在命令结束时关闭日志写入器。 ([`8a172da`](https://github.com/FlanChanXwO/pixiv-cli/commit/8a172da), [`1030531`](https://github.com/FlanChanXwO/pixiv-cli/commit/1030531), [`1e01b74`](https://github.com/FlanChanXwO/pixiv-cli/commit/1e01b74), [`79c14ac`](https://github.com/FlanChanXwO/pixiv-cli/commit/79c14ac))
+
+## 文档
+
+- 更新 App API 搜索和交互变化对应的 CLI、MCP 与产品 Skill 文档。 ([`1ffad53`](https://github.com/FlanChanXwO/pixiv-cli/commit/1ffad53))
+
+## 维护
+
+- 将端到端覆盖迁移到顶层布局并准备 v0.5 发布元数据。 ([`02fe9f5`](https://github.com/FlanChanXwO/pixiv-cli/commit/02fe9f5), [`3053df6`](https://github.com/FlanChanXwO/pixiv-cli/commit/3053df6))
+
+**完整变更**：[v0.4.5...v0.5.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.4.5...v0.5.0)

--- a/changelog/v0.6.0/en.md
+++ b/changelog/v0.6.0/en.md
@@ -1,22 +1,19 @@
 # v0.6.0 — 2026-07-24
 
+## Breaking changes
+
+- Centralized persistent application data under the current user's `.pixiv-cli` directory. ([`352a2f0`](https://github.com/FlanChanXwO/pixiv-cli/commit/352a2f0))
+
 ## Added
 
-- Authenticated App API novel search is now available through `pixiv novel search WORD`, the public `SearchNovel` SDK API, and MCP `search_novel`. It supports keyword matching, date sort, time range, rating, text length, and original-only filters; results include a stable novel URL, rating, text length, and original flag.
-- Added `pixiv user search WORD` and expanded MCP `search_user` to return `{source,user_previews,pagination,text}`. Results identify either the official App user search (`app_search`) or the anonymous related-illustration-author fallback (`related_illust_authors`) so the fallback is never presented as a username search.
-- Completed the Japanese public SDK and MCP tool references, with matching cross-language navigation.
-
-## Changed
-
-- **Breaking:** Persistent local application data now lives directly in `~/.pixiv-cli` on macOS/Linux and `%USERPROFILE%\.pixiv-cli` on Windows, including authentication, configuration, callback-bridge state, logs, the Release-check cache, and the macOS callback helper. Earlier storage paths are not read or migrated.
-- Artwork detail now includes `caption`. The SDK, CLI JSON, and MCP preserve Pixiv's original HTML; the normal CLI detail view safely renders plain text. Lists do not add captions.
-- Release tags must now pass the complete authenticated E2E suite in the protected `pixiv-e2e` Environment. Pull-request and `main` CI remain offline and secret-free; a real-regression failure blocks production build and publication.
-- GitHub Release bodies now include matching English and Simplified Chinese release notes.
-- Operation diagnostics in the CLI, MCP, SDK, downloader, and App API now use safe structured events that never contain tokens, URLs, raw headers, request inputs, or response bodies.
+- Added authenticated novel and user search workflows, plus complete Japanese SDK and MCP references. ([`2f414ac`](https://github.com/FlanChanXwO/pixiv-cli/commit/2f414ac), [`60bd6b4`](https://github.com/FlanChanXwO/pixiv-cli/commit/60bd6b4))
 
 ## Fixed
 
-- Fixed browser OAuth callbacks on desktop Linux and Windows: `pixiv://` is now registered only for the active login and the prior user association is restored afterward. The SSH `--no-open --addr` fallback page now continues a validated Pixiv relay in the browser that submitted it, so a local `ssh -L` tunnel can return the final callback to a GUI-less server without a second pixiv installation.
-- Fixed possible HTTP/2 resource-stream interruptions while downloading static illustrations or ugoira through an explicitly configured HTTP(S) proxy. Resource transfers now negotiate HTTP/1.1 independently; App API, OAuth, and Web metadata requests retain their existing protocol negotiation.
-- File logs now use plain-text `YYYY-MM-DD.txt` names without a `pixiv-` prefix; JSONL output and the unused `log_format` / `PIXIV_LOG_FORMAT` switches were removed. OAuth login, callback, success, and failure pages now keep the browser title `pixiv-cli`.
-- OAuth operation diagnostics now retain the safe `transport_kind` classification, including typed network timeouts, so an upstream failure without an HTTP status can be diagnosed without logging URLs, credentials, headers, or response bodies.
+- Stabilized proxied resource downloads, pagination guidance, and desktop OAuth callback behavior. ([#29](https://github.com/FlanChanXwO/pixiv-cli/pull/29))
+
+## Maintenance
+
+- Prepared the v0.6 release metadata and authenticated release E2E gate. ([`b0c6ad1`](https://github.com/FlanChanXwO/pixiv-cli/commit/b0c6ad1))
+
+**Full Changelog**: [v0.5.0...v0.6.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.5.0...v0.6.0)

--- a/changelog/v0.6.0/zh-CN.md
+++ b/changelog/v0.6.0/zh-CN.md
@@ -1,22 +1,19 @@
 # v0.6.0 — 2026-07-24
 
+## 破坏性变更
+
+- 将持久化应用数据集中到当前用户的 `.pixiv-cli` 目录。 ([`352a2f0`](https://github.com/FlanChanXwO/pixiv-cli/commit/352a2f0))
+
 ## 新增
 
-- 新增认证 App API 小说搜索：CLI `pixiv novel search WORD`、public SDK `SearchNovel` 与 MCP `search_novel` 同步支持关键词匹配、日期排序、时间范围、分级、正文长度和仅原创筛选；小说结果提供稳定小说 URL、分级、正文长度与原创标记。
-- 新增 CLI `pixiv user search WORD`，并将 MCP `search_user` 升级为 `{source,user_previews,pagination,text}`。结果明确标识官方 App 用户搜索（`app_search`）或匿名相关插画作者 fallback（`related_illust_authors`），避免误称后者为用户名搜索。
-- 补齐日语 public SDK 与 MCP tool reference，并完善三语交叉导航。
-
-## 变更
-
-- **Breaking：**持久的本地应用数据统一直接位于用户主目录下：macOS/Linux 为 `~/.pixiv-cli`，Windows 为 `%USERPROFILE%\.pixiv-cli`；其中包括认证、配置、回调桥接状态、日志、Release 检查缓存和 macOS 回调 helper。旧存储路径不会被读取或迁移。
-- 作品详情新增 `caption`：SDK/CLI JSON/MCP 保留 Pixiv 原始 HTML，普通 CLI 详情安全显示纯文本；列表输出不增加作品说明。
-- 发布 tag 现在必须先通过受保护 `pixiv-e2e` Environment 的完整认证 E2E；PR 与 `main` 常规 CI 仍保持离线、无 secret。真实回归失败会阻止后续生产构建与发布。
-- GitHub Release body 现在同时包含对应的英文与简体中文发布说明。
-- CLI、MCP、SDK、下载器与 App API 的 operation diagnostics 统一使用安全结构化事件；事件不记录 token、URL、原始 header、请求输入或 response body。
+- 新增已认证小说和用户搜索流程，以及完整日文 SDK 与 MCP 参考。 ([`2f414ac`](https://github.com/FlanChanXwO/pixiv-cli/commit/2f414ac), [`60bd6b4`](https://github.com/FlanChanXwO/pixiv-cli/commit/60bd6b4))
 
 ## 修复
 
-- 修复桌面 Linux 与 Windows 的浏览器 OAuth 回调：`pixiv://` 现在只在当前登录期间注册，结束后恢复原有用户关联。SSH `--no-open --addr` fallback 页面现在会由提交它的浏览器继续已校验 Pixiv relay，因此本机 `ssh -L` tunnel 可将最终 callback 回传无 GUI 服务器，无需在浏览器机器安装第二份 pixiv。
-- 修复经显式 HTTP(S) 代理下载静态图或 ugoira 时可能出现的 HTTP/2 资源流中断：资源传输现在单独协商 HTTP/1.1，App API、OAuth 和 Web 元数据请求保持原有协议协商。
-- 文件日志现使用无 `pixiv-` 前缀的纯文本 `YYYY-MM-DD.txt`；JSONL 输出及无实际作用的 `log_format` / `PIXIV_LOG_FORMAT` 开关已删除。OAuth 登录、回调、成功和失败页面的浏览器标题统一为 `pixiv-cli`。
-- OAuth operation diagnostics 现在保留安全的 `transport_kind` 分类（包括 typed network timeout），使没有 HTTP 状态码的上游失败可被诊断，同时不记录 URL、凭据、header 或 response body。
+- 稳定代理资源下载、分页引导和桌面 OAuth 回调行为。 ([#29](https://github.com/FlanChanXwO/pixiv-cli/pull/29))
+
+## 维护
+
+- 准备 v0.6 发布元数据和已认证发布 E2E 门禁。 ([`b0c6ad1`](https://github.com/FlanChanXwO/pixiv-cli/commit/b0c6ad1))
+
+**完整变更**：[v0.5.0...v0.6.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.5.0...v0.6.0)

--- a/changelog/v0.7.0/en.md
+++ b/changelog/v0.7.0/en.md
@@ -2,13 +2,10 @@
 
 ## Added
 
-- Release-binary updates and versioned installer assets now carry a static, tested free GitHub Release-source list. They probe viable routes locally, support path and query-parameter proxy templates, and never fetch a remote mirror list.
-- Existing `detail` and `download` inputs now accept strict official Pixiv artwork URLs; `download` also accepts authenticated user profile and artworks URLs to walk every illustration, manga, and ugoira without downloading novels.
-- MCP `illust_detail` accepts exactly one of an ID or URL, and `download` accepts URLs. Illustration query tools now return typed structured results alongside compact text summaries.
-- Illustration `search` and MCP `search_illust` now support official App `keyword` search (tags, titles, and captions), inclusive explicit date bounds, public bookmark-count bounds, and the `half-year` / `year` quick date ranges. Bookmark-count bounds require both App OAuth and an active Pixiv Premium membership. App-only filters return an authentication requirement when App OAuth is absent.
-- Each published GitHub Release now submits the matching tagged `pixiv-cli` product skill to SkillHub. The submission is validated locally first and the workflow requires the returned SkillHub `skillId` and review status before succeeding.
+- Added verified release-source alternatives, official Pixiv URL input support, typed illustration query results, richer App search filters, and tagged SkillHub publication. ([#30](https://github.com/FlanChanXwO/pixiv-cli/pull/30))
 
 ## Changed
 
-- A configured `--proxy`, `https_proxy`, or `HTTPS_PROXY` keeps precedence over public Release sources. The updater preserves canonical GitHub release identity and Ed25519/SHA-256 verification; installers retain a direct GitHub checksum before accepting a proxied archive.
-- Download JSON now reports `{items, failures}` with canonical artwork URLs, IDs, types, pages, and local paths. Partial downloads report every completed outcome and exit non-zero; no download history, cache, or cross-run de-duplication is created.
+- Standardized proxied updater precedence and download JSON outcome reporting. ([#30](https://github.com/FlanChanXwO/pixiv-cli/pull/30))
+
+**Full Changelog**: [v0.6.0...v0.7.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.6.0...v0.7.0)

--- a/changelog/v0.7.0/zh-CN.md
+++ b/changelog/v0.7.0/zh-CN.md
@@ -2,13 +2,10 @@
 
 ## 新增
 
-- Release binary 更新与版本化安装器资产现在携带静态、已测试的免费 GitHub Release-source 列表；它们在本机探测可用路由，支持路径式和查询参数式代理模板，且绝不远程拉取镜像列表。
-- 现有 `detail` 与 `download` 输入现在接受严格的官方 Pixiv 作品 URL；`download` 也接受已认证作者主页和作品页 URL，以遍历全部插画、漫画和 ugoira，但不下载小说。
-- MCP `illust_detail` 现在恰好接受 ID 或 URL 之一，`download` 接受 URL；插画查询 tool 会在紧凑文本摘要之外返回 typed structured result。
-- 插画 `search` 与 MCP `search_illust` 现支持官方 App 的 `keyword` 搜索（标签、标题、说明文字）、包含边界的显式日期、公开收藏数边界，以及 `half-year` / `year` 快捷日期范围。收藏数边界同时需要 App OAuth 与有效的 Pixiv 高级会员。缺少 App OAuth 时，App 专属筛选会返回认证要求。
-- 每个已公开 GitHub Release 现在都会向 SkillHub 提交同一 tag 对应的 `pixiv-cli` 产品 skill。提交前会先在本地校验，工作流必须取得 SkillHub 返回的 `skillId` 与审核状态才会成功。
+- 新增已验证发布源备选项、官方 Pixiv URL 输入支持、类型化图像查询结果、更丰富的 App 搜索筛选和基于 tag 的 SkillHub 发布。 ([#30](https://github.com/FlanChanXwO/pixiv-cli/pull/30))
 
 ## 变更
 
-- 已配置的 `--proxy`、`https_proxy` 或 `HTTPS_PROXY` 继续优先于公共 Release 源。更新器保持规范 GitHub Release 身份和 Ed25519/SHA-256 验证；安装器在接受经代理下载的 archive 前仍直连 GitHub 取得 checksum。
-- 下载 JSON 现在以 `{items, failures}` 报告规范作品 URL、ID、类型、页码和本地路径。部分失败会报告全部已完成结果并以非零退出；不会创建下载历史、缓存或跨次去重。
+- 统一代理更新器优先级和下载 JSON 结果报告。 ([#30](https://github.com/FlanChanXwO/pixiv-cli/pull/30))
+
+**完整变更**：[v0.6.0...v0.7.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.6.0...v0.7.0)

--- a/changelog/v0.7.1/en.md
+++ b/changelog/v0.7.1/en.md
@@ -2,14 +2,14 @@
 
 ## Changed
 
-- Bookmark-count illustration searches now preflight the saved account's cached Pixiv Premium status (24 hours by default) and reject non-Premium accounts locally, preventing Pixiv from silently ignoring the bounds. Configure `[premium] status_cache_ttl` in `config.toml`, or run `pixiv auth refresh [UID] [--all]` to force OAuth credential and membership-cache refresh.
-- Simplified text account feedback: successful login prints the compact safe account summary `✓ uid:UID username:NAME`, and `auth list` uses `*` plus `✓`/`-` local-state markers instead of `token:yes/no`.
-- A missing `config.toml` is now created on the first ordinary CLI command with only common settings; advanced settings remain absent until explicitly configured, and existing files are never overwritten.
-- Reformatted daily local operation logs into a compact Spring/SLF4J-style layout with timestamp, level, PID, business component, repository-relative callsite and operation; empty fields and local-only backend/status values are omitted.
+- Clarified Pixiv Premium search requirements and refreshed local account feedback, configuration creation, and operation-log presentation. ([#34](https://github.com/FlanChanXwO/pixiv-cli/pull/34))
 
 ## Fixed
 
-- Restore macOS browser OAuth callbacks by making the temporary `pixiv://` helper read the same private endpoint file as the active CLI loopback listener; existing helpers rebuild automatically on the next login.
-- Trigger the automatic SkillHub publication from a successful Release workflow instead of its GitHub Release event, because releases created with `github.token` do not recursively emit that event to Actions.
-- Accept SkillHub's community `reviewStatus` response field when confirming an accepted submission, so a successful publish is not reported as failed.
-- Skip SkillHub publication when `skills/pixiv-cli/` is unchanged from the preceding release tag, and let the Skill's own frontmatter version advance independently from the CLI release version.
+- Triggered SkillHub publication from completed releases, accepted its community review status, and skipped unchanged product skills. ([#31](https://github.com/FlanChanXwO/pixiv-cli/pull/31), [#32](https://github.com/FlanChanXwO/pixiv-cli/pull/32), [#33](https://github.com/FlanChanXwO/pixiv-cli/pull/33))
+
+## Maintenance
+
+- Prepared the v0.7.1 release metadata. ([`ab3a89b`](https://github.com/FlanChanXwO/pixiv-cli/commit/ab3a89b))
+
+**Full Changelog**: [v0.7.0...v0.7.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.0...v0.7.1)

--- a/changelog/v0.7.1/zh-CN.md
+++ b/changelog/v0.7.1/zh-CN.md
@@ -2,14 +2,14 @@
 
 ## 变更
 
-- 插画收藏数筛选现在会预检已保存账号缓存的 Pixiv 高级会员状态（默认 24 小时）；非会员在本地被拒绝，避免 Pixiv 静默忽略筛选边界。可在 `config.toml` 设置 `[premium] status_cache_ttl`，或执行 `pixiv auth refresh [UID] [--all]` 强制刷新 OAuth 凭据和会员缓存。
-- 简化账号文本反馈：登录成功输出紧凑安全账号摘要 `✓ uid:UID username:NAME`，`auth list` 用 `*` 与 `✓`/`-` 本地状态符号替代 `token:yes/no`。
-- 首次普通 CLI 命令会生成缺失的 `config.toml`，其中只含常用设置；高级设置保持省略直到显式配置，且绝不覆盖已有文件。
-- 本地按日操作日志改为紧凑的 Spring/SLF4J 风格，包含时间、级别、PID、业务组件、仓库相对调用点和操作；空字段及仅表示本地的 backend/status 会省略。
+- 明确 Pixiv Premium 搜索要求，并更新本地账号反馈、配置创建和操作日志呈现。 ([#34](https://github.com/FlanChanXwO/pixiv-cli/pull/34))
 
 ## 修复
 
-- 修复 macOS 浏览器 OAuth callback：临时 `pixiv://` helper 现在读取与活动 CLI loopback listener 相同的私有端点文件；下次登录会自动重编译既有 helper。
-- 自动 SkillHub 发布现在由成功结束的 Release workflow 触发，而非 GitHub Release event；后者由 `github.token` 创建时不会递归触发 Actions。
-- 确认 SkillHub 社区提交时现在识别其 `reviewStatus` 返回字段，避免已成功发布被误报为失败。
-- 若 `skills/pixiv-cli/` 与上一个 release tag 相比没有变化，则跳过 SkillHub 提交；Skill 的 frontmatter 版本独立于 CLI Release 版本，仅在 Skill 实际变化时递增。
+- 从已完成的 Release 触发 SkillHub 发布、接受社区审核状态并跳过未变化的产品 Skill。 ([#31](https://github.com/FlanChanXwO/pixiv-cli/pull/31), [#32](https://github.com/FlanChanXwO/pixiv-cli/pull/32), [#33](https://github.com/FlanChanXwO/pixiv-cli/pull/33))
+
+## 维护
+
+- 准备 v0.7.1 发布元数据。 ([`ab3a89b`](https://github.com/FlanChanXwO/pixiv-cli/commit/ab3a89b))
+
+**完整变更**：[v0.7.0...v0.7.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.0...v0.7.1)

--- a/changelog/v0.7.2/en.md
+++ b/changelog/v0.7.2/en.md
@@ -2,5 +2,6 @@
 
 ## Fixed
 
-- Make automatic SkillHub publication work for recovered Releases: after the GitHub Release and Homebrew deployment succeed, the downstream workflow receives and revalidates the exact immutable release tag instead of treating its `main` head branch as a version.
-- Publish the updated `pixiv-cli` product skill as independent SkillHub version 0.7.1. Its version changes because the Skill content changed, not merely because the CLI has a new release.
+- Made SkillHub publication work for recovered Releases by handing off and revalidating the exact immutable tag, and stabilized the recovery and installer test fixtures. ([`1a40630`](https://github.com/FlanChanXwO/pixiv-cli/commit/1a40630), [`c68f63f`](https://github.com/FlanChanXwO/pixiv-cli/commit/c68f63f), [`e1cf5c9`](https://github.com/FlanChanXwO/pixiv-cli/commit/e1cf5c9), [`fd0443c`](https://github.com/FlanChanXwO/pixiv-cli/commit/fd0443c))
+
+**Full Changelog**: [v0.7.1...v0.7.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.1...v0.7.2)

--- a/changelog/v0.7.2/zh-CN.md
+++ b/changelog/v0.7.2/zh-CN.md
@@ -2,5 +2,6 @@
 
 ## 修复
 
-- 修复恢复发布后的自动 SkillHub 提交：GitHub Release 和 Homebrew 部署均成功后，下游 workflow 会接收并重新验证精确的不可变 release tag，不再将其 `main` head branch 当作版本。
-- 将更新后的 `pixiv-cli` 产品 Skill 作为独立的 SkillHub 版本 0.7.1 提交。该版本只因 Skill 内容变化而递增，不会仅跟随 CLI 发版而变化。
+- 通过交接并重新验证精确不可变 tag，使 SkillHub 发布支持恢复后的 Release，并稳定恢复与安装器测试 fixture。 ([`1a40630`](https://github.com/FlanChanXwO/pixiv-cli/commit/1a40630), [`c68f63f`](https://github.com/FlanChanXwO/pixiv-cli/commit/c68f63f), [`e1cf5c9`](https://github.com/FlanChanXwO/pixiv-cli/commit/e1cf5c9), [`fd0443c`](https://github.com/FlanChanXwO/pixiv-cli/commit/fd0443c))
+
+**完整变更**：[v0.7.1...v0.7.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.1...v0.7.2)

--- a/changelog/v0.8.0/en.md
+++ b/changelog/v0.8.0/en.md
@@ -2,34 +2,22 @@
 
 ## Breaking changes
 
-- The public Go SDK has a new two-level download API. Use `Download` or `DownloadAll` for the common case, and
-  `DownloadWith` or `DownloadAllWith` with `DownloadOptions` when choosing paths, naming, pages, quality, or
-  concurrency. The previous raw `Download(ctx, ResourceRef, path)` is now `DownloadResource`.
-- SDK construction is now explicit: use `OpenDefault()` for local defaults, `OpenDefaultWith(OpenDefaultOptions)` for
-  local-state customisation, and `NewClient(NewClientOptions)` for access-token clients. The former combined
-  `Options` type has been removed.
-- Configuration is type-safe. `GetConfig`, `SetConfig`, and `UnsetConfig` now use `ConfigKey`, `ConfigInput`, and
-  `ConfigValue`; CLI text is parsed at the boundary. Sensitive relay secrets cannot be read or written through the
-  generic configuration API.
-- `pixiv download` now takes `SRC...` and exposes `--concurrency`. MCP `download` accepts `src` or `srcs` plus
-  `concurrency`; its separate legacy PID/URL input fields have been removed.
+- Reworked the public SDK download and construction APIs, type-safe configuration API, and CLI/MCP download inputs around explicit options and concurrency. ([`3145bf3`](https://github.com/FlanChanXwO/pixiv-cli/commit/3145bf3))
 
 ## Added
 
-- Downloads accept an artwork ID, an official Pixiv artwork URL, or an allowed CDN URL. The beginner defaults are
-  `./downloads`, the documented naming template, and automatic concurrency of `2 × GOMAXPROCS`; a positive
-  concurrency value is used exactly as requested.
-- Batch download results preserve source order and report each item's start state, result, cache state, and error.
-  Direct CDN downloads retain their URL filename and reject artwork-only page, quality, or custom-template options.
-- SDK, CLI, and MCP downloads now use persistent `.pixiv-cache` metadata revalidation, atomic replacement, safe
-  `Range` plus `If-Range` resume, and cached Ugoira ZIP inputs. Resource results expose their cache state.
-- `ParseUserReference` complements artwork-reference parsing without weakening the type-safe ID APIs.
-- Cross-machine `auth login` callback relay configuration is available for macOS, Windows, and desktop Linux clients.
-  It uses an on-demand persistent `pixiv://` handler, strict callback allowlisting, one-time secret/state validation,
-  optional TLS, and explicit warnings when HTTP plaintext is configured or started. macOS restores the prior handler
-  when one exists, and reports the association state when no prior handler exists.
+- Added persistent download-cache revalidation and resume, ordered batch results, artwork/user/CDN references, APNG support, canonical records, pools, feeds, and cross-machine OAuth callback relay configuration. ([`3145bf3`](https://github.com/FlanChanXwO/pixiv-cli/commit/3145bf3))
 
 ## Fixed
 
-- Restored the browser success/failure page for cross-machine `auth login`. The client handler opens a one-time,
-  non-sensitive relay result page that waits for the server's actual OAuth exchange outcome.
+- Restored the browser success and failure result pages for cross-machine authentication. ([`3145bf3`](https://github.com/FlanChanXwO/pixiv-cli/commit/3145bf3))
+
+## Documentation
+
+- Clarified the Pixiv ecosystem positioning and product-skill guidance. ([#35](https://github.com/FlanChanXwO/pixiv-cli/pull/35))
+
+## Maintenance
+
+- Made documentation-only pull requests and main pushes use the focused documentation contract gate. ([#36](https://github.com/FlanChanXwO/pixiv-cli/pull/36))
+
+**Full Changelog**: [v0.7.2...v0.8.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.2...v0.8.0)

--- a/changelog/v0.8.0/zh-CN.md
+++ b/changelog/v0.8.0/zh-CN.md
@@ -2,19 +2,22 @@
 
 ## 破坏性变更
 
-- 公开 Go SDK 采用新的两层下载 API。常见场景使用 `Download` 或 `DownloadAll`；需要选择路径、命名、页码、质量或并发时，使用带 `DownloadOptions` 的 `DownloadWith` 或 `DownloadAllWith`。原始 `Download(ctx, ResourceRef, path)` 更名为 `DownloadResource`。
-- SDK 构造器改为职责明确的入口：本地默认配置使用 `OpenDefault()`，定制本地状态使用 `OpenDefaultWith(OpenDefaultOptions)`，access-token client 使用 `NewClient(NewClientOptions)`；原先混合的 `Options` 类型已移除。
-- 配置 API 已强类型化：`GetConfig`、`SetConfig`、`UnsetConfig` 使用 `ConfigKey`、`ConfigInput` 与 `ConfigValue`，CLI 文本只在边界解析。敏感 relay secret 不能通过通用配置 API 读取或写入。
-- `pixiv download` 现在接收 `SRC...` 并提供 `--concurrency`。MCP `download` 使用 `src` 或 `srcs`，并支持 `concurrency`；原先分开的 PID/URL 输入字段已移除。
+- 围绕显式选项和并发，重构公开 SDK 下载与构造 API、类型安全配置 API，以及 CLI/MCP 下载输入。 ([`3145bf3`](https://github.com/FlanChanXwO/pixiv-cli/commit/3145bf3))
 
 ## 新增
 
-- 下载可接收作品 ID、官方 Pixiv 作品 URL 或受策略允许的 CDN URL。新手默认使用 `./downloads`、文档化的命名模板与 `2 × GOMAXPROCS` 自动并发；正数并发值会严格按指定值执行。
-- 批量下载结果保持来源输入顺序，并逐项报告是否已启动、结果、缓存状态与错误。直链 CDN 下载保留 URL 文件名，并拒绝页码、质量或自定义模板等仅适用于作品的选项。
-- SDK、CLI 与 MCP 下载现在提供持久 `.pixiv-cache` 元数据重验证、原子替换、安全的 `Range` + `If-Range` 续传和 Ugoira ZIP 输入缓存；资源结果会暴露缓存状态。
-- 新增 `ParseUserReference`，与作品引用解析对称，同时不削弱 ID 型 API 的类型安全。
-- macOS、Windows 与桌面 Linux client 新增跨机器 `auth login` callback relay 配置。它使用按需持久化的 `pixiv://` handler、严格 callback 白名单、一次性 secret/state 校验、可选 TLS，并在配置或启动 HTTP 明文 relay 时明确提示风险；macOS 会恢复已有的旧 handler，并在没有旧 handler 时报告关联状态。
+- 新增持久下载缓存重验证与续传、有序批量结果、作品/用户/CDN 引用、APNG 支持、规范记录、收藏夹、动态和跨设备 OAuth 回调 relay 配置。 ([`3145bf3`](https://github.com/FlanChanXwO/pixiv-cli/commit/3145bf3))
 
 ## 修复
 
-- 恢复跨机器 `auth login` 的浏览器成功/失败页面。client handler 会打开一次性、无敏感信息的 relay 结果页，等待服务器真实 OAuth exchange 结果。
+- 恢复跨设备认证的浏览器成功与失败结果页。 ([`3145bf3`](https://github.com/FlanChanXwO/pixiv-cli/commit/3145bf3))
+
+## 文档
+
+- 明确 Pixiv 生态定位和产品 Skill 使用指引。 ([#35](https://github.com/FlanChanXwO/pixiv-cli/pull/35))
+
+## 维护
+
+- 让纯文档 PR 和 main 推送使用聚焦的文档契约门禁。 ([#36](https://github.com/FlanChanXwO/pixiv-cli/pull/36))
+
+**完整变更**：[v0.7.2...v0.8.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.2...v0.8.0)

--- a/docs/maintainers/agents/index.md
+++ b/docs/maintainers/agents/index.md
@@ -13,3 +13,4 @@
 - `CLAUDE.md` 只包含 `@AGENTS.md`，不维护第二份规则。
 - `.github/copilot-instructions.md` 是短提示，不复制主规则全文。
 - `.agents/skills/` 只放高频、可复用、能减少误操作的项目技能。
+- `.agents/skills/pixiv-cli-release-notes/` 记录 feature PR 到双语 release-prep、tag、GitHub Release、SkillHub 与 ClawHub 核验的授权和操作路径。

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -585,7 +585,7 @@ SkillHub CLI 的 dry-run 和提交，并使用 `SKILL.md` 内的独立 SemVer，
 
 功能 PR 在 `.github/PULL_REQUEST_TEMPLATE.md` 中填写机器可读的 release-note 声明：`Added`、`Changed`、`Fixed`、`Security`、`Documentation`、`Maintenance` 或 `None`，以及一句摘要和 breaking 标记。`None` 需要具体理由。Quality gate 离线读取 PR event payload 校验此声明。
 
-完成 feature PR、测试和审查后，使用 `scripts/releasenotes audit` 检查 tag 范围内的提交、关联 PR、direct-commit 例外、新贡献者和 SemVer 建议。审核后的双语 JSON plan 由 `prepare` 先预览，再以 `--apply` 生成版本目录和双语索引；`validate` 离线核对章节顺序、来源、双语集合、compare footer 和可选 audit 覆盖。发布 workflow 的 `release_notes_audit` job 在受保护 publish job 之前使用只读 `contents` 与 `pull-requests` 权限重复验证不可变 tag 的来源和说明。
+完成 feature PR、测试和审查后，使用 `scripts/releasenotes audit` 检查 tag 范围内的提交、关联 PR、direct-commit 例外、新贡献者和 SemVer 建议。新贡献者以该作者在仓库中最早合并的 PR 判定，避免历史 PR 的当前关联状态变化而漏记。审核后的双语 JSON plan 由 `prepare` 先预览，再以 `--apply` 生成版本目录和双语索引；`validate` 离线核对章节顺序、来源、双语集合、compare footer 和可选 audit 覆盖。发布 workflow 的 `release_notes_audit` job 在受保护 publish job 之前使用只读 `contents` 与 `pull-requests` 权限重复验证不可变 tag 的来源和说明。
 
 版本推荐不等于发布授权。创建 release-prep PR、合并、创建或推送 tag、触发发布、同步历史 GitHub Release 前，维护者须在当前会话明确确认具体版本、commit/tag 范围和预期影响。完整操作路径见 `.agents/skills/pixiv-cli-release-notes/SKILL.md`：功能分支与 PR → 合并后审计 → 版本建议与授权 → release-prep PR → tag 与 GitHub Release → SkillHub / ClawHub 验证。
 

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -577,19 +577,19 @@ SkillHub CLI 的 dry-run 和提交，并使用 `SKILL.md` 内的独立 SemVer，
 
 不要提交 Pixiv token、下载内容、本地数据库、机器相关配置、Ed25519 私钥或 tap deploy key。
 
-## Changelog
+## Release notes and publication
 
-`changelog/` 使用 Keep a Changelog 1.1.0 风格维护，并按版本目录保存双语记录。未发布改动必须同时写入
-`changelog/unreleased/en.md` 与 `changelog/unreleased/zh-CN.md`；正式发版时，将这两份记录移入
-`changelog/vX.Y.Z/`，并更新两种语言的目录索引。
+`changelog/` 按版本目录维护英文与简体中文发布说明。每个非空章节依次使用 `Breaking changes`、`Added`、`Changed`、`Fixed`、`Security`、`Documentation`、`Maintenance`；双语文件使用对应译名，并在末尾提供相同范围的 `Full Changelog` compare 链接。首个版本使用该 tag 的 commits 链接。
 
-需要记录的改动：
+每条面向结果的说明内联列出来源 PR；没有 PR 的历史变更使用真实短 SHA commit 链接。一个条目可以归并多个相关来源。每个版本还会列出首次合并且不属于仓库所有者或 bot 的外部贡献者。`changelog/unreleased/` 是 release-prep 入口和说明文件，不是功能 PR 的编辑目标。
 
-- 用户可见的新功能、行为变化或 bug 修复。
-- 配置、CLI、MCP tool、输出格式或兼容性变化。
-- 废弃、移除、安全影响和迁移说明。
+功能 PR 在 `.github/PULL_REQUEST_TEMPLATE.md` 中填写机器可读的 release-note 声明：`Added`、`Changed`、`Fixed`、`Security`、`Documentation`、`Maintenance` 或 `None`，以及一句摘要和 breaking 标记。`None` 需要具体理由。Quality gate 离线读取 PR event payload 校验此声明。
 
-不强制记录纯内部重构、测试补充、文档清理和不会影响用户/集成方的工程整理。
+完成 feature PR、测试和审查后，使用 `scripts/releasenotes audit` 检查 tag 范围内的提交、关联 PR、direct-commit 例外、新贡献者和 SemVer 建议。审核后的双语 JSON plan 由 `prepare` 先预览，再以 `--apply` 生成版本目录和双语索引；`validate` 离线核对章节顺序、来源、双语集合、compare footer 和可选 audit 覆盖。发布 workflow 的 `release_notes_audit` job 在受保护 publish job 之前使用只读 `contents` 与 `pull-requests` 权限重复验证不可变 tag 的来源和说明。
+
+版本推荐不等于发布授权。创建 release-prep PR、合并、创建或推送 tag、触发发布、同步历史 GitHub Release 前，维护者须在当前会话明确确认具体版本、commit/tag 范围和预期影响。完整操作路径见 `.agents/skills/pixiv-cli-release-notes/SKILL.md`：功能分支与 PR → 合并后审计 → 版本建议与授权 → release-prep PR → tag 与 GitHub Release → SkillHub / ClawHub 验证。
+
+`sync-history` 默认 dry-run。明确传入 `--apply` 后，既有 GitHub Release 只更新正文；缺失的历史 Release 以现有 tag 创建且不含资产。两种情况都会读取远端正文并与本地双语渲染结果核对。
 
 ## 文档同步
 

--- a/scripts/documentation/documentation_test.go
+++ b/scripts/documentation/documentation_test.go
@@ -1,8 +1,10 @@
 package documentation_test
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -34,6 +36,7 @@ func TestLocalizedDocumentationLayout(t *testing.T) {
 		"docs/maintainers/development.md",
 		"docs/maintainers/agents/documentation-guidelines.md",
 		"docs/maintainers/adr/0011-localized-documentation-layout.md",
+		".agents/skills/pixiv-cli-release-notes/SKILL.md",
 	}
 	for _, relativePath := range required {
 		if info, err := os.Stat(filepath.Join(repositoryRoot, filepath.FromSlash(relativePath))); err != nil {
@@ -129,6 +132,31 @@ func TestMarkdownRelativeLinksResolve(t *testing.T) {
 func TestVersionedChangelogHasEnglishAndSimplifiedChinesePairs(t *testing.T) {
 	repositoryRoot := filepath.Clean(filepath.Join("..", ".."))
 	changelogRoot := filepath.Join(repositoryRoot, "changelog")
+	versions := []string{
+		"0.1.0", "0.1.1", "0.2.0", "0.3.0", "0.4.0", "0.4.1", "0.4.2", "0.4.3",
+		"0.4.4", "0.4.5", "0.5.0", "0.6.0", "0.7.0", "0.7.1", "0.7.2", "0.8.0",
+	}
+	previous := ""
+	for _, version := range versions {
+		directory := filepath.Join(changelogRoot, "v"+version)
+		for _, locale := range []string{"en.md", "zh-CN.md"} {
+			if info, err := os.Stat(filepath.Join(directory, locale)); err != nil {
+				t.Errorf("v%s %s: %v", version, locale, err)
+			} else if !info.Mode().IsRegular() {
+				t.Errorf("v%s %s is not a regular file", version, locale)
+			}
+		}
+		arguments := []string{"run", "./scripts/releasenotes", "validate", "--version", version, "--dir", filepath.ToSlash(filepath.Join("changelog", "v"+version))}
+		if previous != "" {
+			arguments = append(arguments, "--previous", previous)
+		}
+		command := exec.Command("go", arguments...)
+		command.Dir = repositoryRoot
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Errorf("validate v%s: %v\n%s", version, err, output)
+		}
+		previous = "v" + version
+	}
 	err := filepath.WalkDir(changelogRoot, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -144,6 +172,25 @@ func TestVersionedChangelogHasEnglishAndSimplifiedChinesePairs(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	for _, indexName := range []string{"README.md", "README.zh-CN.md"} {
+		body, err := os.ReadFile(filepath.Join(changelogRoot, indexName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for index, version := range versions {
+			previous := ""
+			if index > 0 {
+				previous = "v" + versions[index-1]
+			}
+			link := "https://github.com/FlanChanXwO/pixiv-cli/commits/v" + version
+			if previous != "" {
+				link = fmt.Sprintf("https://github.com/FlanChanXwO/pixiv-cli/compare/%s...v%s", previous, version)
+			}
+			if !strings.Contains(string(body), "| [v"+version+"]("+link+")") {
+				t.Errorf("%s does not contain the expected v%s index link", indexName, version)
+			}
+		}
 	}
 }
 
@@ -165,6 +212,26 @@ func TestContributionTemplatesArePresentAndEnglish(t *testing.T) {
 				t.Errorf("contribution template %s contains non-ASCII character %q", relativePath, character)
 				break
 			}
+		}
+	}
+}
+
+func TestPullRequestTemplateDeclaresReleaseNoteMetadata(t *testing.T) {
+	repositoryRoot := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repositoryRoot, ".github", "PULL_REQUEST_TEMPLATE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{
+		"<!-- release-note",
+		"category:",
+		"breaking:",
+		"summary:",
+		"none_reason:",
+		"Added, Changed, Fixed, Security, Documentation, Maintenance, or None",
+	} {
+		if !strings.Contains(string(payload), field) {
+			t.Errorf("pull-request template is missing release-note field or category %q", field)
 		}
 	}
 }

--- a/scripts/internal/releasenotesrender/render.go
+++ b/scripts/internal/releasenotesrender/render.go
@@ -1,0 +1,35 @@
+// Package releasenotesrender provides the canonical GitHub Release body rendering shared by releaseassets and history synchronization.
+package releasenotesrender
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// NotesFromChangelog returns the release text after exactly one matching H1 heading.
+func NotesFromChangelog(path, version string) ([]byte, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read changelog: %w", err)
+	}
+	header := regexp.MustCompile(`(?m)^# v` + regexp.QuoteMeta(version) + `(?:\s+[—-]\s+.+)?\s*$`)
+	location := header.FindIndex(body)
+	if location == nil {
+		return nil, fmt.Errorf("changelog has no release heading for v%s", version)
+	}
+	if second := header.FindIndex(body[location[1]:]); second != nil {
+		return nil, fmt.Errorf("changelog has more than one release heading for v%s", version)
+	}
+	notes := strings.Trim(string(body[location[1]:]), "\n")
+	if notes == "" {
+		return nil, fmt.Errorf("changelog release v%s has no release notes", version)
+	}
+	return []byte(notes + "\n"), nil
+}
+
+// BilingualBody keeps the language headings and separators stable for GitHub Release bodies.
+func BilingualBody(english, chinese []byte) []byte {
+	return []byte("# English\n\n" + strings.TrimSpace(string(english)) + "\n\n---\n\n# 简体中文\n\n" + strings.TrimSpace(string(chinese)) + "\n")
+}

--- a/scripts/releaseassets/main.go
+++ b/scripts/releaseassets/main.go
@@ -20,6 +20,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/FlanChanXwO/pixiv-cli/scripts/internal/releasenotesrender"
 )
 
 var semanticVersionPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
@@ -504,30 +506,13 @@ func readEd25519PrivateKey(path string) (ed25519.PrivateKey, error) {
 }
 
 func releaseNotesFromChangelog(path, version string) ([]byte, error) {
-	body, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read changelog: %w", err)
-	}
-	header := regexp.MustCompile(`(?m)^# v` + regexp.QuoteMeta(version) + `(?:\s+[—-]\s+.+)?\s*$`)
-	location := header.FindIndex(body)
-	if location == nil {
-		return nil, fmt.Errorf("changelog has no release heading for v%s", version)
-	}
-	if second := header.FindIndex(body[location[1]:]); second != nil {
-		return nil, fmt.Errorf("changelog has more than one release heading for v%s", version)
-	}
-	remainder := body[location[1]:]
-	notes := strings.Trim(string(remainder), "\n")
-	if notes == "" {
-		return nil, fmt.Errorf("changelog release v%s has no release notes", version)
-	}
-	return []byte(notes + "\n"), nil
+	return releasenotesrender.NotesFromChangelog(path, version)
 }
 
 // bilingualReleaseNotes 为 GitHub Release body 增加稳定的语言标题。两个输入都已经
 // 由 releaseNotesFromChangelog 验证了对应版本标题，并且不会进入签名 checksum asset 集合。
 func bilingualReleaseNotes(english, chinese []byte) []byte {
-	return []byte("# English\n\n" + strings.TrimSpace(string(english)) + "\n\n---\n\n# 简体中文\n\n" + strings.TrimSpace(string(chinese)) + "\n")
+	return releasenotesrender.BilingualBody(english, chinese)
 }
 
 func signedChecksumsManifest(keyID string, privateKey ed25519.PrivateKey, checksums []byte) ([]byte, error) {

--- a/scripts/releasenotes/main.go
+++ b/scripts/releasenotes/main.go
@@ -56,12 +56,15 @@ type githubUser struct {
 }
 
 type githubPullRequest struct {
-	Number            int        `json:"number"`
-	Title             string     `json:"title"`
-	Body              string     `json:"body"`
-	HTMLURL           string     `json:"html_url"`
-	AuthorAssociation string     `json:"author_association"`
-	User              githubUser `json:"user"`
+	Number  int        `json:"number"`
+	Title   string     `json:"title"`
+	Body    string     `json:"body"`
+	HTMLURL string     `json:"html_url"`
+	User    githubUser `json:"user"`
+}
+
+type githubPullRequestSearchResult struct {
+	Items []githubPullRequest `json:"items"`
 }
 
 type auditSource struct {
@@ -661,6 +664,7 @@ func collectAudit(ctx context.Context, config auditConfig) (auditReport, error) 
 	}
 	seenPulls := make(map[int]struct{})
 	seenContributors := make(map[string]struct{})
+	firstMergedPulls := make(map[string]int)
 	for _, commit := range commits {
 		pulls, err := config.client.pullRequestsForCommit(ctx, config.repository, commit)
 		if err != nil {
@@ -706,7 +710,21 @@ func collectAudit(ctx context.Context, config auditConfig) (auditReport, error) 
 				source.Note = &note
 			}
 			report.Sources = append(report.Sources, source)
-			if isNewExternalContributor(pull, owner) {
+			if isExternalContributor(pull, owner) {
+				firstMergedPull, known := firstMergedPulls[pull.User.Login]
+				if !known {
+					// author_association 会随仓库历史变化，故以仓库中该作者
+					// 最早合并的 PR 为准，并缓存结果避免同一作者重复查询。
+					first, firstErr := config.client.firstMergedPullRequest(ctx, config.repository, pull.User.Login)
+					if firstErr != nil {
+						return auditReport{}, fmt.Errorf("lookup first merged PR for %q: %w", pull.User.Login, firstErr)
+					}
+					firstMergedPull = first.Number
+					firstMergedPulls[pull.User.Login] = firstMergedPull
+				}
+				if firstMergedPull != pull.Number {
+					continue
+				}
 				if _, exists := seenContributors[pull.User.Login]; !exists {
 					seenContributors[pull.User.Login] = struct{}{}
 					report.NewContributors = append(report.NewContributors, newContributor{
@@ -747,6 +765,24 @@ func (client githubClient) pullRequest(ctx context.Context, repository string, n
 		return githubPullRequest{}, err
 	}
 	return pull, nil
+}
+
+// firstMergedPullRequest 使用仓库的完整 PR 历史，而不是当前 author_association，
+// 判定某个作者最早合并的 PR。该查询只取排序后的首项，不依赖任意分页上限。
+func (client githubClient) firstMergedPullRequest(ctx context.Context, repository, login string) (githubPullRequest, error) {
+	query := url.Values{}
+	query.Set("q", "repo:"+repository+" type:pr author:"+login+" is:merged")
+	query.Set("sort", "created")
+	query.Set("order", "asc")
+	query.Set("per_page", "1")
+	var result githubPullRequestSearchResult
+	if err := client.getJSON(ctx, "/search/issues?"+query.Encode(), &result); err != nil {
+		return githubPullRequest{}, err
+	}
+	if len(result.Items) == 0 {
+		return githubPullRequest{}, fmt.Errorf("no merged pull request found")
+	}
+	return result.Items[0], nil
 }
 
 func (client githubClient) getJSON(ctx context.Context, path string, destination any) error {
@@ -904,8 +940,8 @@ func renderGitHubReleaseBody(directory, version string) (string, error) {
 	return string(releasenotesrender.BilingualBody(english, chinese)), nil
 }
 
-func isNewExternalContributor(pull githubPullRequest, owner string) bool {
-	if pull.AuthorAssociation != "FIRST_TIME_CONTRIBUTOR" || pull.User.Login == "" || pull.User.Login == owner {
+func isExternalContributor(pull githubPullRequest, owner string) bool {
+	if pull.User.Login == "" || pull.User.Login == owner {
 		return false
 	}
 	return pull.User.Type != "Bot" && !strings.HasSuffix(strings.ToLower(pull.User.Login), "[bot]")

--- a/scripts/releasenotes/main.go
+++ b/scripts/releasenotes/main.go
@@ -1,0 +1,1285 @@
+// Command releasenotes audits and validates the versioned changelog contract.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/FlanChanXwO/pixiv-cli/scripts/internal/releasenotesrender"
+)
+
+var (
+	releaseHeadingPattern  = regexp.MustCompile(`(?m)^# v([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)\s+[—-]\s+.+$`)
+	sectionPattern         = regexp.MustCompile(`(?m)^##\s+(.+?)\s*$`)
+	sourcePattern          = regexp.MustCompile(`https://github\.com/FlanChanXwO/pixiv-cli/(?:pull/[0-9]+|commit/[0-9a-fA-F]{7,64})`)
+	linkPattern            = regexp.MustCompile(`\[[^\]]+\]\((https://github\.com/FlanChanXwO/pixiv-cli/(?:compare/[^)\s]+|commits/[^)\s]+))\)`)
+	releaseNotePattern     = regexp.MustCompile(`(?s)<!--\s*release-note\s*\n(.*?)-->`)
+	semanticVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$`)
+	datePattern            = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}$`)
+)
+
+// releaseNote 是 PR 模板中 release-note 注释的稳定语义模型。它不包含 PR 编号，
+// 因为 audit 会将同一声明与 GitHub 返回的 PR 元数据关联。
+type releaseNote struct {
+	Category   string `json:"category"`
+	Breaking   bool   `json:"breaking"`
+	Summary    string `json:"summary"`
+	NoneReason string `json:"none_reason"`
+}
+
+// githubClient 只封装 release-note 流程需要的 GitHub REST 读取。写入历史
+// Release 的操作在 sync-history 子命令中单独、显式地处理。
+type githubClient struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+type githubUser struct {
+	Login   string `json:"login"`
+	Type    string `json:"type"`
+	HTMLURL string `json:"html_url"`
+}
+
+type githubPullRequest struct {
+	Number            int        `json:"number"`
+	Title             string     `json:"title"`
+	Body              string     `json:"body"`
+	HTMLURL           string     `json:"html_url"`
+	AuthorAssociation string     `json:"author_association"`
+	User              githubUser `json:"user"`
+}
+
+type auditSource struct {
+	Kind       string       `json:"kind"`
+	URL        string       `json:"url"`
+	PullNumber int          `json:"pull_number,omitempty"`
+	Commit     string       `json:"commit,omitempty"`
+	Title      string       `json:"title"`
+	Author     string       `json:"author"`
+	Note       *releaseNote `json:"release_note,omitempty"`
+	Issue      string       `json:"issue,omitempty"`
+}
+
+type newContributor struct {
+	Login      string `json:"login"`
+	ProfileURL string `json:"profile_url"`
+	PullNumber int    `json:"pull_number"`
+	PullURL    string `json:"pull_url"`
+}
+
+type auditReport struct {
+	Repository             string           `json:"repository"`
+	From                   string           `json:"from,omitempty"`
+	To                     string           `json:"to"`
+	RecommendedVersionBump string           `json:"recommended_version_bump"`
+	Sources                []auditSource    `json:"sources"`
+	NewContributors        []newContributor `json:"new_contributors"`
+}
+
+// preparePlan 是审核后、可纳入 release-prep PR 的编辑输入。工具刻意不从 PR
+// 标题自动生成面向用户的文案：维护者需要在此处合并相关变更并提供双语摘要。
+type preparePlan struct {
+	Entries         []preparedEntry  `json:"entries"`
+	NewContributors []newContributor `json:"new_contributors,omitempty"`
+}
+
+type preparedEntry struct {
+	Category string   `json:"category"`
+	Breaking bool     `json:"breaking,omitempty"`
+	English  string   `json:"english"`
+	Chinese  string   `json:"zh_cn"`
+	Sources  []string `json:"sources"`
+}
+
+type prepareConfig struct {
+	Version       string
+	Previous      string
+	Date          string
+	ChangelogRoot string
+	PlanPath      string
+	AuditPath     string
+	Apply         bool
+	Replace       bool
+}
+
+type syncHistoryConfig struct {
+	Repository string
+	Version    string
+	Directory  string
+	Client     githubClient
+	Apply      bool
+}
+
+type githubRelease struct {
+	ID      int                  `json:"id"`
+	TagName string               `json:"tag_name"`
+	Name    string               `json:"name"`
+	Body    string               `json:"body"`
+	Assets  []githubReleaseAsset `json:"assets"`
+}
+
+type githubReleaseAsset struct {
+	Name string `json:"name"`
+}
+
+type githubReleaseWrite struct {
+	TagName string `json:"tag_name,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Body    string `json:"body"`
+	Draft   bool   `json:"draft"`
+}
+
+type releaseDocument struct {
+	sections []releaseSection
+	sources  []string
+	compare  string
+}
+
+type releaseSection struct {
+	name    string
+	entries []string
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(arguments []string) error {
+	if len(arguments) == 0 {
+		return errors.New("a subcommand is required: validate, audit, prepare, pr-validate, or sync-history")
+	}
+	switch arguments[0] {
+	case "validate":
+		return runValidate(arguments[1:])
+	case "audit":
+		return runAudit(arguments[1:])
+	case "prepare":
+		return runPrepare(arguments[1:])
+	case "pr-validate":
+		return runPullRequestValidate(arguments[1:])
+	case "sync-history":
+		return runSyncHistory(arguments[1:])
+	case "-h", "--help", "help":
+		return errors.New("usage: releasenotes validate|audit|prepare|pr-validate|sync-history")
+	default:
+		return fmt.Errorf("unknown subcommand %q", arguments[0])
+	}
+}
+
+func runAudit(arguments []string) error {
+	flags := flag.NewFlagSet("audit", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	repository := flags.String("repo", "", "GitHub repository in owner/name form")
+	from := flags.String("from", "", "exclusive base tag; empty for the initial release")
+	to := flags.String("to", "", "inclusive Git ref or tag")
+	apiBase := flags.String("api-base", "https://api.github.com", "GitHub REST API base URL")
+	tokenEnv := flags.String("token-env", "GH_TOKEN", "environment variable containing an optional GitHub token")
+	output := flags.String("output", "", "optional JSON report path")
+	requireClassified := flags.Bool("require-classified", false, "fail when a source has no usable release-note declaration")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("audit accepts no positional arguments: %q", flags.Arg(0))
+	}
+	if !validRepository(*repository) || *to == "" {
+		return errors.New("audit requires --repo owner/name and --to")
+	}
+	report, err := collectAudit(context.Background(), auditConfig{
+		repository: *repository,
+		from:       *from,
+		to:         *to,
+		client: githubClient{
+			baseURL: *apiBase,
+			token:   os.Getenv(*tokenEnv),
+			client:  http.DefaultClient,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if err := writeJSON(*output, report); err != nil {
+		return err
+	}
+	if *requireClassified {
+		for _, source := range report.Sources {
+			if source.Issue != "" {
+				return fmt.Errorf("audit has unresolved source %s: %s", source.URL, source.Issue)
+			}
+		}
+	}
+	return nil
+}
+
+func runPrepare(arguments []string) error {
+	flags := flag.NewFlagSet("prepare", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	version := flags.String("version", "", "semantic version without v")
+	previous := flags.String("previous", "", "previous v-prefixed tag; empty for the initial release")
+	date := flags.String("date", "", "release date in YYYY-MM-DD form")
+	changelogRoot := flags.String("changelog-root", "changelog", "changelog root directory")
+	plan := flags.String("plan", "", "reviewed JSON release plan")
+	audit := flags.String("audit", "", "optional JSON audit report whose sources must be covered")
+	apply := flags.Bool("apply", false, "write the versioned notes and indexes after rendering")
+	replace := flags.Bool("replace", false, "replace an existing versioned note pair during an authorized historical backfill")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("prepare accepts no positional arguments: %q", flags.Arg(0))
+	}
+	if *version == "" || *date == "" || *plan == "" {
+		return errors.New("prepare requires --version, --date, and --plan")
+	}
+	return prepareRelease(prepareConfig{
+		Version:       *version,
+		Previous:      *previous,
+		Date:          *date,
+		ChangelogRoot: *changelogRoot,
+		PlanPath:      *plan,
+		AuditPath:     *audit,
+		Apply:         *apply,
+		Replace:       *replace,
+	})
+}
+
+func prepareRelease(config prepareConfig) error {
+	if !semanticVersionPattern.MatchString(config.Version) {
+		return fmt.Errorf("invalid semantic version %q", config.Version)
+	}
+	if !datePattern.MatchString(config.Date) {
+		return fmt.Errorf("invalid release date %q", config.Date)
+	}
+	if _, err := time.Parse("2006-01-02", config.Date); err != nil {
+		return fmt.Errorf("invalid release date %q: %w", config.Date, err)
+	}
+	if config.ChangelogRoot == "" || config.PlanPath == "" {
+		return errors.New("changelog root and plan path are required")
+	}
+	if config.Replace && !config.Apply {
+		return errors.New("prepare --replace requires --apply")
+	}
+	plan, err := readPreparePlan(config.PlanPath)
+	if err != nil {
+		return err
+	}
+	if err := validatePreparePlan(plan); err != nil {
+		return err
+	}
+	var report *auditReport
+	if config.AuditPath != "" {
+		parsedReport, err := readAuditReport(config.AuditPath)
+		if err != nil {
+			return err
+		}
+		if err := validatePlanCoverage(plan, parsedReport); err != nil {
+			return err
+		}
+		report = &parsedReport
+	}
+	files, err := renderPreparedRelease(config, plan)
+	if err != nil {
+		return err
+	}
+	if !config.Apply {
+		for _, path := range sortedFilePaths(files) {
+			fmt.Fprintln(os.Stdout, path)
+		}
+		return nil
+	}
+	for _, path := range sortedFilePaths(files) {
+		if err := writePreparedFile(path, files[path], config.Replace); err != nil {
+			return err
+		}
+	}
+	directory := filepath.Join(config.ChangelogRoot, "v"+config.Version)
+	if report != nil {
+		return validateSourceCoverage(directory, config.Version, config.Previous, *report)
+	}
+	return validateReleaseDirectory(directory, config.Version, config.Previous)
+}
+
+func readPreparePlan(path string) (preparePlan, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return preparePlan{}, fmt.Errorf("read release plan: %w", err)
+	}
+	var plan preparePlan
+	if err := json.Unmarshal(body, &plan); err != nil {
+		return preparePlan{}, fmt.Errorf("parse release plan: %w", err)
+	}
+	return plan, nil
+}
+
+func readAuditReport(path string) (auditReport, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return auditReport{}, fmt.Errorf("read audit report: %w", err)
+	}
+	var report auditReport
+	if err := json.Unmarshal(body, &report); err != nil {
+		return auditReport{}, fmt.Errorf("parse audit report: %w", err)
+	}
+	return report, nil
+}
+
+func validatePreparePlan(plan preparePlan) error {
+	if len(plan.Entries) == 0 {
+		return errors.New("release plan has no entries")
+	}
+	for index, entry := range plan.Entries {
+		if _, ok := releaseNoteCategories[entry.Category]; !ok || entry.Category == "None" {
+			return fmt.Errorf("entry %d has unsupported category %q", index+1, entry.Category)
+		}
+		if entry.English == "" || entry.Chinese == "" {
+			return fmt.Errorf("entry %d must contain both English and Simplified Chinese text", index+1)
+		}
+		if len(entry.Sources) == 0 {
+			return fmt.Errorf("entry %d has no sources", index+1)
+		}
+		entrySources := make(map[string]struct{})
+		for _, source := range entry.Sources {
+			if _, err := renderSourceLink(source); err != nil {
+				return fmt.Errorf("entry %d source: %w", index+1, err)
+			}
+			if _, exists := entrySources[source]; exists {
+				return fmt.Errorf("release plan entry %d repeats source %s", index+1, source)
+			}
+			entrySources[source] = struct{}{}
+		}
+	}
+	contributors := make(map[string]struct{})
+	for _, contributor := range plan.NewContributors {
+		if contributor.Login == "" || contributor.ProfileURL == "" || contributor.PullNumber <= 0 || contributor.PullURL == "" {
+			return errors.New("new contributor record is incomplete")
+		}
+		if _, err := renderSourceLink(contributor.PullURL); err != nil {
+			return fmt.Errorf("new contributor %q: %w", contributor.Login, err)
+		}
+		if _, exists := contributors[contributor.Login]; exists {
+			return fmt.Errorf("release plan repeats new contributor %q", contributor.Login)
+		}
+		contributors[contributor.Login] = struct{}{}
+	}
+	return nil
+}
+
+func validatePlanCoverage(plan preparePlan, report auditReport) error {
+	planned := make(map[string]struct{})
+	for _, entry := range plan.Entries {
+		for _, source := range entry.Sources {
+			planned[source] = struct{}{}
+		}
+	}
+	for _, contributor := range plan.NewContributors {
+		planned[contributor.PullURL] = struct{}{}
+	}
+	for _, source := range report.Sources {
+		if source.Kind == "pull_request" && (source.Note == nil || source.Issue != "") {
+			return fmt.Errorf("audit source %s is not classified: %s", source.URL, source.Issue)
+		}
+		if source.Note != nil && source.Note.Category == "None" {
+			continue
+		}
+		if _, ok := planned[source.URL]; !ok {
+			return fmt.Errorf("release plan does not cover audited source %s", source.URL)
+		}
+	}
+	plannedContributors := make(map[string]newContributor, len(plan.NewContributors))
+	for _, contributor := range plan.NewContributors {
+		plannedContributors[contributor.Login] = contributor
+	}
+	for _, contributor := range report.NewContributors {
+		planned, ok := plannedContributors[contributor.Login]
+		if !ok {
+			return fmt.Errorf("release plan does not include audited new contributor %q", contributor.Login)
+		}
+		if planned.ProfileURL != contributor.ProfileURL || planned.PullNumber != contributor.PullNumber || planned.PullURL != contributor.PullURL {
+			return fmt.Errorf("release plan new contributor %q differs from the audit report", contributor.Login)
+		}
+		delete(plannedContributors, contributor.Login)
+	}
+	for login := range plannedContributors {
+		return fmt.Errorf("release plan includes new contributor %q absent from the audit report", login)
+	}
+	return nil
+}
+
+func renderPreparedRelease(config prepareConfig, plan preparePlan) (map[string][]byte, error) {
+	english, err := renderReleaseDocument(config, plan, false)
+	if err != nil {
+		return nil, err
+	}
+	chinese, err := renderReleaseDocument(config, plan, true)
+	if err != nil {
+		return nil, err
+	}
+	englishIndex, err := updateChangelogIndex(filepath.Join(config.ChangelogRoot, "README.md"), config.Version, config.Previous, config.Date, config.Replace)
+	if err != nil {
+		return nil, err
+	}
+	chineseIndex, err := updateChangelogIndex(filepath.Join(config.ChangelogRoot, "README.zh-CN.md"), config.Version, config.Previous, config.Date, config.Replace)
+	if err != nil {
+		return nil, err
+	}
+	directory := filepath.Join(config.ChangelogRoot, "v"+config.Version)
+	return map[string][]byte{
+		filepath.Join(directory, "en.md"):                      english,
+		filepath.Join(directory, "zh-CN.md"):                   chinese,
+		filepath.Join(config.ChangelogRoot, "README.md"):       englishIndex,
+		filepath.Join(config.ChangelogRoot, "README.zh-CN.md"): chineseIndex,
+	}, nil
+}
+
+func renderReleaseDocument(config prepareConfig, plan preparePlan, chinese bool) ([]byte, error) {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "# v%s — %s\n", config.Version, config.Date)
+	sectionEntries := make(map[string][]string)
+	for _, entry := range plan.Entries {
+		section := entry.Category
+		if entry.Breaking {
+			section = "Breaking changes"
+		}
+		if chinese {
+			section = chineseSectionName(section)
+		}
+		text := entry.English
+		if chinese {
+			text = entry.Chinese
+		}
+		links := make([]string, 0, len(entry.Sources))
+		for _, source := range entry.Sources {
+			link, err := renderSourceLink(source)
+			if err != nil {
+				return nil, err
+			}
+			links = append(links, link)
+		}
+		sectionEntries[section] = append(sectionEntries[section], "- "+text+" ("+strings.Join(links, ", ")+")")
+	}
+	order := englishSectionOrder[:7]
+	if chinese {
+		order = chineseSectionOrder[:7]
+	}
+	for _, section := range order {
+		entries := sectionEntries[section]
+		if len(entries) == 0 {
+			continue
+		}
+		fmt.Fprintf(&builder, "\n## %s\n\n%s\n", section, strings.Join(entries, "\n"))
+	}
+	if len(plan.NewContributors) > 0 {
+		name := "New Contributors"
+		if chinese {
+			name = "新贡献者"
+		}
+		fmt.Fprintf(&builder, "\n## %s\n\n", name)
+		for _, contributor := range plan.NewContributors {
+			link, err := renderSourceLink(contributor.PullURL)
+			if err != nil {
+				return nil, err
+			}
+			if chinese {
+				fmt.Fprintf(&builder, "- [@%s](%s) 在 %s 中完成首次贡献。\n", contributor.Login, contributor.ProfileURL, link)
+			} else {
+				fmt.Fprintf(&builder, "- [@%s](%s) made their first contribution in %s.\n", contributor.Login, contributor.ProfileURL, link)
+			}
+		}
+	}
+	link := changelogCompareLink(config.Version, config.Previous)
+	if chinese {
+		fmt.Fprintf(&builder, "\n**完整变更**：[%s](%s)\n", changelogCompareLabel(config.Version, config.Previous), link)
+	} else {
+		fmt.Fprintf(&builder, "\n**Full Changelog**: [%s](%s)\n", changelogCompareLabel(config.Version, config.Previous), link)
+	}
+	return []byte(builder.String()), nil
+}
+
+func chineseSectionName(english string) string {
+	for index, candidate := range englishSectionOrder[:7] {
+		if candidate == english {
+			return chineseSectionOrder[index]
+		}
+	}
+	return english
+}
+
+func renderSourceLink(source string) (string, error) {
+	if !sourcePattern.MatchString(source) || sourcePattern.FindString(source) != source {
+		return "", fmt.Errorf("unsupported source URL %q", source)
+	}
+	if pull, ok := strings.CutPrefix(source, "https://github.com/FlanChanXwO/pixiv-cli/pull/"); ok {
+		return "[#" + pull + "](" + source + ")", nil
+	}
+	commit, _ := strings.CutPrefix(source, "https://github.com/FlanChanXwO/pixiv-cli/commit/")
+	if len(commit) < 7 {
+		return "", fmt.Errorf("commit source URL has a short hash %q", source)
+	}
+	return "[`" + commit[:7] + "`](" + source + ")", nil
+}
+
+func changelogCompareLink(version, previous string) string {
+	if previous == "" {
+		return "https://github.com/FlanChanXwO/pixiv-cli/commits/v" + version
+	}
+	return "https://github.com/FlanChanXwO/pixiv-cli/compare/" + previous + "...v" + version
+}
+
+func changelogCompareLabel(version, previous string) string {
+	if previous == "" {
+		return "v" + version + " commits"
+	}
+	return previous + "...v" + version
+}
+
+func updateChangelogIndex(path, version, previous, date string, replace bool) ([]byte, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read changelog index: %w", err)
+	}
+	content := string(body)
+	versionMarker := "v" + version + "]("
+	if strings.Contains(content, versionMarker) {
+		if replace {
+			return body, nil
+		}
+		return nil, fmt.Errorf("changelog index already contains v%s", version)
+	}
+	anchor := "| Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n"
+	position := strings.Index(content, anchor)
+	if position < 0 {
+		return nil, fmt.Errorf("changelog index %s has no Unreleased row", path)
+	}
+	row := fmt.Sprintf("| [v%s](%s) | %s | [English](v%s/en.md) · [简体中文](v%s/zh-CN.md) |\n", version, changelogCompareLink(version, previous), date, version, version)
+	position += len(anchor)
+	return []byte(content[:position] + row + content[position:]), nil
+}
+
+func sortedFilePaths(files map[string][]byte) []string {
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func writePreparedFile(path string, body []byte, replace bool) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if _, err := os.Lstat(path); err == nil {
+		base := filepath.Base(path)
+		if base != "README.md" && base != "README.zh-CN.md" && !replace {
+			return fmt.Errorf("refusing to replace existing file %s", path)
+		}
+		return os.WriteFile(path, body, 0o644)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(body); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runPullRequestValidate(arguments []string) error {
+	flags := flag.NewFlagSet("pr-validate", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	eventPath := flags.String("event", "", "GitHub pull_request event JSON path")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 || *eventPath == "" {
+		return errors.New("pr-validate requires --event")
+	}
+	return validatePullRequestEvent(*eventPath)
+}
+
+func validatePullRequestEvent(path string) error {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read pull request event: %w", err)
+	}
+	var event struct {
+		PullRequest struct {
+			Body string `json:"body"`
+		} `json:"pull_request"`
+	}
+	if err := json.Unmarshal(body, &event); err != nil {
+		return fmt.Errorf("parse pull request event: %w", err)
+	}
+	_, err = parseReleaseNoteDeclaration(event.PullRequest.Body)
+	return err
+}
+
+type auditConfig struct {
+	repository string
+	from       string
+	to         string
+	client     githubClient
+}
+
+func collectAudit(ctx context.Context, config auditConfig) (auditReport, error) {
+	commits, err := gitRevisionList(config.from, config.to)
+	if err != nil {
+		return auditReport{}, err
+	}
+	owner, _, _ := strings.Cut(config.repository, "/")
+	report := auditReport{
+		Repository:      config.repository,
+		From:            config.from,
+		To:              config.to,
+		Sources:         make([]auditSource, 0),
+		NewContributors: make([]newContributor, 0),
+	}
+	seenPulls := make(map[int]struct{})
+	seenContributors := make(map[string]struct{})
+	for _, commit := range commits {
+		pulls, err := config.client.pullRequestsForCommit(ctx, config.repository, commit)
+		if err != nil {
+			return auditReport{}, fmt.Errorf("lookup PRs for commit %s: %w", commit, err)
+		}
+		if len(pulls) == 0 {
+			title, author, detailErr := gitCommitDetail(commit)
+			if detailErr != nil {
+				return auditReport{}, detailErr
+			}
+			report.Sources = append(report.Sources, auditSource{
+				Kind:   "commit",
+				URL:    "https://github.com/" + config.repository + "/commit/" + commit,
+				Commit: commit,
+				Title:  title,
+				Author: author,
+				Issue:  "direct commit requires an explicit historical attribution",
+			})
+			continue
+		}
+		for _, summary := range pulls {
+			if _, exists := seenPulls[summary.Number]; exists {
+				continue
+			}
+			seenPulls[summary.Number] = struct{}{}
+			pull, err := config.client.pullRequest(ctx, config.repository, summary.Number)
+			if err != nil {
+				return auditReport{}, fmt.Errorf("lookup PR #%d: %w", summary.Number, err)
+			}
+			source := auditSource{
+				Kind:       "pull_request",
+				URL:        pull.HTMLURL,
+				PullNumber: pull.Number,
+				Title:      pull.Title,
+				Author:     pull.User.Login,
+			}
+			note, parseErr := parseReleaseNoteDeclaration(pull.Body)
+			if parseErr != nil {
+				source.Issue = parseErr.Error()
+			} else if note.Category == "None" {
+				source.Note = &note
+			} else {
+				source.Note = &note
+			}
+			report.Sources = append(report.Sources, source)
+			if isNewExternalContributor(pull, owner) {
+				if _, exists := seenContributors[pull.User.Login]; !exists {
+					seenContributors[pull.User.Login] = struct{}{}
+					report.NewContributors = append(report.NewContributors, newContributor{
+						Login:      pull.User.Login,
+						ProfileURL: pull.User.HTMLURL,
+						PullNumber: pull.Number,
+						PullURL:    pull.HTMLURL,
+					})
+				}
+			}
+		}
+	}
+	notes := make([]releaseNote, 0, len(report.Sources))
+	for _, source := range report.Sources {
+		if source.Note != nil {
+			notes = append(notes, *source.Note)
+		}
+	}
+	report.RecommendedVersionBump = recommendedVersionBump(notes)
+	sort.Slice(report.Sources, func(left, right int) bool { return report.Sources[left].URL < report.Sources[right].URL })
+	sort.Slice(report.NewContributors, func(left, right int) bool {
+		return report.NewContributors[left].Login < report.NewContributors[right].Login
+	})
+	return report, nil
+}
+
+func (client githubClient) pullRequestsForCommit(ctx context.Context, repository, commit string) ([]githubPullRequest, error) {
+	var pulls []githubPullRequest
+	if err := client.getJSON(ctx, "/repos/"+repository+"/commits/"+url.PathEscape(commit)+"/pulls", &pulls); err != nil {
+		return nil, err
+	}
+	return pulls, nil
+}
+
+func (client githubClient) pullRequest(ctx context.Context, repository string, number int) (githubPullRequest, error) {
+	var pull githubPullRequest
+	if err := client.getJSON(ctx, fmt.Sprintf("/repos/%s/pulls/%d", repository, number), &pull); err != nil {
+		return githubPullRequest{}, err
+	}
+	return pull, nil
+}
+
+func (client githubClient) getJSON(ctx context.Context, path string, destination any) error {
+	return client.requestJSON(ctx, http.MethodGet, path, nil, destination)
+}
+
+type githubHTTPError struct {
+	Path       string
+	StatusCode int
+	Body       string
+}
+
+func (err *githubHTTPError) Error() string {
+	if err.Body == "" {
+		return fmt.Sprintf("GitHub API %s: HTTP %d", err.Path, err.StatusCode)
+	}
+	return fmt.Sprintf("GitHub API %s: HTTP %d: %s", err.Path, err.StatusCode, err.Body)
+}
+
+func (client githubClient) requestJSON(ctx context.Context, method, path string, input, destination any) error {
+	baseURL := strings.TrimRight(client.baseURL, "/")
+	if baseURL == "" {
+		return errors.New("GitHub API base URL is required")
+	}
+	var body io.Reader
+	if input != nil {
+		encoded, err := json.Marshal(input)
+		if err != nil {
+			return fmt.Errorf("encode GitHub API request: %w", err)
+		}
+		body = strings.NewReader(string(encoded))
+	}
+	request, err := http.NewRequestWithContext(ctx, method, baseURL+path, body)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if input != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if client.token != "" {
+		request.Header.Set("Authorization", "Bearer "+client.token)
+	}
+	httpClient := client.client
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		responseBody, readErr := io.ReadAll(response.Body)
+		if readErr != nil {
+			return &githubHTTPError{Path: path, StatusCode: response.StatusCode}
+		}
+		return &githubHTTPError{Path: path, StatusCode: response.StatusCode, Body: strings.TrimSpace(string(responseBody))}
+	}
+	if destination == nil {
+		return nil
+	}
+	return json.NewDecoder(response.Body).Decode(destination)
+}
+
+func runSyncHistory(arguments []string) error {
+	flags := flag.NewFlagSet("sync-history", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	repository := flags.String("repo", "", "GitHub repository in owner/name form")
+	version := flags.String("version", "", "semantic version without v")
+	directory := flags.String("dir", "", "version directory containing en.md and zh-CN.md")
+	apiBase := flags.String("api-base", "https://api.github.com", "GitHub REST API base URL")
+	tokenEnv := flags.String("token-env", "GH_TOKEN", "environment variable containing a GitHub token")
+	apply := flags.Bool("apply", false, "create or update the historical GitHub Release body")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 || !validRepository(*repository) || !semanticVersionPattern.MatchString(*version) || *directory == "" {
+		return errors.New("sync-history requires --repo, --version, and --dir")
+	}
+	return syncHistoricalRelease(context.Background(), syncHistoryConfig{
+		Repository: *repository,
+		Version:    *version,
+		Directory:  *directory,
+		Apply:      *apply,
+		Client: githubClient{
+			baseURL: *apiBase,
+			token:   os.Getenv(*tokenEnv),
+			client:  http.DefaultClient,
+		},
+	})
+}
+
+// syncHistoricalRelease 只读取或更新 Release 正文。它不接触 tag、draft 状态和
+// assets，因此补写历史文本不会补造或替换任何已发布的二进制资产。
+func syncHistoricalRelease(ctx context.Context, config syncHistoryConfig) error {
+	body, err := renderGitHubReleaseBody(config.Directory, config.Version)
+	if err != nil {
+		return err
+	}
+	path := "/repos/" + config.Repository + "/releases/tags/v" + config.Version
+	var release githubRelease
+	err = config.Client.getJSON(ctx, path, &release)
+	if err != nil {
+		var apiErr *githubHTTPError
+		if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusNotFound {
+			return err
+		}
+		if !config.Apply {
+			fmt.Fprintf(os.Stdout, "would create historical Release v%s without assets\n", config.Version)
+			return nil
+		}
+		created := githubRelease{}
+		if err := config.Client.requestJSON(ctx, http.MethodPost, "/repos/"+config.Repository+"/releases", githubReleaseWrite{
+			TagName: "v" + config.Version,
+			Name:    "v" + config.Version,
+			Body:    body,
+			Draft:   false,
+		}, &created); err != nil {
+			return fmt.Errorf("create historical Release v%s: %w", config.Version, err)
+		}
+		release = created
+	} else {
+		if !config.Apply {
+			fmt.Fprintf(os.Stdout, "would update historical Release v%s body; assets remain unchanged\n", config.Version)
+			return nil
+		}
+		if err := config.Client.requestJSON(ctx, http.MethodPatch, fmt.Sprintf("/repos/%s/releases/%d", config.Repository, release.ID), githubReleaseWrite{Body: body}, &release); err != nil {
+			return fmt.Errorf("update historical Release v%s: %w", config.Version, err)
+		}
+	}
+	var verified githubRelease
+	if err := config.Client.getJSON(ctx, path, &verified); err != nil {
+		return fmt.Errorf("verify historical Release v%s: %w", config.Version, err)
+	}
+	if verified.TagName != "v"+config.Version {
+		return fmt.Errorf("verified historical Release tag %q, want v%s", verified.TagName, config.Version)
+	}
+	if verified.Body != body {
+		return fmt.Errorf("verified historical Release v%s body differs from local rendering", config.Version)
+	}
+	return nil
+}
+
+func renderGitHubReleaseBody(directory, version string) (string, error) {
+	english, err := releasenotesrender.NotesFromChangelog(filepath.Join(directory, "en.md"), version)
+	if err != nil {
+		return "", fmt.Errorf("English changelog: %w", err)
+	}
+	chinese, err := releasenotesrender.NotesFromChangelog(filepath.Join(directory, "zh-CN.md"), version)
+	if err != nil {
+		return "", fmt.Errorf("Simplified Chinese changelog: %w", err)
+	}
+	return string(releasenotesrender.BilingualBody(english, chinese)), nil
+}
+
+func isNewExternalContributor(pull githubPullRequest, owner string) bool {
+	if pull.AuthorAssociation != "FIRST_TIME_CONTRIBUTOR" || pull.User.Login == "" || pull.User.Login == owner {
+		return false
+	}
+	return pull.User.Type != "Bot" && !strings.HasSuffix(strings.ToLower(pull.User.Login), "[bot]")
+}
+
+func gitRevisionList(from, to string) ([]string, error) {
+	if to == "" {
+		return nil, errors.New("git revision target is required")
+	}
+	revision := to
+	if from != "" {
+		revision = from + ".." + to
+	}
+	output, err := exec.Command("git", "rev-list", "--reverse", revision).Output()
+	if err != nil {
+		return nil, fmt.Errorf("list commits for %s: %w", revision, err)
+	}
+	lines := strings.Fields(string(output))
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("no commits found for %s", revision)
+	}
+	return lines, nil
+}
+
+func gitCommitDetail(commit string) (title, author string, err error) {
+	output, err := exec.Command("git", "show", "-s", "--format=%s%x00%an", commit).Output()
+	if err != nil {
+		return "", "", fmt.Errorf("read direct commit %s: %w", commit, err)
+	}
+	title, author, ok := strings.Cut(strings.TrimSuffix(string(output), "\n"), "\x00")
+	if !ok || title == "" || author == "" {
+		return "", "", fmt.Errorf("read direct commit %s: malformed git metadata", commit)
+	}
+	return title, author, nil
+}
+
+func validRepository(repository string) bool {
+	owner, name, ok := strings.Cut(repository, "/")
+	return ok && owner != "" && name != "" && !strings.Contains(name, "/")
+}
+
+func writeJSON(path string, value any) error {
+	var destination io.Writer = os.Stdout
+	var file *os.File
+	if path != "" {
+		opened, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+		if err != nil {
+			return err
+		}
+		file = opened
+		destination = file
+		defer file.Close()
+	}
+	encoder := json.NewEncoder(destination)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func runValidate(arguments []string) error {
+	flags := flag.NewFlagSet("validate", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	version := flags.String("version", "", "semantic version without v")
+	directory := flags.String("dir", "", "directory containing en.md and zh-CN.md")
+	previous := flags.String("previous", "", "previous v-prefixed tag; empty for the initial release")
+	auditPath := flags.String("audit", "", "optional audit JSON report whose source set must match")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("validate accepts no positional arguments: %q", flags.Arg(0))
+	}
+	if *version == "" || *directory == "" {
+		return errors.New("validate requires --version and --dir")
+	}
+	if *auditPath == "" {
+		return validateReleaseDirectory(*directory, *version, *previous)
+	}
+	report, err := readAuditReport(*auditPath)
+	if err != nil {
+		return err
+	}
+	return validateSourceCoverage(*directory, *version, *previous, report)
+}
+
+// validateReleaseDirectory 检查可发布的双语版本文件。它不依赖网络，因此既可用于
+// 文档 CI，也可用于不可变 tag 的发布前门禁。
+func validateReleaseDirectory(directory, version, previous string) error {
+	english, err := readReleaseDocument(filepath.Join(directory, "en.md"), version, englishSectionOrder)
+	if err != nil {
+		return fmt.Errorf("English changelog: %w", err)
+	}
+	chinese, err := readReleaseDocument(filepath.Join(directory, "zh-CN.md"), version, chineseSectionOrder)
+	if err != nil {
+		return fmt.Errorf("Simplified Chinese changelog: %w", err)
+	}
+	if !sameStrings(english.sources, chinese.sources) {
+		return fmt.Errorf("bilingual source sets differ: English=%v SimplifiedChinese=%v", english.sources, chinese.sources)
+	}
+	if err := validateCompareLink(english.compare, version, previous); err != nil {
+		return fmt.Errorf("English Full Changelog: %w", err)
+	}
+	if err := validateCompareLink(chinese.compare, version, previous); err != nil {
+		return fmt.Errorf("Simplified Chinese Full Changelog: %w", err)
+	}
+	if english.compare != chinese.compare {
+		return fmt.Errorf("bilingual compare links differ: English=%q SimplifiedChinese=%q", english.compare, chinese.compare)
+	}
+	return nil
+}
+
+// validateSourceCoverage 将已经渲染的说明与审计报告逐项对照。它既能发现漏记的
+// PR/历史 direct commit，也拒绝无法由该版本审计报告解释的额外来源链接。
+func validateSourceCoverage(directory, version, previous string, report auditReport) error {
+	if err := validateReleaseDirectory(directory, version, previous); err != nil {
+		return err
+	}
+	english, err := readReleaseDocument(filepath.Join(directory, "en.md"), version, englishSectionOrder)
+	if err != nil {
+		return err
+	}
+	expected := make(map[string]struct{})
+	for _, source := range report.Sources {
+		if source.Kind == "pull_request" {
+			if source.Note == nil || source.Issue != "" {
+				return fmt.Errorf("audit source %s is not classified: %s", source.URL, source.Issue)
+			}
+			if source.Note.Category == "None" {
+				continue
+			}
+		}
+		expected[source.URL] = struct{}{}
+	}
+	for _, contributor := range report.NewContributors {
+		expected[contributor.PullURL] = struct{}{}
+	}
+	actual := make(map[string]struct{}, len(english.sources))
+	for _, source := range english.sources {
+		actual[source] = struct{}{}
+	}
+	for source := range expected {
+		if _, ok := actual[source]; !ok {
+			return fmt.Errorf("release notes does not cover audited source %s", source)
+		}
+	}
+	for source := range actual {
+		if _, ok := expected[source]; !ok {
+			return fmt.Errorf("release notes source %s is not present in the audit report", source)
+		}
+	}
+	return nil
+}
+
+var englishSectionOrder = []string{
+	"Breaking changes",
+	"Added",
+	"Changed",
+	"Fixed",
+	"Security",
+	"Documentation",
+	"Maintenance",
+	"New Contributors",
+}
+
+var chineseSectionOrder = []string{
+	"破坏性变更",
+	"新增",
+	"变更",
+	"修复",
+	"安全",
+	"文档",
+	"维护",
+	"新贡献者",
+}
+
+func readReleaseDocument(path, version string, sectionOrder []string) (releaseDocument, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return releaseDocument{}, err
+	}
+	content := strings.TrimSpace(string(body))
+	heading := releaseHeadingPattern.FindStringSubmatch(content)
+	if len(heading) != 2 || heading[1] != version {
+		return releaseDocument{}, fmt.Errorf("must start with heading for v%s", version)
+	}
+
+	matches := sectionPattern.FindAllStringSubmatchIndex(content, -1)
+	if len(matches) == 0 {
+		return releaseDocument{}, errors.New("has no release-note sections")
+	}
+	allowed := make(map[string]int, len(sectionOrder))
+	for index, name := range sectionOrder {
+		allowed[name] = index
+	}
+	document := releaseDocument{}
+	previousIndex := -1
+	for index, match := range matches {
+		name := strings.TrimSpace(content[match[2]:match[3]])
+		order, ok := allowed[name]
+		if !ok {
+			return releaseDocument{}, fmt.Errorf("contains unsupported section %q", name)
+		}
+		if order <= previousIndex {
+			return releaseDocument{}, fmt.Errorf("section %q is out of order", name)
+		}
+		previousIndex = order
+		end := len(content)
+		if index+1 < len(matches) {
+			end = matches[index+1][0]
+		}
+		entries := bulletEntries(content[match[1]:end])
+		if len(entries) == 0 {
+			return releaseDocument{}, fmt.Errorf("section %q has no entries", name)
+		}
+		for _, entry := range entries {
+			sources := sourcePattern.FindAllString(entry, -1)
+			if len(sources) == 0 {
+				return releaseDocument{}, fmt.Errorf("entry in section %q has no source link", name)
+			}
+			document.sources = append(document.sources, sources...)
+		}
+		document.sections = append(document.sections, releaseSection{name: name, entries: entries})
+	}
+
+	links := linkPattern.FindAllStringSubmatch(content, -1)
+	if len(links) != 1 {
+		return releaseDocument{}, errors.New("must contain exactly one Full Changelog link")
+	}
+	document.compare = links[0][1]
+	document.sources = sortedUnique(document.sources)
+	return document, nil
+}
+
+func bulletEntries(section string) []string {
+	lines := strings.Split(section, "\n")
+	entries := make([]string, 0)
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "- ") {
+			entries = append(entries, strings.TrimSpace(strings.TrimPrefix(line, "- ")))
+		}
+	}
+	return entries
+}
+
+func validateCompareLink(link, version, previous string) error {
+	if previous == "" {
+		expected := "https://github.com/FlanChanXwO/pixiv-cli/commits/v" + version
+		if link != expected {
+			return fmt.Errorf("got %q, want %q", link, expected)
+		}
+		return nil
+	}
+	expected := "https://github.com/FlanChanXwO/pixiv-cli/compare/" + previous + "...v" + version
+	if link != expected {
+		return fmt.Errorf("got %q, want %q", link, expected)
+	}
+	return nil
+}
+
+func sortedUnique(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	result := make([]string, 0, len(seen))
+	for value := range seen {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func sameStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+// parseReleaseNoteDeclaration 读取 PR 正文中的机器可读注释。注释不直接显示在
+// GitHub 页面上，既避免重复面向读者的描述，也能让 CI 在离线事件载荷中稳定校验。
+func parseReleaseNoteDeclaration(body string) (releaseNote, error) {
+	match := releaseNotePattern.FindStringSubmatch(body)
+	if len(match) != 2 {
+		return releaseNote{}, errors.New("missing release-note declaration")
+	}
+	values := make(map[string]string)
+	for _, rawLine := range strings.Split(match[1], "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			return releaseNote{}, fmt.Errorf("invalid release-note line %q", line)
+		}
+		key = strings.TrimSpace(key)
+		if _, exists := values[key]; exists {
+			return releaseNote{}, fmt.Errorf("release-note repeats %q", key)
+		}
+		values[key] = strings.TrimSpace(value)
+	}
+	for _, key := range []string{"category", "breaking", "summary", "none_reason"} {
+		if _, ok := values[key]; !ok {
+			return releaseNote{}, fmt.Errorf("release-note is missing %s", key)
+		}
+	}
+	for key := range values {
+		switch key {
+		case "category", "breaking", "summary", "none_reason":
+		default:
+			return releaseNote{}, fmt.Errorf("release-note contains unsupported key %q", key)
+		}
+	}
+	if _, ok := releaseNoteCategories[values["category"]]; !ok {
+		return releaseNote{}, fmt.Errorf("release-note has unsupported category %q", values["category"])
+	}
+	breaking, err := strconv.ParseBool(values["breaking"])
+	if err != nil {
+		return releaseNote{}, fmt.Errorf("release-note breaking: %w", err)
+	}
+	note := releaseNote{
+		Category:   values["category"],
+		Breaking:   breaking,
+		Summary:    values["summary"],
+		NoneReason: values["none_reason"],
+	}
+	if note.Summary == "" {
+		return releaseNote{}, errors.New("release-note summary is required")
+	}
+	if note.Category == "None" {
+		if note.Breaking {
+			return releaseNote{}, errors.New("release-note None category cannot be breaking")
+		}
+		if note.NoneReason == "" {
+			return releaseNote{}, errors.New("release-note none_reason is required for category None")
+		}
+	} else if note.NoneReason != "" {
+		return releaseNote{}, errors.New("release-note none_reason is only valid for category None")
+	}
+	return note, nil
+}
+
+var releaseNoteCategories = map[string]struct{}{
+	"Added":         {},
+	"Changed":       {},
+	"Fixed":         {},
+	"Security":      {},
+	"Documentation": {},
+	"Maintenance":   {},
+	"None":          {},
+}
+
+func recommendedVersionBump(notes []releaseNote) string {
+	bump := "none"
+	for _, note := range notes {
+		if note.Category == "None" {
+			continue
+		}
+		if note.Breaking {
+			return "major"
+		}
+		if note.Category == "Added" {
+			bump = "minor"
+			continue
+		}
+		if bump == "none" {
+			bump = "patch"
+		}
+	}
+	return bump
+}

--- a/scripts/releasenotes/main_test.go
+++ b/scripts/releasenotes/main_test.go
@@ -163,7 +163,7 @@ func TestRecommendedVersionBump(t *testing.T) {
 	}
 }
 
-func TestGitHubClientReadsPullRequestAndFirstExternalContributor(t *testing.T) {
+func TestGitHubClientReadsPullRequestAndFindsFirstMergedPullRequest(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
@@ -172,13 +172,23 @@ func TestGitHubClientReadsPullRequestAndFirstExternalContributor(t *testing.T) {
 			_ = json.NewEncoder(response).Encode([]githubPullRequest{{Number: 42}})
 		case "/repos/owner/project/pulls/42":
 			_ = json.NewEncoder(response).Encode(githubPullRequest{
-				Number:            42,
-				Title:             "feat: add APNG",
-				Body:              "<!-- release-note\ncategory: Added\nbreaking: false\nsummary: Add APNG output.\nnone_reason:\n-->",
-				HTMLURL:           "https://github.com/owner/project/pull/42",
-				AuthorAssociation: "FIRST_TIME_CONTRIBUTOR",
-				User:              githubUser{Login: "new-contributor", Type: "User"},
+				Number:  42,
+				Title:   "feat: add APNG",
+				Body:    "<!-- release-note\ncategory: Added\nbreaking: false\nsummary: Add APNG output.\nnone_reason:\n-->",
+				HTMLURL: "https://github.com/owner/project/pull/42",
+				User:    githubUser{Login: "new-contributor", Type: "User"},
 			})
+		case "/search/issues":
+			if got, want := request.URL.Query().Get("q"), "repo:owner/project type:pr author:new-contributor is:merged"; got != want {
+				t.Fatalf("search query = %q, want %q", got, want)
+			}
+			if got, want := request.URL.Query().Get("sort"), "created"; got != want {
+				t.Fatalf("search sort = %q, want %q", got, want)
+			}
+			if got, want := request.URL.Query().Get("order"), "asc"; got != want {
+				t.Fatalf("search order = %q, want %q", got, want)
+			}
+			_ = json.NewEncoder(response).Encode(githubPullRequestSearchResult{Items: []githubPullRequest{{Number: 42}}})
 		default:
 			t.Fatalf("unexpected GitHub API path %q", request.URL.Path)
 		}
@@ -197,8 +207,15 @@ func TestGitHubClientReadsPullRequestAndFirstExternalContributor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pull request: %v", err)
 	}
-	if !isNewExternalContributor(pull, "owner") {
-		t.Fatalf("pull %#v should be a new external contributor", pull)
+	if !isExternalContributor(pull, "owner") {
+		t.Fatalf("pull %#v should be an eligible external contributor", pull)
+	}
+	first, err := client.firstMergedPullRequest(context.Background(), "owner/project", pull.User.Login)
+	if err != nil {
+		t.Fatalf("first merged pull request: %v", err)
+	}
+	if first.Number != pull.Number {
+		t.Fatalf("first merged pull = %#v, want #%d", first, pull.Number)
 	}
 	if _, err := parseReleaseNoteDeclaration(pull.Body); err != nil {
 		t.Fatalf("parse pull release note: %v", err)
@@ -209,13 +226,15 @@ func TestNewContributorExcludesOwnerAndBots(t *testing.T) {
 	t.Parallel()
 
 	for _, pull := range []githubPullRequest{
-		{AuthorAssociation: "FIRST_TIME_CONTRIBUTOR", User: githubUser{Login: "owner", Type: "User"}},
-		{AuthorAssociation: "FIRST_TIME_CONTRIBUTOR", User: githubUser{Login: "dependabot[bot]", Type: "Bot"}},
-		{AuthorAssociation: "CONTRIBUTOR", User: githubUser{Login: "other", Type: "User"}},
+		{User: githubUser{Login: "owner", Type: "User"}},
+		{User: githubUser{Login: "dependabot[bot]", Type: "Bot"}},
 	} {
-		if isNewExternalContributor(pull, "owner") {
+		if isExternalContributor(pull, "owner") {
 			t.Fatalf("pull %#v must not be listed as a new external contributor", pull)
 		}
+	}
+	if !isExternalContributor(githubPullRequest{User: githubUser{Login: "other", Type: "User"}}, "owner") {
+		t.Fatal("an external user should be eligible before historical PR lookup")
 	}
 }
 

--- a/scripts/releasenotes/main_test.go
+++ b/scripts/releasenotes/main_test.go
@@ -1,0 +1,442 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateAcceptsMatchingBilingualReleaseNotes(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeReleaseNote(t, root, "en.md", `# v1.2.0 — 2026-07-30
+
+## Added
+
+- Added APNG output. ([#42](https://github.com/FlanChanXwO/pixiv-cli/pull/42))
+
+**Full Changelog**: [v1.1.0...v1.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.1.0...v1.2.0)
+`)
+	writeReleaseNote(t, root, "zh-CN.md", `# v1.2.0 — 2026-07-30
+
+## 新增
+
+- 新增 APNG 输出。([#42](https://github.com/FlanChanXwO/pixiv-cli/pull/42))
+
+**完整变更**：[v1.1.0...v1.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.1.0...v1.2.0)
+`)
+
+	if err := validateReleaseDirectory(root, "1.2.0", "v1.1.0"); err != nil {
+		t.Fatalf("validate release directory: %v", err)
+	}
+}
+
+func TestValidateRejectsMissingEntrySource(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeReleaseNote(t, root, "en.md", `# v1.2.0 — 2026-07-30
+
+## Fixed
+
+- Fixed an issue without an attribution.
+
+**Full Changelog**: [v1.1.0...v1.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.1.0...v1.2.0)
+`)
+	writeReleaseNote(t, root, "zh-CN.md", `# v1.2.0 — 2026-07-30
+
+## 修复
+
+- 修复未标注来源的问题。
+
+**完整变更**：[v1.1.0...v1.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.1.0...v1.2.0)
+`)
+
+	err := validateReleaseDirectory(root, "1.2.0", "v1.1.0")
+	if err == nil || !strings.Contains(err.Error(), "source") {
+		t.Fatalf("validate error = %v, want missing source error", err)
+	}
+}
+
+func TestValidateRejectsMismatchedBilingualSources(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeReleaseNote(t, root, "en.md", `# v1.2.0 — 2026-07-30
+
+## Changed
+
+- Changed output. ([#42](https://github.com/FlanChanXwO/pixiv-cli/pull/42))
+
+**Full Changelog**: [v1.1.0...v1.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.1.0...v1.2.0)
+`)
+	writeReleaseNote(t, root, "zh-CN.md", `# v1.2.0 — 2026-07-30
+
+## 变更
+
+- 修改输出。([#43](https://github.com/FlanChanXwO/pixiv-cli/pull/43))
+
+**完整变更**：[v1.1.0...v1.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.1.0...v1.2.0)
+`)
+
+	err := validateReleaseDirectory(root, "1.2.0", "v1.1.0")
+	if err == nil || !strings.Contains(err.Error(), "source sets differ") {
+		t.Fatalf("validate error = %v, want bilingual source mismatch", err)
+	}
+}
+
+func TestValidateAcceptsInitialReleaseCommitLink(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	entry := "([`abcdef0`](https://github.com/FlanChanXwO/pixiv-cli/commit/abcdef0123456789))"
+	writeReleaseNote(t, root, "en.md", "# v1.0.0 — 2026-07-30\n\n## Added\n\n- First release. "+entry+"\n\n**Full Changelog**: [v1.0.0 commits](https://github.com/FlanChanXwO/pixiv-cli/commits/v1.0.0)\n")
+	writeReleaseNote(t, root, "zh-CN.md", "# v1.0.0 — 2026-07-30\n\n## 新增\n\n- 首次发布。"+entry+"\n\n**完整变更**：[v1.0.0 commits](https://github.com/FlanChanXwO/pixiv-cli/commits/v1.0.0)\n")
+
+	if err := validateReleaseDirectory(root, "1.0.0", ""); err != nil {
+		t.Fatalf("validate initial release: %v", err)
+	}
+}
+
+func TestParseReleaseNoteDeclaration(t *testing.T) {
+	t.Parallel()
+
+	note, err := parseReleaseNoteDeclaration(`
+## Summary
+
+Implemented a user-visible change.
+
+<!-- release-note
+category: Changed
+breaking: true
+summary: Reworked the download request contract.
+none_reason:
+-->
+`)
+	if err != nil {
+		t.Fatalf("parse declaration: %v", err)
+	}
+	if note.Category != "Changed" || !note.Breaking || note.Summary != "Reworked the download request contract." {
+		t.Fatalf("release note = %#v", note)
+	}
+}
+
+func TestParseReleaseNoteDeclarationRequiresNoneReason(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseReleaseNoteDeclaration(`<!-- release-note
+category: None
+breaking: false
+summary: No release entry.
+none_reason:
+-->`)
+	if err == nil || !strings.Contains(err.Error(), "none_reason") {
+		t.Fatalf("parse error = %v, want none_reason validation", err)
+	}
+}
+
+func TestRecommendedVersionBump(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name  string
+		notes []releaseNote
+		want  string
+	}{
+		{name: "maintenance", notes: []releaseNote{{Category: "Maintenance", Summary: "Refresh CI."}}, want: "patch"},
+		{name: "feature", notes: []releaseNote{{Category: "Added", Summary: "Add APNG."}}, want: "minor"},
+		{name: "breaking", notes: []releaseNote{{Category: "Changed", Breaking: true, Summary: "Change output."}}, want: "major"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := recommendedVersionBump(test.notes); got != test.want {
+				t.Fatalf("recommended bump = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestGitHubClientReadsPullRequestAndFirstExternalContributor(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/repos/owner/project/commits/abcdef012345/pulls":
+			_ = json.NewEncoder(response).Encode([]githubPullRequest{{Number: 42}})
+		case "/repos/owner/project/pulls/42":
+			_ = json.NewEncoder(response).Encode(githubPullRequest{
+				Number:            42,
+				Title:             "feat: add APNG",
+				Body:              "<!-- release-note\ncategory: Added\nbreaking: false\nsummary: Add APNG output.\nnone_reason:\n-->",
+				HTMLURL:           "https://github.com/owner/project/pull/42",
+				AuthorAssociation: "FIRST_TIME_CONTRIBUTOR",
+				User:              githubUser{Login: "new-contributor", Type: "User"},
+			})
+		default:
+			t.Fatalf("unexpected GitHub API path %q", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := githubClient{baseURL: server.URL, client: server.Client()}
+	pulls, err := client.pullRequestsForCommit(context.Background(), "owner/project", "abcdef012345")
+	if err != nil {
+		t.Fatalf("pull requests for commit: %v", err)
+	}
+	if len(pulls) != 1 || pulls[0].Number != 42 {
+		t.Fatalf("pulls = %#v", pulls)
+	}
+	pull, err := client.pullRequest(context.Background(), "owner/project", 42)
+	if err != nil {
+		t.Fatalf("pull request: %v", err)
+	}
+	if !isNewExternalContributor(pull, "owner") {
+		t.Fatalf("pull %#v should be a new external contributor", pull)
+	}
+	if _, err := parseReleaseNoteDeclaration(pull.Body); err != nil {
+		t.Fatalf("parse pull release note: %v", err)
+	}
+}
+
+func TestNewContributorExcludesOwnerAndBots(t *testing.T) {
+	t.Parallel()
+
+	for _, pull := range []githubPullRequest{
+		{AuthorAssociation: "FIRST_TIME_CONTRIBUTOR", User: githubUser{Login: "owner", Type: "User"}},
+		{AuthorAssociation: "FIRST_TIME_CONTRIBUTOR", User: githubUser{Login: "dependabot[bot]", Type: "Bot"}},
+		{AuthorAssociation: "CONTRIBUTOR", User: githubUser{Login: "other", Type: "User"}},
+	} {
+		if isNewExternalContributor(pull, "owner") {
+			t.Fatalf("pull %#v must not be listed as a new external contributor", pull)
+		}
+	}
+}
+
+func TestPrepareRendersBilingualNotesAndIndex(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeReleaseNote(t, root, "README.md", "# Changelog\n\n| Version | Date | Release notes |\n| --- | --- | --- |\n| Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n| [v1.0.0](https://github.com/FlanChanXwO/pixiv-cli/commits/v1.0.0) | 2026-01-01 | [English](v1.0.0/en.md) · [简体中文](v1.0.0/zh-CN.md) |\n")
+	writeReleaseNote(t, root, "README.zh-CN.md", "# 更新日志\n\n| 版本 | 日期 | 发布说明 |\n| --- | --- | --- |\n| Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n| [v1.0.0](https://github.com/FlanChanXwO/pixiv-cli/commits/v1.0.0) | 2026-01-01 | [English](v1.0.0/en.md) · [简体中文](v1.0.0/zh-CN.md) |\n")
+	planPath := filepath.Join(root, "plan.json")
+	plan := preparePlan{Entries: []preparedEntry{{
+		Category: "Added",
+		English:  "Add APNG downloads.",
+		Chinese:  "新增 APNG 下载。",
+		Sources:  []string{"https://github.com/FlanChanXwO/pixiv-cli/pull/42"},
+	}}, NewContributors: []newContributor{{
+		Login: "new-contributor", ProfileURL: "https://github.com/new-contributor", PullNumber: 42, PullURL: "https://github.com/FlanChanXwO/pixiv-cli/pull/42",
+	}}}
+	writeJSONFile(t, planPath, plan)
+
+	if err := prepareRelease(prepareConfig{Version: "1.1.0", Previous: "v1.0.0", Date: "2026-07-30", ChangelogRoot: root, PlanPath: planPath, Apply: true}); err != nil {
+		t.Fatalf("prepare release: %v", err)
+	}
+	if err := validateReleaseDirectory(filepath.Join(root, "v1.1.0"), "1.1.0", "v1.0.0"); err != nil {
+		t.Fatalf("validate prepared notes: %v", err)
+	}
+	english, err := os.ReadFile(filepath.Join(root, "v1.1.0", "en.md"))
+	if err != nil {
+		t.Fatalf("read English notes: %v", err)
+	}
+	if !strings.Contains(string(english), "## New Contributors") || !strings.Contains(string(english), "[@new-contributor](https://github.com/new-contributor) made their first contribution in [#42]") {
+		t.Fatalf("English notes missing contributor: %s", english)
+	}
+	index, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	if !strings.Contains(string(index), "| [v1.1.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.0.0...v1.1.0) | 2026-07-30") {
+		t.Fatalf("index missing new release row: %s", index)
+	}
+}
+
+func TestPrepareRejectsRepeatedSource(t *testing.T) {
+	t.Parallel()
+
+	plan := preparePlan{Entries: []preparedEntry{{
+		Category: "Added", English: "Add one.", Chinese: "新增一。", Sources: []string{
+			"https://github.com/FlanChanXwO/pixiv-cli/pull/42",
+			"https://github.com/FlanChanXwO/pixiv-cli/pull/42",
+		},
+	}}}
+	if err := validatePreparePlan(plan); err == nil || !strings.Contains(err.Error(), "repeats source") {
+		t.Fatalf("validate plan error = %v, want repeated source error", err)
+	}
+}
+
+func TestValidateCoverageRejectsMissingAuditSource(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeReleaseNote(t, root, "en.md", `# v1.2.0 — 2026-07-30
+
+## Added
+
+- Added one. ([#42](https://github.com/FlanChanXwO/pixiv-cli/pull/42))
+
+**Full Changelog**: [v1.1.0...v1.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.1.0...v1.2.0)
+`)
+	writeReleaseNote(t, root, "zh-CN.md", `# v1.2.0 — 2026-07-30
+
+## 新增
+
+- 新增一。([#42](https://github.com/FlanChanXwO/pixiv-cli/pull/42))
+
+**完整变更**：[v1.1.0...v1.2.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.1.0...v1.2.0)
+`)
+	report := auditReport{Sources: []auditSource{
+		{Kind: "pull_request", URL: "https://github.com/FlanChanXwO/pixiv-cli/pull/42", Note: &releaseNote{Category: "Added", Summary: "Add one."}},
+		{Kind: "pull_request", URL: "https://github.com/FlanChanXwO/pixiv-cli/pull/43", Note: &releaseNote{Category: "Fixed", Summary: "Fix two."}},
+	}}
+	if err := validateSourceCoverage(root, "1.2.0", "v1.1.0", report); err == nil || !strings.Contains(err.Error(), "does not cover") {
+		t.Fatalf("source coverage error = %v, want missing source error", err)
+	}
+}
+
+func TestPreparePlanRequiresAuditedNewContributor(t *testing.T) {
+	t.Parallel()
+
+	plan := preparePlan{Entries: []preparedEntry{{
+		Category: "Added", English: "Add one.", Chinese: "新增一。", Sources: []string{"https://github.com/FlanChanXwO/pixiv-cli/pull/42"},
+	}}}
+	report := auditReport{
+		Sources:         []auditSource{{Kind: "pull_request", URL: "https://github.com/FlanChanXwO/pixiv-cli/pull/42", Note: &releaseNote{Category: "Added", Summary: "Add one."}}},
+		NewContributors: []newContributor{{Login: "new-contributor", ProfileURL: "https://github.com/new-contributor", PullNumber: 42, PullURL: "https://github.com/FlanChanXwO/pixiv-cli/pull/42"}},
+	}
+	if err := validatePlanCoverage(plan, report); err == nil || !strings.Contains(err.Error(), "new contributor") {
+		t.Fatalf("plan coverage error = %v, want missing contributor error", err)
+	}
+}
+
+func TestPRValidateReadsEventPayload(t *testing.T) {
+	t.Parallel()
+
+	eventPath := filepath.Join(t.TempDir(), "event.json")
+	writeJSONFile(t, eventPath, map[string]any{"pull_request": map[string]any{"body": "<!-- release-note\ncategory: Documentation\nbreaking: false\nsummary: Clarify the release workflow.\nnone_reason:\n-->"}})
+	if err := validatePullRequestEvent(eventPath); err != nil {
+		t.Fatalf("validate PR event: %v", err)
+	}
+}
+
+func TestSyncHistoryDryRunAndApplyPreservesAssets(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	writeReleaseNote(t, directory, "en.md", "# v1.1.0 — 2026-07-30\n\n## Added\n\n- Added one. ([#42](https://github.com/FlanChanXwO/pixiv-cli/pull/42))\n\n**Full Changelog**: [v1.0.0...v1.1.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.0.0...v1.1.0)\n")
+	writeReleaseNote(t, directory, "zh-CN.md", "# v1.1.0 — 2026-07-30\n\n## 新增\n\n- 新增一。([#42](https://github.com/FlanChanXwO/pixiv-cli/pull/42))\n\n**完整变更**：[v1.0.0...v1.1.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.0.0...v1.1.0)\n")
+	var releaseBody string
+	var patchCount int
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.Method == http.MethodGet && request.URL.Path == "/repos/owner/project/releases/tags/v1.1.0":
+			_ = json.NewEncoder(response).Encode(githubRelease{ID: 99, TagName: "v1.1.0", Body: releaseBody, Assets: []githubReleaseAsset{{Name: "pixiv-cli.tar.gz"}}})
+		case request.Method == http.MethodPatch && request.URL.Path == "/repos/owner/project/releases/99":
+			patchCount++
+			var payload githubReleaseWrite
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode patch: %v", err)
+			}
+			releaseBody = payload.Body
+			response.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(response).Encode(githubRelease{ID: 99, TagName: "v1.1.0", Body: releaseBody, Assets: []githubReleaseAsset{{Name: "pixiv-cli.tar.gz"}}})
+		default:
+			t.Fatalf("unexpected %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	config := syncHistoryConfig{Repository: "owner/project", Version: "1.1.0", Directory: directory, Client: githubClient{baseURL: server.URL, client: server.Client()}}
+	if err := syncHistoricalRelease(context.Background(), config); err != nil {
+		t.Fatalf("dry-run sync: %v", err)
+	}
+	if patchCount != 0 {
+		t.Fatalf("dry-run patched %d times", patchCount)
+	}
+	config.Apply = true
+	if err := syncHistoricalRelease(context.Background(), config); err != nil {
+		t.Fatalf("apply sync: %v", err)
+	}
+	if patchCount != 1 || !strings.Contains(releaseBody, "# English") || !strings.Contains(releaseBody, "# 简体中文") {
+		t.Fatalf("sync result patchCount=%d body=%q", patchCount, releaseBody)
+	}
+}
+
+func TestSyncHistoryCreatesMissingHistoricalReleaseWithoutAssets(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	writeReleaseNote(t, directory, "en.md", "# v0.4.0 — 2026-07-18\n\n## Maintenance\n\n- Historical maintenance. ([`abcdef0`](https://github.com/FlanChanXwO/pixiv-cli/commit/abcdef0123456789))\n\n**Full Changelog**: [v0.3.0...v0.4.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.0)\n")
+	writeReleaseNote(t, directory, "zh-CN.md", "# v0.4.0 — 2026-07-18\n\n## 维护\n\n- 历史维护。([`abcdef0`](https://github.com/FlanChanXwO/pixiv-cli/commit/abcdef0123456789))\n\n**完整变更**：[v0.3.0...v0.4.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.3.0...v0.4.0)\n")
+	var created githubReleaseWrite
+	var createdRelease githubRelease
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.Method == http.MethodGet && request.URL.Path == "/repos/owner/project/releases/tags/v0.4.0" && createdRelease.ID == 0:
+			response.WriteHeader(http.StatusNotFound)
+			_, _ = response.Write([]byte(`{"message":"Not Found"}`))
+		case request.Method == http.MethodPost && request.URL.Path == "/repos/owner/project/releases":
+			if err := json.NewDecoder(request.Body).Decode(&created); err != nil {
+				t.Fatalf("decode create: %v", err)
+			}
+			createdRelease = githubRelease{ID: 40, TagName: created.TagName, Name: created.Name, Body: created.Body}
+			_ = json.NewEncoder(response).Encode(createdRelease)
+		case request.Method == http.MethodGet && request.URL.Path == "/repos/owner/project/releases/tags/v0.4.0":
+			_ = json.NewEncoder(response).Encode(createdRelease)
+		default:
+			t.Fatalf("unexpected %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	err := syncHistoricalRelease(context.Background(), syncHistoryConfig{
+		Repository: "owner/project", Version: "0.4.0", Directory: directory, Apply: true,
+		Client: githubClient{baseURL: server.URL, client: server.Client()},
+	})
+	if err != nil {
+		t.Fatalf("create historical release: %v", err)
+	}
+	if created.TagName != "v0.4.0" || created.Name != "v0.4.0" || created.Draft || strings.Contains(created.Body, "assets") {
+		t.Fatalf("created release payload = %#v", created)
+	}
+}
+
+func writeJSONFile(t *testing.T, path string, value any) {
+	t.Helper()
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestRenderSourceLink(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct{ source, want string }{
+		{"https://github.com/FlanChanXwO/pixiv-cli/pull/42", "[#42](https://github.com/FlanChanXwO/pixiv-cli/pull/42)"},
+		{"https://github.com/FlanChanXwO/pixiv-cli/commit/abcdef0123456789", "[`abcdef0`](https://github.com/FlanChanXwO/pixiv-cli/commit/abcdef0123456789)"},
+	} {
+		if got, err := renderSourceLink(test.source); err != nil || got != test.want {
+			t.Fatalf("render source %q = %q, %v; want %q", test.source, got, err, test.want)
+		}
+	}
+	if _, err := renderSourceLink(fmt.Sprintf("https://example.com/%d", 42)); err == nil {
+		t.Fatal("unsupported source must fail")
+	}
+}
+
+func writeReleaseNote(t *testing.T, root, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}

--- a/scripts/releaseworkflow/build_recovery_test.go
+++ b/scripts/releaseworkflow/build_recovery_test.go
@@ -334,7 +334,11 @@ func TestCheckWorkflowRejectsProductionIsolationMutations(t *testing.T) {
 			requireMappingValue(t, requireMappingValue(t, upload, "with"), "name").Value = "test-gate-${{ matrix.artifact }}"
 		}},
 		{name: "verify bypasses production", mutate: func(t *testing.T, root *yaml.Node) {
-			requireMappingValue(t, jobNode(t, root, "verify_release_source"), "needs").Value = "build"
+			needs := requireMappingValue(t, jobNode(t, root, "verify_release_source"), "needs")
+			needs.Kind = yaml.ScalarNode
+			needs.Tag = "!!str"
+			needs.Value = "build"
+			needs.Content = nil
 		}},
 		{name: "publish downloads test artifacts", mutate: func(t *testing.T, root *yaml.Node) {
 			steps := requireMappingValue(t, jobNode(t, root, "publish"), "steps")

--- a/scripts/releaseworkflow/main.go
+++ b/scripts/releaseworkflow/main.go
@@ -93,7 +93,7 @@ func checkWorkflow(body []byte) error {
 	if !ok || jobs.Kind != yaml.MappingNode {
 		return errors.New("workflow must have a jobs mapping")
 	}
-	if err := requireOnlyMappingKeys(jobs, "validate", "e2e", "build", "build_production", "verify_release_source", "publish", "render_homebrew_formula", "verify_homebrew_formula", "deploy_homebrew_tap"); err != nil {
+	if err := requireOnlyMappingKeys(jobs, "validate", "e2e", "build", "build_production", "release_notes_audit", "verify_release_source", "publish", "render_homebrew_formula", "verify_homebrew_formula", "deploy_homebrew_tap"); err != nil {
 		return fmt.Errorf("workflow jobs: %w", err)
 	}
 	validate, ok := workflowpolicy.MappingValue(jobs, "validate")
@@ -111,6 +111,10 @@ func checkWorkflow(body []byte) error {
 	productionBuild, ok := workflowpolicy.MappingValue(jobs, "build_production")
 	if !ok || productionBuild.Kind != yaml.MappingNode {
 		return errors.New("workflow must have a build_production job")
+	}
+	releaseNotesAudit, ok := workflowpolicy.MappingValue(jobs, "release_notes_audit")
+	if !ok || releaseNotesAudit.Kind != yaml.MappingNode {
+		return errors.New("workflow must have a release_notes_audit job")
 	}
 	verifyReleaseSource, ok := workflowpolicy.MappingValue(jobs, "verify_release_source")
 	if !ok || verifyReleaseSource.Kind != yaml.MappingNode {
@@ -135,7 +139,7 @@ func checkWorkflow(body []byte) error {
 	// 先报告任何越界 secret 引用，避免后续 checkout 形状校验掩盖真实的凭据泄露风险。
 	preflightPublishSteps, _ := jobSteps(publish)
 	preflightSigningIndex, _ := signingStepIndex(preflightPublishSteps)
-	if err := checkSigningSecretReachability(validate, build, productionBuild, verifyReleaseSource, publish, preflightPublishSteps, preflightSigningIndex); err != nil {
+	if err := checkSigningSecretReachability(validate, build, productionBuild, releaseNotesAudit, verifyReleaseSource, publish, preflightPublishSteps, preflightSigningIndex); err != nil {
 		return err
 	}
 	if err := checkE2ESecretReachability(e2e); err != nil {
@@ -159,6 +163,9 @@ func checkWorkflow(body []byte) error {
 	if err := checkRecoveryPolicy(root); err != nil {
 		return err
 	}
+	if err := checkReleaseNotesAuditJob(releaseNotesAudit); err != nil {
+		return err
+	}
 	if err := checkVerifyReleaseSourceJob(verifyReleaseSource); err != nil {
 		return err
 	}
@@ -166,7 +173,7 @@ func checkWorkflow(body []byte) error {
 	if err != nil {
 		return err
 	}
-	if err := checkSigningSecretReachability(validate, build, productionBuild, verifyReleaseSource, publish, publishSteps, signingIndex); err != nil {
+	if err := checkSigningSecretReachability(validate, build, productionBuild, releaseNotesAudit, verifyReleaseSource, publish, publishSteps, signingIndex); err != nil {
 		return err
 	}
 	if err := checkRenderHomebrewJob(renderHomebrew); err != nil {

--- a/scripts/releaseworkflow/publish_policy.go
+++ b/scripts/releaseworkflow/publish_policy.go
@@ -20,7 +20,7 @@ func checkVerifyReleaseSourceJob(job *yaml.Node) error {
 	if err := requireOnlyMappingKeys(job, "name", "needs", "runs-on", "permissions", "steps"); err != nil {
 		return fmt.Errorf("verify_release_source job: %w", err)
 	}
-	if err := workflowpolicy.RequireScalar(job, "needs", "build_production"); err != nil {
+	if err := requireExactStringSequence(job, "needs", "build_production", "release_notes_audit"); err != nil {
 		return fmt.Errorf("verify_release_source job: %w", err)
 	}
 	if err := workflowpolicy.RequireScalar(job, "runs-on", "ubuntu-24.04"); err != nil {
@@ -330,11 +330,11 @@ func requireApprovedChannelCaseCommands(commands []string, channelCase string) e
 	return nil
 }
 
-func checkSigningSecretReachability(validate, build, productionBuild, verifyReleaseSource, publish *yaml.Node, publishSteps []*yaml.Node, signingIndex int) error {
+func checkSigningSecretReachability(validate, build, productionBuild, releaseNotesAudit, verifyReleaseSource, publish *yaml.Node, publishSteps []*yaml.Node, signingIndex int) error {
 	// release Environment 的 secret 只应在 verify_release_source 成功后才由 publish job 注入；
 	// 非发布 job、publish 的 job 级字段和非签名 step 都不允许引用 secrets，防止同一 job
 	// 启动即注入的 credential 在 shell gate 或其它步骤被提前访问。
-	for _, job := range []*yaml.Node{validate, build, productionBuild, verifyReleaseSource} {
+	for _, job := range []*yaml.Node{validate, build, productionBuild, releaseNotesAudit, verifyReleaseSource} {
 		if workflowpolicy.ContainsSecretReference(job) {
 			return errors.New("non-release job must not reference secrets")
 		}

--- a/scripts/releaseworkflow/release_notes_policy.go
+++ b/scripts/releaseworkflow/release_notes_policy.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/FlanChanXwO/pixiv-cli/scripts/internal/workflowpolicy"
+	"gopkg.in/yaml.v3"
+)
+
+// checkReleaseNotesAuditJob 将来源审计固定在受保护 publish job 之前。该 job
+// 只有读取提交、PR 元数据和 tag 内说明所需的权限，不能读取发布签名 secret。
+func checkReleaseNotesAuditJob(job *yaml.Node) error {
+	const auditCommands = `
+set -euo pipefail
+previous_tag=$(git tag --merged "$RELEASE_TAG^" --sort=-version:refname | head -n 1)
+test -n "$previous_tag"
+audit_report="$RUNNER_TEMP/release-notes-audit.json"
+go run ./scripts/releasenotes audit \
+--repo "$GITHUB_REPOSITORY" \
+--from "$previous_tag" \
+--to "$RELEASE_TAG" \
+--require-classified \
+--output "$audit_report"
+go run ./scripts/releasenotes validate \
+--version "${RELEASE_TAG#v}" \
+--dir "changelog/$RELEASE_TAG" \
+--previous "$previous_tag" \
+--audit "$audit_report"`
+
+	if err := requireRequiredJobExecution(job, "release_notes_audit job"); err != nil {
+		return err
+	}
+	if err := requireNoEnvironment(job, "release_notes_audit job"); err != nil {
+		return err
+	}
+	if err := requireOnlyMappingKeys(job, "name", "needs", "runs-on", "permissions", "steps"); err != nil {
+		return fmt.Errorf("release_notes_audit job: %w", err)
+	}
+	if err := workflowpolicy.RequireScalar(job, "name", "Audit release notes provenance"); err != nil {
+		return fmt.Errorf("release_notes_audit job: %w", err)
+	}
+	if err := workflowpolicy.RequireScalar(job, "needs", "build_production"); err != nil {
+		return fmt.Errorf("release_notes_audit job: %w", err)
+	}
+	if err := workflowpolicy.RequireScalar(job, "runs-on", "ubuntu-24.04"); err != nil {
+		return fmt.Errorf("release_notes_audit job: %w", err)
+	}
+	permissions, ok := workflowpolicy.MappingValue(job, "permissions")
+	if !ok || !workflowpolicy.HasExactMappingKeys(permissions, "contents", "pull-requests") ||
+		workflowpolicy.RequireScalar(permissions, "contents", "read") != nil ||
+		workflowpolicy.RequireScalar(permissions, "pull-requests", "read") != nil {
+		return errors.New("release_notes_audit job permissions must contain only contents: read and pull-requests: read")
+	}
+	steps, err := jobSteps(job)
+	if err != nil || len(steps) != 3 {
+		return errors.New("release_notes_audit job must contain only checkout, Go setup, and the source audit")
+	}
+	if err := requireCanonicalCheckout(steps[0], "release_notes_audit job", checkoutWithRequirement{"fetch-depth", "0"}, checkoutWithRequirement{"persist-credentials", "false"}, checkoutWithRequirement{"ref", "${{ env.RELEASE_TAG }}"}); err != nil {
+		return err
+	}
+	if err := requireExactActionStep(steps[1], "release_notes_audit Go setup", setupGoAction, map[string]string{"go-version": "1.26.3"}); err != nil {
+		return err
+	}
+	if err := requireOnlyMappingKeys(steps[2], "name", "shell", "env", "run"); err != nil ||
+		workflowpolicy.RequireScalar(steps[2], "name", "Audit release-note sources and validate the bilingual tag notes") != nil ||
+		workflowpolicy.RequireScalar(steps[2], "shell", "bash") != nil ||
+		!equalCommands(splitCommands(requireRunValue(steps[2])), splitCommands(auditCommands)) {
+		return errors.New("release_notes_audit job must run the canonical direct audit commands")
+	}
+	env, ok := workflowpolicy.MappingValue(steps[2], "env")
+	if !ok || !workflowpolicy.HasExactMappingKeys(env, "GH_TOKEN") || workflowpolicy.RequireScalar(env, "GH_TOKEN", "${{ github.token }}") != nil {
+		return errors.New("release_notes_audit job must use only the ephemeral GitHub token")
+	}
+	return nil
+}

--- a/scripts/releaseworkflow/release_notes_policy_test.go
+++ b/scripts/releaseworkflow/release_notes_policy_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCheckWorkflowRejectsReleaseNotesAuditPrivilegeOrDependencyChanges(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name   string
+		want   string
+		mutate func(t *testing.T, root *yaml.Node)
+	}{
+		{
+			name: "permission elevated",
+			want: "permissions must contain only contents: read and pull-requests: read",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				t.Helper()
+				requireMappingValue(t, requireMappingValue(t, jobNode(t, root, "release_notes_audit"), "permissions"), "contents").Value = "write"
+			},
+		},
+		{
+			name: "secret reference",
+			want: "non-release job must not reference secrets",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				t.Helper()
+				step := requireMappingValue(t, jobNode(t, root, "release_notes_audit"), "steps").Content[2]
+				appendMappingValue(t, step, "extra", scalarNode("${{ secrets.RELEASE_SIGNING_PRIVATE_KEY }}"))
+			},
+		},
+		{
+			name: "verify no longer needs audit",
+			want: "needs must equal",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				t.Helper()
+				needs := requireMappingValue(t, jobNode(t, root, "verify_release_source"), "needs")
+				needs.Content = needs.Content[:1]
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := releaseWorkflowRoot(t)
+			test.mutate(t, root)
+			err := checkWorkflow(mustMarshalYAML(t, root))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("policy error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add audited bilingual release-note generation, validation, and historical Release synchronization
- backfill all v0.1.0 through v0.8.0 notes, including v0.4.0 and v0.4.1
- gate release publication on immutable-tag provenance and PR release-note metadata
- clarify Skill installation, account sign-in, and account-information guidance in all README locales

## Scope and compatibility

Release governance, documentation, and historical GitHub Release body formatting change. CLI, MCP, SDK, and authentication behavior are unchanged.

## Verification

```text
go test ./... -count=1
sh scripts/build.sh
sh scripts/test-package-release.sh
sh scripts/test-homebrew-prepublish-workflow.sh
sh scripts/test-release-workflow.sh
pre-commit run --all-files
```

<!-- release-note
category: Documentation
breaking: false
summary: Add auditable release-note automation and clarify account guidance.
none_reason:
-->