### PR TITLE
docs: localize contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
-name: Bug report
-description: Report a reproducible problem in the CLI, MCP server, or public Go SDK.
+name: Bug report / Bug 报告 / バグ報告
+description: Report a reproducible problem in the CLI, MCP server, or public Go SDK. / 报告 CLI、MCP server 或 public Go SDK 中可复现的问题。 / CLI、MCP server、または public Go SDK で再現できる問題を報告します。
 title: "[Bug]: "
 labels:
   - bug
@@ -7,21 +7,23 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to report a problem. Remove or redact refresh tokens, cookies, proxy credentials, private URLs, downloaded work, and private API responses before submitting.
+        English: Thank you for taking the time to report a problem. Remove or redact refresh tokens, cookies, proxy credentials, private URLs, downloaded work, and private API responses before submitting.
+        中文：感谢你报告问题。提交前请删除或脱敏 refresh token、cookie、代理凭据、私有 URL、下载作品和私有 API 响应。
+        日本語：問題の報告ありがとうございます。送信前に refresh token、cookie、proxy credential、private URL、downloaded work、private API response を削除またはマスクしてください。
 
   - type: textarea
     id: summary
     attributes:
-      label: What happened?
-      description: Describe the observed behavior and why it is incorrect.
+      label: What happened? / 发生了什么？ / 何が起きましたか？
+      description: Describe the observed behavior and why it is incorrect. / 请描述观察到的行为及其不正确的原因。 / 観測した動作と、それが正しくない理由を説明してください。
     validations:
       required: true
 
   - type: textarea
     id: reproduction
     attributes:
-      label: Reproduction steps
-      description: Provide the smallest safe sequence that reproduces the problem. Use placeholder IDs or redacted values when needed.
+      label: Reproduction steps / 复现步骤 / 再現手順
+      description: Provide the smallest safe sequence that reproduces the problem. Use placeholder IDs or redacted values when needed. / 请提供可复现问题的最小安全步骤；必要时使用占位 ID 或脱敏值。 / 問題を再現する最小限で安全な手順を示してください。必要に応じてプレースホルダー ID またはマスク済みの値を使用します。
       placeholder: |
         1. Run `pixiv ...`
         2. Provide the redacted input or configuration
@@ -32,34 +34,34 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: Expected behavior
-      description: Describe what you expected to happen instead.
+      label: Expected behavior / 预期行为 / 期待する動作
+      description: Describe what you expected to happen instead. / 请描述你期望发生的行为。 / 本来期待していた動作を説明してください。
     validations:
       required: true
 
   - type: dropdown
     id: surface
     attributes:
-      label: Affected interface
-      description: Select every interface where you observed the problem.
+      label: Affected interface / 受影响的接口 / 影響を受けたインターフェース
+      description: Select every interface where you observed the problem. / 请选择发现该问题的所有接口。 / 問題を確認したすべてのインターフェースを選択してください。
       multiple: true
       options:
         - CLI
         - MCP server
         - Public Go SDK
-        - OAuth or account management
-        - Download or ugoira processing
-        - Release installer or updater
-        - Documentation
-        - Other
+        - OAuth or account management / OAuth 或账号管理 / OAuth またはアカウント管理
+        - Download or ugoira processing / 下载或 ugoira 处理 / download または ugoira 処理
+        - Release installer or updater / 发布安装器或更新器 / release installer または updater
+        - Documentation / 文档 / ドキュメント
+        - Other / 其他 / その他
     validations:
       required: true
 
   - type: textarea
     id: environment
     attributes:
-      label: Environment
-      description: Include `pixiv version --json`, operating system, architecture, installation method, and any relevant proxy or authentication state. Do not include secrets.
+      label: Environment / 环境 / 環境
+      description: Include `pixiv version --json`, operating system, architecture, installation method, and any relevant proxy or authentication state. Do not include secrets. / 请提供 `pixiv version --json`、操作系统、架构、安装方式以及相关代理或认证状态；不要包含密钥。 / `pixiv version --json`、OS、architecture、installation method、関連する proxy または authentication state を記載してください。secret は含めないでください。
       render: text
     validations:
       required: true
@@ -67,14 +69,14 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Redacted logs or output
-      description: Paste only redacted output. Never include refresh tokens, cookies, authorization codes, proxy userinfo, private URLs, or response bodies.
+      label: Redacted logs or output / 脱敏日志或输出 / マスク済みのログまたは出力
+      description: Paste only redacted output. Never include refresh tokens, cookies, authorization codes, proxy userinfo, private URLs, or response bodies. / 仅粘贴已脱敏的输出，切勿包含 refresh token、cookie、authorization code、代理用户信息、私有 URL 或响应体。 / マスク済みの出力だけを貼り付けてください。refresh token、cookie、authorization code、proxy userinfo、private URL、response body は絶対に含めないでください。
       render: shell
 
   - type: checkboxes
     id: safety
     attributes:
-      label: Safety confirmation
+      label: Safety confirmation / 安全确认 / 安全確認
       options:
-        - label: I have removed all secrets and private content from this report.
+        - label: I have removed all secrets and private content from this report. / 我已从此报告中移除所有密钥和私密内容。 / この報告からすべての secret と private content を削除しました。
           required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,5 @@
-name: Bug report / Bug 报告 / バグ報告
+# Localized content: English / 中文 / 日本語
+name: Bug report
 description: Report a reproducible problem in the CLI, MCP server, or public Go SDK. / 报告 CLI、MCP server 或 public Go SDK 中可复现的问题。 / CLI、MCP server、または public Go SDK で再現できる問題を報告します。
 title: "[Bug]: "
 labels:
@@ -14,7 +15,7 @@ body:
   - type: textarea
     id: summary
     attributes:
-      label: What happened? / 发生了什么？ / 何が起きましたか？
+      label: What happened?
       description: Describe the observed behavior and why it is incorrect. / 请描述观察到的行为及其不正确的原因。 / 観測した動作と、それが正しくない理由を説明してください。
     validations:
       required: true
@@ -22,7 +23,7 @@ body:
   - type: textarea
     id: reproduction
     attributes:
-      label: Reproduction steps / 复现步骤 / 再現手順
+      label: Reproduction steps
       description: Provide the smallest safe sequence that reproduces the problem. Use placeholder IDs or redacted values when needed. / 请提供可复现问题的最小安全步骤；必要时使用占位 ID 或脱敏值。 / 問題を再現する最小限で安全な手順を示してください。必要に応じてプレースホルダー ID またはマスク済みの値を使用します。
       placeholder: |
         1. Run `pixiv ...`
@@ -34,7 +35,7 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: Expected behavior / 预期行为 / 期待する動作
+      label: Expected behavior
       description: Describe what you expected to happen instead. / 请描述你期望发生的行为。 / 本来期待していた動作を説明してください。
     validations:
       required: true
@@ -42,25 +43,25 @@ body:
   - type: dropdown
     id: surface
     attributes:
-      label: Affected interface / 受影响的接口 / 影響を受けたインターフェース
+      label: Affected interface
       description: Select every interface where you observed the problem. / 请选择发现该问题的所有接口。 / 問題を確認したすべてのインターフェースを選択してください。
       multiple: true
       options:
         - CLI
         - MCP server
         - Public Go SDK
-        - OAuth or account management / OAuth 或账号管理 / OAuth またはアカウント管理
-        - Download or ugoira processing / 下载或 ugoira 处理 / download または ugoira 処理
-        - Release installer or updater / 发布安装器或更新器 / release installer または updater
-        - Documentation / 文档 / ドキュメント
-        - Other / 其他 / その他
+        - OAuth or account management
+        - Download or ugoira processing
+        - Release installer or updater
+        - Documentation
+        - Other
     validations:
       required: true
 
   - type: textarea
     id: environment
     attributes:
-      label: Environment / 环境 / 環境
+      label: Environment
       description: Include `pixiv version --json`, operating system, architecture, installation method, and any relevant proxy or authentication state. Do not include secrets. / 请提供 `pixiv version --json`、操作系统、架构、安装方式以及相关代理或认证状态；不要包含密钥。 / `pixiv version --json`、OS、architecture、installation method、関連する proxy または authentication state を記載してください。secret は含めないでください。
       render: text
     validations:
@@ -69,14 +70,14 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Redacted logs or output / 脱敏日志或输出 / マスク済みのログまたは出力
+      label: Redacted logs or output
       description: Paste only redacted output. Never include refresh tokens, cookies, authorization codes, proxy userinfo, private URLs, or response bodies. / 仅粘贴已脱敏的输出，切勿包含 refresh token、cookie、authorization code、代理用户信息、私有 URL 或响应体。 / マスク済みの出力だけを貼り付けてください。refresh token、cookie、authorization code、proxy userinfo、private URL、response body は絶対に含めないでください。
       render: shell
 
   - type: checkboxes
     id: safety
     attributes:
-      label: Safety confirmation / 安全确认 / 安全確認
+      label: Safety confirmation
       options:
-        - label: I have removed all secrets and private content from this report. / 我已从此报告中移除所有密钥和私密内容。 / この報告からすべての secret と private content を削除しました。
+        - label: I have removed all secrets and private content from this report.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Documentation and usage questions
+  - name: Documentation and usage questions / 文档与使用问题 / ドキュメントと使い方の質問
     url: https://github.com/FlanChanXwO/pixiv-cli/discussions
-    about: Ask for usage help or discuss an idea before opening a feature request.
-  - name: Security vulnerability
+    about: Ask for usage help or discuss an idea before opening a feature request. / 打开功能请求前，可在此寻求使用帮助或讨论想法。 / 機能リクエストを開く前に、使い方の支援を求めたりアイデアを相談したりできます。
+  - name: Security vulnerability / 安全漏洞 / セキュリティ脆弱性
     url: https://github.com/FlanChanXwO/pixiv-cli/security/advisories/new
-    about: Report suspected security issues privately. Do not disclose credentials or exploit details in a public issue.
+    about: Report suspected security issues privately. Do not disclose credentials or exploit details in a public issue. / 请私下报告疑似安全问题，不要在公开 Issue 中披露凭据或利用细节。 / セキュリティ上の懸念は非公開で報告してください。public issue で credential や exploit detail を開示しないでください。

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,9 @@
+# Localized content: English / 中文 / 日本語
 blank_issues_enabled: false
 contact_links:
-  - name: Documentation and usage questions / 文档与使用问题 / ドキュメントと使い方の質問
+  - name: Documentation and usage questions
     url: https://github.com/FlanChanXwO/pixiv-cli/discussions
     about: Ask for usage help or discuss an idea before opening a feature request. / 打开功能请求前，可在此寻求使用帮助或讨论想法。 / 機能リクエストを開く前に、使い方の支援を求めたりアイデアを相談したりできます。
-  - name: Security vulnerability / 安全漏洞 / セキュリティ脆弱性
+  - name: Security vulnerability
     url: https://github.com/FlanChanXwO/pixiv-cli/security/advisories/new
     about: Report suspected security issues privately. Do not disclose credentials or exploit details in a public issue. / 请私下报告疑似安全问题，不要在公开 Issue 中披露凭据或利用细节。 / セキュリティ上の懸念は非公開で報告してください。public issue で credential や exploit detail を開示しないでください。

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
-name: Feature request
-description: Propose a focused improvement to pixiv-cli.
+name: Feature request / 功能请求 / 機能リクエスト
+description: Propose a focused improvement to pixiv-cli. / 为 pixiv-cli 提出明确的改进建议。 / pixiv-cli の焦点を絞った改善を提案します。
 title: "[Feature]: "
 labels:
   - enhancement
@@ -7,60 +7,62 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please describe the user problem first. Do not include refresh tokens, cookies, private URLs, downloaded works, or private API responses.
+        English: Please describe the user problem first. Do not include refresh tokens, cookies, private URLs, downloaded works, or private API responses.
+        中文：请先描述用户问题。不要包含 refresh token、cookie、私有 URL、下载作品或私有 API 响应。
+        日本語：まず user problem を説明してください。refresh token、cookie、private URL、downloaded work、private API response は含めないでください。
 
   - type: textarea
     id: problem
     attributes:
-      label: Problem to solve
-      description: Explain the concrete workflow or limitation that motivates this request.
+      label: Problem to solve / 要解决的问题 / 解決したい問題
+      description: Explain the concrete workflow or limitation that motivates this request. / 请说明促使你提出此请求的具体流程或限制。 / このリクエストの動機となる具体的な workflow または制約を説明してください。
     validations:
       required: true
 
   - type: textarea
     id: proposal
     attributes:
-      label: Proposed behavior
-      description: Describe the desired CLI, MCP, SDK, or documentation behavior. Include examples when useful.
+      label: Proposed behavior / 建议的行为 / 提案する動作
+      description: Describe the desired CLI, MCP, SDK, or documentation behavior. Include examples when useful. / 请描述期望的 CLI、MCP、SDK 或文档行为；适当时附上示例。 / 期待する CLI、MCP、SDK、または documentation の動作を説明してください。必要に応じて例を含めてください。
     validations:
       required: true
 
   - type: dropdown
     id: surface
     attributes:
-      label: Affected interface
-      description: Select every interface that should expose the change.
+      label: Affected interface / 受影响的接口 / 影響を受けるインターフェース
+      description: Select every interface that should expose the change. / 请选择应提供此变更的所有接口。 / この変更を提供すべきすべてのインターフェースを選択してください。
       multiple: true
       options:
         - CLI
         - MCP server
         - Public Go SDK
-        - OAuth or account management
-        - Download or ugoira processing
-        - Release installer or updater
-        - Documentation
-        - Other
+        - OAuth or account management / OAuth 或账号管理 / OAuth またはアカウント管理
+        - Download or ugoira processing / 下载或 ugoira 处理 / download または ugoira 処理
+        - Release installer or updater / 发布安装器或更新器 / release installer または updater
+        - Documentation / 文档 / ドキュメント
+        - Other / 其他 / その他
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives considered
-      description: Describe existing commands, workarounds, or other designs you considered.
+      label: Alternatives considered / 已考虑的替代方案 / 検討した代替案
+      description: Describe existing commands, workarounds, or other designs you considered. / 请说明已考虑的现有命令、变通方案或其他设计。 / 検討した既存の command、workaround、または他の design を説明してください。
 
   - type: checkboxes
     id: compatibility
     attributes:
-      label: Compatibility
+      label: Compatibility / 兼容性 / 互換性
       options:
-        - label: This proposal may require a breaking CLI, MCP, SDK, configuration, or output-contract change.
+        - label: This proposal may require a breaking CLI, MCP, SDK, configuration, or output-contract change. / 此提案可能需要破坏性变更 CLI、MCP、SDK、配置或输出契约。 / この提案では CLI、MCP、SDK、configuration、または output contract の破壊的変更が必要になる可能性があります。
           required: false
 
   - type: checkboxes
     id: safety
     attributes:
-      label: Safety confirmation
+      label: Safety confirmation / 安全确认 / 安全確認
       options:
-        - label: I have not included secrets or private content in this request.
+        - label: I have not included secrets or private content in this request. / 我没有在此请求中包含密钥或私密内容。 / このリクエストには secret や private content を含めていません。
           required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,4 +1,5 @@
-name: Feature request / 功能请求 / 機能リクエスト
+# Localized content: English / 中文 / 日本語
+name: Feature request
 description: Propose a focused improvement to pixiv-cli. / 为 pixiv-cli 提出明确的改进建议。 / pixiv-cli の焦点を絞った改善を提案します。
 title: "[Feature]: "
 labels:
@@ -14,7 +15,7 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: Problem to solve / 要解决的问题 / 解決したい問題
+      label: Problem to solve
       description: Explain the concrete workflow or limitation that motivates this request. / 请说明促使你提出此请求的具体流程或限制。 / このリクエストの動機となる具体的な workflow または制約を説明してください。
     validations:
       required: true
@@ -22,7 +23,7 @@ body:
   - type: textarea
     id: proposal
     attributes:
-      label: Proposed behavior / 建议的行为 / 提案する動作
+      label: Proposed behavior
       description: Describe the desired CLI, MCP, SDK, or documentation behavior. Include examples when useful. / 请描述期望的 CLI、MCP、SDK 或文档行为；适当时附上示例。 / 期待する CLI、MCP、SDK、または documentation の動作を説明してください。必要に応じて例を含めてください。
     validations:
       required: true
@@ -30,39 +31,39 @@ body:
   - type: dropdown
     id: surface
     attributes:
-      label: Affected interface / 受影响的接口 / 影響を受けるインターフェース
+      label: Affected interface
       description: Select every interface that should expose the change. / 请选择应提供此变更的所有接口。 / この変更を提供すべきすべてのインターフェースを選択してください。
       multiple: true
       options:
         - CLI
         - MCP server
         - Public Go SDK
-        - OAuth or account management / OAuth 或账号管理 / OAuth またはアカウント管理
-        - Download or ugoira processing / 下载或 ugoira 处理 / download または ugoira 処理
-        - Release installer or updater / 发布安装器或更新器 / release installer または updater
-        - Documentation / 文档 / ドキュメント
-        - Other / 其他 / その他
+        - OAuth or account management
+        - Download or ugoira processing
+        - Release installer or updater
+        - Documentation
+        - Other
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives considered / 已考虑的替代方案 / 検討した代替案
+      label: Alternatives considered
       description: Describe existing commands, workarounds, or other designs you considered. / 请说明已考虑的现有命令、变通方案或其他设计。 / 検討した既存の command、workaround、または他の design を説明してください。
 
   - type: checkboxes
     id: compatibility
     attributes:
-      label: Compatibility / 兼容性 / 互換性
+      label: Compatibility
       options:
-        - label: This proposal may require a breaking CLI, MCP, SDK, configuration, or output-contract change. / 此提案可能需要破坏性变更 CLI、MCP、SDK、配置或输出契约。 / この提案では CLI、MCP、SDK、configuration、または output contract の破壊的変更が必要になる可能性があります。
+        - label: This proposal may require a breaking CLI, MCP, SDK, configuration, or output-contract change.
           required: false
 
   - type: checkboxes
     id: safety
     attributes:
-      label: Safety confirmation / 安全确认 / 安全確認
+      label: Safety confirmation
       options:
-        - label: I have not included secrets or private content in this request. / 我没有在此请求中包含密钥或私密内容。 / このリクエストには secret や private content を含めていません。
+        - label: I have not included secrets or private content in this request.
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-## Summary / 概述 / 概要
+<!-- Localized instructions: English / 中文 / 日本語 -->
+
+## Summary
 
 <!--
 English: Describe the user problem and the change that addresses it. Link related issues with "Fixes #123" when applicable.
@@ -6,7 +8,7 @@ English: Describe the user problem and the change that addresses it. Link relate
 日本語：user problem と、それを解決する変更を説明してください。該当する場合は "Fixes #123" で関連 issue をリンクします。
 -->
 
-## Scope and compatibility / 范围与兼容性 / 変更範囲と互換性
+## Scope and compatibility
 
 <!--
 English: List affected CLI commands or flags, MCP tools or schemas, SDK APIs, configuration, environment variables, output contracts, and release behavior. State "None" when there is no public impact.
@@ -14,7 +16,7 @@ English: List affected CLI commands or flags, MCP tools or schemas, SDK APIs, co
 日本語：影響を受ける CLI command または flag、MCP tool または schema、SDK API、configuration、environment variable、output contract、release behavior を列挙してください。public impact がない場合は "None" と記載します。
 -->
 
-## Verification / 验证 / 検証
+## Verification
 
 <!--
 English: List the exact commands you ran and their results. For real Pixiv API coverage, state whether it was run and use only redacted evidence.
@@ -26,7 +28,7 @@ English: List the exact commands you ran and their results. For real Pixiv API c
 go test ./...
 ```
 
-## Release note declaration / Release note 声明 / リリースノート宣言
+## Release note declaration
 
 <!--
 English: This required metadata is validated by the Quality gate. It is used only after merge to prepare the bilingual release notes; do not edit changelog/unreleased in a feature PR. Select exactly one category: Added, Changed, Fixed, Security, Documentation, Maintenance, or None. Set breaking to true only when the change requires a major-version release. None requires a concrete reason.
@@ -41,7 +43,7 @@ summary:
 none_reason:
 -->
 
-## Checklist / 检查清单 / チェックリスト
+## Checklist
 
 - [ ] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。 / 変更は焦点が絞られ、該当する場合は issue にリンクされています。
 - [ ] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。 / 変更された動作に対する focused test を追加または更新しました。

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,38 @@
-## Summary
+## Summary / 概述 / 概要
 
-<!-- Describe the user problem and the change that addresses it. Link related issues with "Fixes #123" when applicable. -->
+<!--
+English: Describe the user problem and the change that addresses it. Link related issues with "Fixes #123" when applicable.
+中文：说明用户问题及解决该问题的改动。适用时使用 “Fixes #123” 关联 Issue。
+日本語：user problem と、それを解決する変更を説明してください。該当する場合は "Fixes #123" で関連 issue をリンクします。
+-->
 
-## Scope and compatibility
+## Scope and compatibility / 范围与兼容性 / 変更範囲と互換性
 
-<!-- List affected CLI commands or flags, MCP tools or schemas, SDK APIs, configuration, environment variables, output contracts, and release behavior. State "None" when there is no public impact. -->
+<!--
+English: List affected CLI commands or flags, MCP tools or schemas, SDK APIs, configuration, environment variables, output contracts, and release behavior. State "None" when there is no public impact.
+中文：列出受影响的 CLI command 或 flag、MCP tool 或 schema、SDK API、配置、环境变量、输出契约和发布行为。没有公开影响时填写 “None”。
+日本語：影響を受ける CLI command または flag、MCP tool または schema、SDK API、configuration、environment variable、output contract、release behavior を列挙してください。public impact がない場合は "None" と記載します。
+-->
 
-## Verification
+## Verification / 验证 / 検証
 
-<!-- List the exact commands you ran and their results. For real Pixiv API coverage, state whether it was run and use only redacted evidence. -->
+<!--
+English: List the exact commands you ran and their results. For real Pixiv API coverage, state whether it was run and use only redacted evidence.
+中文：列出实际运行的精确命令及结果。真实 Pixiv API 覆盖须说明是否运行，且只提供脱敏证据。
+日本語：実行した正確な command と結果を列挙してください。real Pixiv API coverage は実行の有無を示し、マスク済みの証拠だけを使用してください。
+-->
 
 ```text
 go test ./...
 ```
 
-## Release note declaration
+## Release note declaration / Release note 声明 / リリースノート宣言
 
-<!-- This required metadata is validated by the Quality gate. It is used only after merge to prepare the bilingual release notes; do not edit changelog/unreleased in a feature PR. Select exactly one category: Added, Changed, Fixed, Security, Documentation, Maintenance, or None. Set breaking to true only when the change requires a major-version release. None requires a concrete reason. -->
+<!--
+English: This required metadata is validated by the Quality gate. It is used only after merge to prepare the bilingual release notes; do not edit changelog/unreleased in a feature PR. Select exactly one category: Added, Changed, Fixed, Security, Documentation, Maintenance, or None. Set breaking to true only when the change requires a major-version release. None requires a concrete reason.
+中文：Quality gate 会校验此必填 metadata。它仅在合并后用于准备双语 release note；feature PR 中不要编辑 changelog/unreleased。只能选择一个类别：Added、Changed、Fixed、Security、Documentation、Maintenance 或 None。只有变更需要 major-version release 时才将 breaking 设为 true；None 必须提供具体理由。
+日本語：この必須 metadata は Quality gate で検証されます。merge 後に bilingual release note を準備するためだけに使用し、feature PR で changelog/unreleased を編集しないでください。Added、Changed、Fixed、Security、Documentation、Maintenance、None から正確に 1 つ選びます。major-version release が必要な変更だけで breaking を true にし、None には具体的な理由が必要です。
+-->
 
 <!-- release-note
 category:
@@ -25,13 +41,13 @@ summary:
 none_reason:
 -->
 
-## Checklist
+## Checklist / 检查清单 / チェックリスト
 
-- [ ] The change is focused and linked to an issue when appropriate.
-- [ ] I added or updated focused tests for changed behavior.
-- [ ] I ran the relevant tests and recorded the results above.
-- [ ] I updated the required CLI, MCP, SDK, README, maintainer, and product-skill documentation.
-- [ ] I completed the required release-note declaration above; `None` has a concrete reason when selected.
-- [ ] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence.
-- [ ] I did not add refresh tokens, cookies, authorization codes, proxy credentials, private URLs, downloaded works, local state, or private API responses.
-- [ ] I updated migration guidance for every breaking change.
+- [ ] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。 / 変更は焦点が絞られ、該当する場合は issue にリンクされています。
+- [ ] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。 / 変更された動作に対する focused test を追加または更新しました。
+- [ ] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。 / 関連する test を実行し、結果を上に記録しました。
+- [ ] I updated the required CLI, MCP, SDK, README, maintainer, and product-skill documentation. / 我已更新所需的 CLI、MCP、SDK、README、维护者和产品 skill 文档。 / 必要な CLI、MCP、SDK、README、maintainer、product-skill documentation を更新しました。
+- [ ] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。 / 必須の release-note declaration を上で完了し、`None` を選んだ場合は具体的な理由を記載しました。
+- [ ] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增 timeout、retry、pagination 或结果限制、truncation、fallback 或 downgrade 及其证据。 / 新しい timeout、retry、pagination または result limit、truncation、fallback、downgrade とその証拠をすべて記載しました。
+- [ ] I did not add refresh tokens, cookies, authorization codes, proxy credentials, private URLs, downloaded works, local state, or private API responses. / 我没有添加 refresh token、cookie、authorization code、代理凭据、私有 URL、下载作品、本地状态或私有 API 响应。 / refresh token、cookie、authorization code、proxy credential、private URL、downloaded work、local state、private API response を追加していません。
+- [ ] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。 / すべての breaking change の migration guidance を更新しました。

--- a/scripts/documentation/documentation_test.go
+++ b/scripts/documentation/documentation_test.go
@@ -194,23 +194,22 @@ func TestVersionedChangelogHasEnglishAndSimplifiedChinesePairs(t *testing.T) {
 	}
 }
 
-func TestContributionTemplatesArePresentAndEnglish(t *testing.T) {
+func TestContributionTemplatesArePresentAndLocalized(t *testing.T) {
 	repositoryRoot := filepath.Clean(filepath.Join("..", ".."))
-	for _, relativePath := range []string{
-		".github/ISSUE_TEMPLATE/config.yml",
-		".github/ISSUE_TEMPLATE/bug-report.yml",
-		".github/ISSUE_TEMPLATE/feature-request.yml",
-		".github/PULL_REQUEST_TEMPLATE.md",
+	for relativePath, markers := range map[string][]string{
+		".github/ISSUE_TEMPLATE/config.yml":          {"文档与使用问题", "ドキュメントと使い方の質問"},
+		".github/ISSUE_TEMPLATE/bug-report.yml":      {"发生了什么？", "何が起きましたか？"},
+		".github/ISSUE_TEMPLATE/feature-request.yml": {"要解决的问题", "解決したい問題"},
+		".github/PULL_REQUEST_TEMPLATE.md":           {"概述", "概要"},
 	} {
 		payload, err := os.ReadFile(filepath.Join(repositoryRoot, filepath.FromSlash(relativePath)))
 		if err != nil {
 			t.Errorf("read contribution template %s: %v", relativePath, err)
 			continue
 		}
-		for _, character := range string(payload) {
-			if character > 127 {
-				t.Errorf("contribution template %s contains non-ASCII character %q", relativePath, character)
-				break
+		for _, marker := range markers {
+			if !strings.Contains(string(payload), marker) {
+				t.Errorf("contribution template %s is missing localized marker %q", relativePath, marker)
 			}
 		}
 	}

--- a/scripts/documentation/documentation_test.go
+++ b/scripts/documentation/documentation_test.go
@@ -196,21 +196,20 @@ func TestVersionedChangelogHasEnglishAndSimplifiedChinesePairs(t *testing.T) {
 
 func TestContributionTemplatesArePresentAndLocalized(t *testing.T) {
 	repositoryRoot := filepath.Clean(filepath.Join("..", ".."))
-	for relativePath, markers := range map[string][]string{
-		".github/ISSUE_TEMPLATE/config.yml":          {"文档与使用问题", "ドキュメントと使い方の質問"},
-		".github/ISSUE_TEMPLATE/bug-report.yml":      {"发生了什么？", "何が起きましたか？"},
-		".github/ISSUE_TEMPLATE/feature-request.yml": {"要解决的问题", "解決したい問題"},
-		".github/PULL_REQUEST_TEMPLATE.md":           {"概述", "概要"},
+	const languageMarker = "English / 中文 / 日本語"
+	for _, relativePath := range []string{
+		".github/ISSUE_TEMPLATE/config.yml",
+		".github/ISSUE_TEMPLATE/bug-report.yml",
+		".github/ISSUE_TEMPLATE/feature-request.yml",
+		".github/PULL_REQUEST_TEMPLATE.md",
 	} {
 		payload, err := os.ReadFile(filepath.Join(repositoryRoot, filepath.FromSlash(relativePath)))
 		if err != nil {
 			t.Errorf("read contribution template %s: %v", relativePath, err)
 			continue
 		}
-		for _, marker := range markers {
-			if !strings.Contains(string(payload), marker) {
-				t.Errorf("contribution template %s is missing localized marker %q", relativePath, marker)
-			}
+		if !strings.Contains(string(payload), languageMarker) {
+			t.Errorf("contribution template %s is missing language marker %q", relativePath, languageMarker)
 		}
 	}
 }


### PR DESCRIPTION
## Summary / 概述 / 概要

Localize Issue Forms, contact links, and the pull-request template in English, Simplified Chinese, and Japanese while retaining English Issue title prefixes.

## Scope and compatibility / 范围与兼容性 / 変更範囲と互換性

Documentation-only contribution-template update; no CLI, MCP, SDK, configuration, or runtime behavior changes.

## Verification / 验证 / 検証

```text
go test ./...
pre-commit run --all-files
```

<!-- release-note
category: Documentation
breaking: false
summary: Localize issue and pull-request contribution templates in English, Chinese, and Japanese.
none_reason:
-->

## Checklist / 检查清单 / チェックリスト

- [x] The change is focused and linked to an issue when appropriate.
- [x] I added or updated focused tests for changed behavior.
- [x] I ran the relevant tests and recorded the results above.
- [x] I updated the required CLI, MCP, SDK, README, maintainer, and product-skill documentation.
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected.
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence.
- [x] I did not add refresh tokens, cookies, authorization codes, proxy credentials, private URLs, downloaded works, local state, or private API responses.
- [x] I updated migration guidance for every breaking change.

## Summary by Sourcery

在本地化 GitHub 贡献模板为英文、简体中文和日文的同时，保留现有工作流和元数据要求。

文档：
- 为错误报告和功能请求的 Issue 表单添加多语言标题、描述和安全指引。
- 将 Pull Request 模板中的各个部分、检查清单项以及发布说明声明本地化为英文、简体中文和日文。
- 更新 Issue 模板配置中的联系链接，以提供多语言文档和安全指引。

测试：
- 放宽文档测试要求，从强制贡献模板仅使用 ASCII 字符，改为断言存在特定的本地化标记。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Localize GitHub contribution templates in English, Simplified Chinese, and Japanese while preserving existing workflows and metadata requirements.

Documentation:
- Add multilingual headings, descriptions, and safety guidance to bug-report and feature-request issue forms.
- Localize pull-request template sections, checklist items, and release-note declaration in English, Simplified Chinese, and Japanese.
- Update issue template config contact links to provide multilingual documentation and security guidance.

Tests:
- Relax documentation tests to assert presence of specific localization markers instead of enforcing ASCII-only contribution templates.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * Issue、功能请求及 Pull Request 模板现支持英文、中文和日文。
  * 补充了多语言字段说明、填写提示、安全提示及联系信息。
  * 更新贡献模板检查，确保本地化内容完整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->