### PR TITLE
release: prepare v0.9.0 notes

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@ grouped by user outcome and carry inline PR or historical direct-commit sources;
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.9.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.8.0...v0.9.0) | 2026-07-31 | [English](v0.9.0/en.md) · [简体中文](v0.9.0/zh-CN.md) |
 | [v0.8.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.2...v0.8.0) | 2026-07-28 | [English](v0.8.0/en.md) · [简体中文](v0.8.0/zh-CN.md) |
 | [v0.7.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.1...v0.7.2) | 2026-07-25 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |
 | [v0.7.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.0...v0.7.1) | 2026-07-25 | [English](v0.7.1/en.md) · [简体中文](v0.7.1/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,6 +5,7 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | 未发布 | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.9.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.8.0...v0.9.0) | 2026-07-31 | [English](v0.9.0/en.md) · [简体中文](v0.9.0/zh-CN.md) |
 | [v0.8.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.2...v0.8.0) | 2026-07-28 | [English](v0.8.0/en.md) · [简体中文](v0.8.0/zh-CN.md) |
 | [v0.7.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.1...v0.7.2) | 2026-07-25 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |
 | [v0.7.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.0...v0.7.1) | 2026-07-25 | [English](v0.7.1/en.md) · [简体中文](v0.7.1/zh-CN.md) |

--- a/changelog/v0.9.0/en.md
+++ b/changelog/v0.9.0/en.md
@@ -1,0 +1,19 @@
+# v0.9.0 — 2026-07-31
+
+## Breaking changes
+
+- Unify the v0.9 command and automation surface: use `pixiv timeline latest|following` instead of `feed`; migrate to renamed MCP timeline tools; use `SupportedDrawingTools()` for SDK drawing-tool discovery; remove SDK and project loggers plus MCP account/configuration tools; and use a one-time desktop remote-login handoff instead of devices, pairing, and callback-copy forms. The release also adds APNG ugoira output, interactive download progress, richer list filters, a static drawing-tool catalog, canonical download de-duplication, and safer account-pool behavior. ([#40](https://github.com/FlanChanXwO/pixiv-cli/pull/40))
+
+## Fixed
+
+- Make the released ClawHub skill and Homebrew formula deployment recover cleanly from moderation, pending-card, and unavailable beta-formula states. ([`0915746`](https://github.com/FlanChanXwO/pixiv-cli/commit/09157462ab6e36da209eae6973a5fc60c7c1bb8a), [`2a6e9f2`](https://github.com/FlanChanXwO/pixiv-cli/commit/2a6e9f2c6f6967c8698928f2c37a9f8bc461f183), [`384a3e8`](https://github.com/FlanChanXwO/pixiv-cli/commit/384a3e825c5a966c524e5d974e7480c18610928a), [`3e67b28`](https://github.com/FlanChanXwO/pixiv-cli/commit/3e67b286e72c3052a86d3f14675b53c0b0ce7c48), [`73b30c2`](https://github.com/FlanChanXwO/pixiv-cli/commit/73b30c24dbee98bbcc7d8b82d1b2d679cde4519e), [`b09f161`](https://github.com/FlanChanXwO/pixiv-cli/commit/b09f16140600644b48d3393217d52398ff10c6f0))
+
+## Documentation
+
+- Introduce auditable bilingual release notes, clearer AI-agent installation and account guidance, and localized contribution templates; distinguish the SkillHub and ClawHub installation paths. ([`66d5fd7`](https://github.com/FlanChanXwO/pixiv-cli/commit/66d5fd705f1e5aebf6413b5ced270c40670a8527), [`92261fa`](https://github.com/FlanChanXwO/pixiv-cli/commit/92261faf3f2ca8fd7afde6776ea882d0686c2b48), [`ea02b29`](https://github.com/FlanChanXwO/pixiv-cli/commit/ea02b29fcf3c14f6c6edabb94aa92b3d09c4eefd), [#37](https://github.com/FlanChanXwO/pixiv-cli/pull/37), [#38](https://github.com/FlanChanXwO/pixiv-cli/pull/38))
+
+## Maintenance
+
+- Use stable packaged-binary smoke job names without GitHub expression placeholders. ([`b8daaa1`](https://github.com/FlanChanXwO/pixiv-cli/commit/b8daaa1c4de024d369410fcabf18041b631e4f11))
+
+**Full Changelog**: [v0.8.0...v0.9.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.8.0...v0.9.0)

--- a/changelog/v0.9.0/zh-CN.md
+++ b/changelog/v0.9.0/zh-CN.md
@@ -1,0 +1,19 @@
+# v0.9.0 — 2026-07-31
+
+## 破坏性变更
+
+- 统一 v0.9 的命令与自动化能力面：使用 `pixiv timeline latest|following` 取代 `feed`；迁移到改名后的 MCP timeline 工具；SDK 绘图工具发现改用 `SupportedDrawingTools()`；移除 SDK 与项目日志和 MCP 账号/配置工具；远程登录改为一次性桌面 handoff，不再提供设备、配对和复制 callback 表单。本版本还新增 APNG ugoira 输出、交互式下载进度、更丰富的列表筛选、静态绘图工具目录、规范下载去重和更安全的账号池行为。 ([#40](https://github.com/FlanChanXwO/pixiv-cli/pull/40))
+
+## 修复
+
+- 让已发布的 ClawHub Skill 与 Homebrew Formula 部署可从审核、待展示卡片和不可用 beta Formula 状态中正常恢复。 ([`0915746`](https://github.com/FlanChanXwO/pixiv-cli/commit/09157462ab6e36da209eae6973a5fc60c7c1bb8a), [`2a6e9f2`](https://github.com/FlanChanXwO/pixiv-cli/commit/2a6e9f2c6f6967c8698928f2c37a9f8bc461f183), [`384a3e8`](https://github.com/FlanChanXwO/pixiv-cli/commit/384a3e825c5a966c524e5d974e7480c18610928a), [`3e67b28`](https://github.com/FlanChanXwO/pixiv-cli/commit/3e67b286e72c3052a86d3f14675b53c0b0ce7c48), [`73b30c2`](https://github.com/FlanChanXwO/pixiv-cli/commit/73b30c24dbee98bbcc7d8b82d1b2d679cde4519e), [`b09f161`](https://github.com/FlanChanXwO/pixiv-cli/commit/b09f16140600644b48d3393217d52398ff10c6f0))
+
+## 文档
+
+- 引入可审计的双语发布说明，完善 AI agent 安装与账号说明，并提供本地化贡献模板；同时区分 SkillHub 与 ClawHub 的安装路径。 ([`66d5fd7`](https://github.com/FlanChanXwO/pixiv-cli/commit/66d5fd705f1e5aebf6413b5ced270c40670a8527), [`92261fa`](https://github.com/FlanChanXwO/pixiv-cli/commit/92261faf3f2ca8fd7afde6776ea882d0686c2b48), [`ea02b29`](https://github.com/FlanChanXwO/pixiv-cli/commit/ea02b29fcf3c14f6c6edabb94aa92b3d09c4eefd), [#37](https://github.com/FlanChanXwO/pixiv-cli/pull/37), [#38](https://github.com/FlanChanXwO/pixiv-cli/pull/38))
+
+## 维护
+
+- 将打包二进制 smoke job 名称改为稳定文本，不再包含 GitHub 表达式占位符。 ([`b8daaa1`](https://github.com/FlanChanXwO/pixiv-cli/commit/b8daaa1c4de024d369410fcabf18041b631e4f11))
+
+**完整变更**：[v0.8.0...v0.9.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.8.0...v0.9.0)

--- a/scripts/releasenotes/main.go
+++ b/scripts/releasenotes/main.go
@@ -566,8 +566,19 @@ func updateChangelogIndex(path, version, previous, date string, replace bool) ([
 		}
 		return nil, fmt.Errorf("changelog index already contains v%s", version)
 	}
-	anchor := "| Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n"
-	position := strings.Index(content, anchor)
+	anchors := []string{
+		"| Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n",
+		"| 未发布 | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n",
+	}
+	position := -1
+	anchor := ""
+	for _, candidate := range anchors {
+		if index := strings.Index(content, candidate); index >= 0 {
+			position = index
+			anchor = candidate
+			break
+		}
+	}
 	if position < 0 {
 		return nil, fmt.Errorf("changelog index %s has no Unreleased row", path)
 	}

--- a/scripts/releasenotes/main.go
+++ b/scripts/releasenotes/main.go
@@ -566,21 +566,18 @@ func updateChangelogIndex(path, version, previous, date string, replace bool) ([
 		}
 		return nil, fmt.Errorf("changelog index already contains v%s", version)
 	}
-	anchors := []string{
-		"| Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n",
-		"| 未发布 | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n",
-	}
-	position := -1
+	const unreleasedNotesLinks = "[English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md)"
+	position := 0
 	anchor := ""
-	for _, candidate := range anchors {
-		if index := strings.Index(content, candidate); index >= 0 {
-			position = index
+	for _, candidate := range strings.SplitAfter(content, "\n") {
+		if strings.HasPrefix(candidate, "| ") && strings.Contains(candidate, unreleasedNotesLinks) {
 			anchor = candidate
 			break
 		}
+		position += len(candidate)
 	}
-	if position < 0 {
-		return nil, fmt.Errorf("changelog index %s has no Unreleased row", path)
+	if anchor == "" {
+		return nil, fmt.Errorf("changelog index %s has no unreleased release-notes row", path)
 	}
 	row := fmt.Sprintf("| [v%s](%s) | %s | [English](v%s/en.md) · [简体中文](v%s/zh-CN.md) |\n", version, changelogCompareLink(version, previous), date, version, version)
 	position += len(anchor)

--- a/scripts/releasenotes/main_test.go
+++ b/scripts/releasenotes/main_test.go
@@ -281,8 +281,9 @@ func TestPrepareRendersBilingualNotesAndIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read Simplified Chinese index: %v", err)
 	}
-	if !strings.Contains(string(chineseIndex), "| [v1.1.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.0.0...v1.1.0) | 2026-07-30") {
-		t.Fatalf("Simplified Chinese index missing new release row: %s", chineseIndex)
+	const chineseRows = "| 未发布 | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n| [v1.1.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.0.0...v1.1.0) | 2026-07-30"
+	if !strings.Contains(string(chineseIndex), chineseRows) {
+		t.Fatalf("Simplified Chinese index does not place the new release row after the localized unreleased row: %s", chineseIndex)
 	}
 }
 

--- a/scripts/releasenotes/main_test.go
+++ b/scripts/releasenotes/main_test.go
@@ -245,7 +245,7 @@ func TestPrepareRendersBilingualNotesAndIndex(t *testing.T) {
 
 	root := t.TempDir()
 	writeReleaseNote(t, root, "README.md", "# Changelog\n\n| Version | Date | Release notes |\n| --- | --- | --- |\n| Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n| [v1.0.0](https://github.com/FlanChanXwO/pixiv-cli/commits/v1.0.0) | 2026-01-01 | [English](v1.0.0/en.md) · [简体中文](v1.0.0/zh-CN.md) |\n")
-	writeReleaseNote(t, root, "README.zh-CN.md", "# 更新日志\n\n| 版本 | 日期 | 发布说明 |\n| --- | --- | --- |\n| Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n| [v1.0.0](https://github.com/FlanChanXwO/pixiv-cli/commits/v1.0.0) | 2026-01-01 | [English](v1.0.0/en.md) · [简体中文](v1.0.0/zh-CN.md) |\n")
+	writeReleaseNote(t, root, "README.zh-CN.md", "# 更新日志\n\n| 版本 | 日期 | 发布说明 |\n| --- | --- | --- |\n| 未发布 | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |\n| [v1.0.0](https://github.com/FlanChanXwO/pixiv-cli/commits/v1.0.0) | 2026-01-01 | [English](v1.0.0/en.md) · [简体中文](v1.0.0/zh-CN.md) |\n")
 	planPath := filepath.Join(root, "plan.json")
 	plan := preparePlan{Entries: []preparedEntry{{
 		Category: "Added",
@@ -276,6 +276,13 @@ func TestPrepareRendersBilingualNotesAndIndex(t *testing.T) {
 	}
 	if !strings.Contains(string(index), "| [v1.1.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.0.0...v1.1.0) | 2026-07-30") {
 		t.Fatalf("index missing new release row: %s", index)
+	}
+	chineseIndex, err := os.ReadFile(filepath.Join(root, "README.zh-CN.md"))
+	if err != nil {
+		t.Fatalf("read Simplified Chinese index: %v", err)
+	}
+	if !strings.Contains(string(chineseIndex), "| [v1.1.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v1.0.0...v1.1.0) | 2026-07-30") {
+		t.Fatalf("Simplified Chinese index missing new release row: %s", chineseIndex)
 	}
 }
 


### PR DESCRIPTION
## Summary / 概述 / 概要

- Prepare audited bilingual v0.9.0 release notes, source coverage, and changelog indexes.
- Fix the release-note generator so the localized `未发布` index row works as the release-prep anchor.

## Scope and compatibility / 范围与兼容性 / 変更範囲と互換性

None — this PR prepares the already-audited release and fixes its internal note-generation anchor.

## Verification / 验证 / 検証

- `go test ./scripts/releasenotes ./scripts/documentation ./scripts/releaseassets ./scripts/releaseworkflow ./scripts/platformsmokeworkflow`
- `pre-commit run --files changelog/README.md changelog/README.zh-CN.md changelog/v0.9.0/en.md changelog/v0.9.0/zh-CN.md scripts/releasenotes/main.go scripts/releasenotes/main_test.go`
- `go run ./scripts/releasenotes validate --version 0.9.0 --dir changelog/v0.9.0 --previous v0.8.0 --audit /tmp/pixiv-cli-v0.9.0-audit.json`

<!-- release-note
category: None
breaking: false
summary: Release preparation only; it does not change the published product.
none_reason: Generates and validates the already-audited v0.9.0 notes and fixes their localized index anchor.
-->

## Checklist / 检查清单 / チェックリスト

- [x] The change is focused and release-prep only. / 改动聚焦于 release-prep。
- [x] Focused tests cover the localized index behavior. / 聚焦测试覆盖本地化索引行为。
- [x] Relevant verification commands passed. / 已通过相关验证命令。
- [x] No credential, callback, private URL, or local state is included. / 未包含凭据、回调、私有 URL 或本地状态。