### PR TITLE
fix(release): accept attributed historical commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,7 +418,6 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --from "$previous_tag" \
             --to "$RELEASE_TAG" \
-            --require-classified \
             --output "$audit_report"
           go run ./scripts/releasenotes validate \
             --version "${RELEASE_TAG#v}" \

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -587,7 +587,7 @@ SkillHub CLI 的 dry-run 和提交，并使用 `SKILL.md` 内的独立 SemVer，
 
 功能 PR 在 `.github/PULL_REQUEST_TEMPLATE.md` 中填写机器可读的 release-note 声明：`Added`、`Changed`、`Fixed`、`Security`、`Documentation`、`Maintenance` 或 `None`，以及一句摘要和 breaking 标记。每项面向用户的兼容性破坏都必须标为 breaking；审计会将 `v0.x` 的此类变更建议为 minor、将稳定 `v1+` 的此类变更建议为 major。`None` 需要具体理由。Quality gate 离线读取 PR event payload 校验此声明。
 
-完成 feature PR、测试和审查后，使用 `scripts/releasenotes audit` 检查 tag 范围内的提交、关联 PR、direct-commit 例外、新贡献者和 SemVer 建议。PR 必须具有有效的 release-note 声明；历史 direct commit 则必须以双语说明中的精确 commit 链接归属，随后由 `validate` 的来源覆盖检查核验。新贡献者以该作者在仓库中最早合并的 PR 判定，避免历史 PR 的当前关联状态变化而漏记。审核后的双语 JSON plan 由 `prepare` 先预览，再以 `--apply` 生成版本目录和双语索引；`validate` 离线核对章节顺序、来源、双语集合、compare footer 和可选 audit 覆盖。发布 workflow 的 `release_notes_audit` job 在受保护 publish job 之前使用只读 `contents` 与 `pull-requests` 权限重复验证不可变 tag 的来源和说明。
+完成 feature PR、测试和审查后，使用 `scripts/releasenotes audit` 检查 tag 范围内的提交、关联 PR、direct-commit 例外、新贡献者和 SemVer 建议。PR 必须具有有效的 release-note 声明；历史 direct-commit 则必须以双语说明中的精确 commit 链接归属，随后由 `validate` 的来源覆盖检查核验。新贡献者以该作者在仓库中最早合并的 PR 判定，避免历史 PR 的当前关联状态变化而漏记。审核后的双语 JSON plan 由 `prepare` 先预览，再以 `--apply` 生成版本目录和双语索引；`validate` 离线核对章节顺序、来源、双语集合、compare footer 和可选 audit 覆盖。发布 workflow 的 `release_notes_audit` job 在受保护 publish job 之前使用只读 `contents` 与 `pull-requests` 权限重复验证不可变 tag 的来源和说明。
 
 版本推荐不等于发布授权。创建 release-prep PR、合并、创建或推送 tag、触发发布、同步历史 GitHub Release 前，维护者须在当前会话明确确认具体版本、commit/tag 范围和预期影响。完整操作路径见 `.agents/skills/pixiv-cli-release-notes/SKILL.md`：功能分支与 PR → 合并后审计 → 版本建议与授权 → release-prep PR → tag 与 GitHub Release → SkillHub / ClawHub 验证。
 

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -587,7 +587,7 @@ SkillHub CLI 的 dry-run 和提交，并使用 `SKILL.md` 内的独立 SemVer，
 
 功能 PR 在 `.github/PULL_REQUEST_TEMPLATE.md` 中填写机器可读的 release-note 声明：`Added`、`Changed`、`Fixed`、`Security`、`Documentation`、`Maintenance` 或 `None`，以及一句摘要和 breaking 标记。每项面向用户的兼容性破坏都必须标为 breaking；审计会将 `v0.x` 的此类变更建议为 minor、将稳定 `v1+` 的此类变更建议为 major。`None` 需要具体理由。Quality gate 离线读取 PR event payload 校验此声明。
 
-完成 feature PR、测试和审查后，使用 `scripts/releasenotes audit` 检查 tag 范围内的提交、关联 PR、direct-commit 例外、新贡献者和 SemVer 建议。新贡献者以该作者在仓库中最早合并的 PR 判定，避免历史 PR 的当前关联状态变化而漏记。审核后的双语 JSON plan 由 `prepare` 先预览，再以 `--apply` 生成版本目录和双语索引；`validate` 离线核对章节顺序、来源、双语集合、compare footer 和可选 audit 覆盖。发布 workflow 的 `release_notes_audit` job 在受保护 publish job 之前使用只读 `contents` 与 `pull-requests` 权限重复验证不可变 tag 的来源和说明。
+完成 feature PR、测试和审查后，使用 `scripts/releasenotes audit` 检查 tag 范围内的提交、关联 PR、direct-commit 例外、新贡献者和 SemVer 建议。PR 必须具有有效的 release-note 声明；历史 direct commit 则必须以双语说明中的精确 commit 链接归属，随后由 `validate` 的来源覆盖检查核验。新贡献者以该作者在仓库中最早合并的 PR 判定，避免历史 PR 的当前关联状态变化而漏记。审核后的双语 JSON plan 由 `prepare` 先预览，再以 `--apply` 生成版本目录和双语索引；`validate` 离线核对章节顺序、来源、双语集合、compare footer 和可选 audit 覆盖。发布 workflow 的 `release_notes_audit` job 在受保护 publish job 之前使用只读 `contents` 与 `pull-requests` 权限重复验证不可变 tag 的来源和说明。
 
 版本推荐不等于发布授权。创建 release-prep PR、合并、创建或推送 tag、触发发布、同步历史 GitHub Release 前，维护者须在当前会话明确确认具体版本、commit/tag 范围和预期影响。完整操作路径见 `.agents/skills/pixiv-cli-release-notes/SKILL.md`：功能分支与 PR → 合并后审计 → 版本建议与授权 → release-prep PR → tag 与 GitHub Release → SkillHub / ClawHub 验证。
 

--- a/scripts/releaseworkflow/release_notes_policy.go
+++ b/scripts/releaseworkflow/release_notes_policy.go
@@ -20,7 +20,6 @@ go run ./scripts/releasenotes audit \
 --repo "$GITHUB_REPOSITORY" \
 --from "$previous_tag" \
 --to "$RELEASE_TAG" \
---require-classified \
 --output "$audit_report"
 go run ./scripts/releasenotes validate \
 --version "${RELEASE_TAG#v}" \

--- a/scripts/releaseworkflow/release_notes_policy_test.go
+++ b/scripts/releaseworkflow/release_notes_policy_test.go
@@ -41,6 +41,16 @@ func TestCheckWorkflowRejectsReleaseNotesAuditPrivilegeOrDependencyChanges(t *te
 				needs.Content = needs.Content[:1]
 			},
 		},
+		{
+			name: "direct commits incorrectly require PR declarations",
+			want: "canonical direct audit commands",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				t.Helper()
+				step := requireMappingValue(t, jobNode(t, root, "release_notes_audit"), "steps").Content[2]
+				run := requireMappingValue(t, step, "run")
+				run.Value += "\n--require-classified"
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/scripts/releaseworkflow/release_notes_policy_test.go
+++ b/scripts/releaseworkflow/release_notes_policy_test.go
@@ -48,7 +48,12 @@ func TestCheckWorkflowRejectsReleaseNotesAuditPrivilegeOrDependencyChanges(t *te
 				t.Helper()
 				step := requireMappingValue(t, jobNode(t, root, "release_notes_audit"), "steps").Content[2]
 				run := requireMappingValue(t, step, "run")
-				run.Value += "\n--require-classified"
+				run.Value = strings.Replace(
+					run.Value,
+					"go run ./scripts/releasenotes audit \\\n",
+					"go run ./scripts/releasenotes audit --require-classified \\\n",
+					1,
+				)
 			},
 		},
 	} {


### PR DESCRIPTION
## Summary / 概述 / 概要

Allow the release audit to validate historical direct commits through the immutable tag bilingual source links. Pull requests remain required to provide release-note metadata.

## Scope and compatibility / 范围与兼容性 / 変更範囲と互換性

Release-workflow gate only. It restores publication of the existing immutable v0.9.0 tag; CLI, MCP, SDK, configuration, and artifact inputs are unchanged.

## Verification / 验证 / 検証

- gopls check scripts/releaseworkflow/release_notes_policy.go scripts/releaseworkflow/release_notes_policy_test.go
- go test ./scripts/releaseworkflow ./scripts/releasenotes -count=1
- sh scripts/test-release-workflow.sh
- go run ./scripts/releasenotes audit --repo FlanChanXwO/pixiv-cli --from v0.8.0 --to v0.9.0 --output /tmp/pixiv-cli-v0.9.0-recovery-audit.json
- go run ./scripts/releasenotes validate --version 0.9.0 --dir changelog/v0.9.0 --previous v0.8.0 --audit /tmp/pixiv-cli-v0.9.0-recovery-audit.json
- pre-commit: go test ./... passed.

<!-- release-note
category: Fixed
breaking: false
summary: Restore release validation for explicitly attributed historical commits.
none_reason:
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新发布说明流程指引，明确审计需验证 PR 声明及历史直接提交的双语归属链接。
  * 补充来源覆盖核验要求，其他生成、校验和发布流程保持不变。

* **改进**
  * 调整发布说明审计规则，不再强制要求审计结果包含分类标记。
  * 增加相关校验场景，帮助及时识别不符合规范的审计命令。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->