### PR TITLE
docs: localize issue title prefixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 # Localized content: English / 中文 / 日本語
 name: Bug report
 description: Report a reproducible problem in the CLI, MCP server, or public Go SDK. / 报告 CLI、MCP server 或 public Go SDK 中可复现的问题。 / CLI、MCP server、または public Go SDK で再現できる問題を報告します。
-title: "[Bug]: "
+title: "[Bug / 问题 / バグ]: "
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
 # Localized content: English / 中文 / 日本語
 name: Feature request
 description: Propose a focused improvement to pixiv-cli. / 为 pixiv-cli 提出明确的改进建议。 / pixiv-cli の焦点を絞った改善を提案します。
-title: "[Feature]: "
+title: "[Feature / 功能 / 機能]: "
 labels:
   - enhancement
 body:

--- a/scripts/documentation/documentation_test.go
+++ b/scripts/documentation/documentation_test.go
@@ -214,6 +214,23 @@ func TestContributionTemplatesArePresentAndLocalized(t *testing.T) {
 	}
 }
 
+func TestIssueTemplateTitlesAreLocalized(t *testing.T) {
+	repositoryRoot := filepath.Clean(filepath.Join("..", ".."))
+	for relativePath, title := range map[string]string{
+		".github/ISSUE_TEMPLATE/bug-report.yml":      `title: "[Bug / 问题 / バグ]: "`,
+		".github/ISSUE_TEMPLATE/feature-request.yml": `title: "[Feature / 功能 / 機能]: "`,
+	} {
+		payload, err := os.ReadFile(filepath.Join(repositoryRoot, filepath.FromSlash(relativePath)))
+		if err != nil {
+			t.Errorf("read issue template %s: %v", relativePath, err)
+			continue
+		}
+		if !strings.Contains(string(payload), title) {
+			t.Errorf("issue template %s is missing localized title %q", relativePath, title)
+		}
+	}
+}
+
 func TestPullRequestTemplateDeclaresReleaseNoteMetadata(t *testing.T) {
 	repositoryRoot := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repositoryRoot, ".github", "PULL_REQUEST_TEMPLATE.md"))


### PR DESCRIPTION
## Summary

Localize the default Bug and Feature Issue title prefixes in English, Simplified Chinese, and Japanese.

## Scope and compatibility

Documentation-only contribution-template update; no CLI, MCP, SDK, configuration, or runtime behavior changes.

## Verification

```text
go test ./...
pre-commit run --all-files
```

<!-- release-note
category: Documentation
breaking: false
summary: Localize default issue title prefixes in English, Chinese, and Japanese.
none_reason:
-->

## Checklist

- [x] The change is focused and linked to an issue when appropriate.
- [x] I added or updated focused tests for changed behavior.
- [x] I ran the relevant tests and recorded the results above.
- [x] I updated the required CLI, MCP, SDK, README, maintainer, and product-skill documentation.
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected.
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence.
- [x] I did not add refresh tokens, cookies, authorization codes, proxy credentials, private URLs, downloaded works, local state, or private API responses.
- [x] I updated migration guidance for every breaking change.

## 由 Sourcery 提供的摘要

在所有支持的语言中本地化 Issue 模板标题前缀，并通过文档测试强制保证其存在。

文档：
- 更新 bug 和 feature Issue 模板，使其在英文、简体中文和日文中使用本地化的标题前缀。

测试：
- 添加一个文档测试，用于验证 bug 和 feature Issue 模板是否包含预期的本地化标题前缀。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Localize issue template title prefixes across supported languages and enforce their presence via documentation tests.

Documentation:
- Update bug and feature issue templates to use localized title prefixes in English, Simplified Chinese, and Japanese.

Tests:
- Add a documentation test that verifies bug and feature issue templates include the expected localized title prefixes.

</details>