### PR TITLE
fix(release): overlay release notes policy during recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,8 @@ jobs:
             scripts/releaseworkflow/main_test.go
             scripts/releaseworkflow/publish_policy.go
             scripts/releaseworkflow/publish_security_test.go
+            scripts/releaseworkflow/release_notes_policy.go
+            scripts/releaseworkflow/release_notes_policy_test.go
             scripts/releaseworkflow/recovery_policy.go
             scripts/releaseworkflow/test_helpers_test.go
             scripts/releaseworkflow/workflow_policy.go

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -401,12 +401,14 @@ allowlist 必须逐字列出以下路径，不能改成目录或 glob：
 - `scripts/releaseworkflow/main_test.go`
 - `scripts/releaseworkflow/publish_policy.go`
 - `scripts/releaseworkflow/publish_security_test.go`
+- `scripts/releaseworkflow/release_notes_policy.go`
+- `scripts/releaseworkflow/release_notes_policy_test.go`
 - `scripts/releaseworkflow/recovery_policy.go`
 - `scripts/releaseworkflow/test_helpers_test.go`
 - `scripts/releaseworkflow/workflow_policy.go`
 - `scripts/releaseworkflow/workflow_policy_test.go`
 
-全部拆出的 release test files 与 `scripts/installers/installers_test.go` 都必须 overlay，才能保留当前 mutation suite，并修复已失败 tag 的受控 installer fixture；共享 production helper
+全部拆出的 release test files 与 `scripts/installers/installers_test.go` 都必须 overlay，才能保留当前 mutation suite，并修复已失败 tag 的受控 installer fixture。`release_notes_policy.go` 及其测试同样属于该范围：它只验证来自默认分支的恢复 workflow 定义与 tag 内 release notes 的来源映射，并不改写 tag 的发布输入。共享 production helper
 `scripts/internal/workflowpolicy/policy.go` 是两个 verifier 共用的 YAML policy 实现及唯一的 per-target
 Rust toolchain 映射，也是从默认分支编译 release verifier 的必要依赖；它不参与生产资产构建，且共享包
 自己的 `policy_test.go` 仍不进入恢复 overlay。提取前必须用

--- a/scripts/releaseworkflow/build_recovery_test.go
+++ b/scripts/releaseworkflow/build_recovery_test.go
@@ -427,6 +427,8 @@ recovery_overlay_paths=(
   scripts/releaseworkflow/main_test.go
   scripts/releaseworkflow/publish_policy.go
   scripts/releaseworkflow/publish_security_test.go
+  scripts/releaseworkflow/release_notes_policy.go
+  scripts/releaseworkflow/release_notes_policy_test.go
   scripts/releaseworkflow/recovery_policy.go
   scripts/releaseworkflow/test_helpers_test.go
   scripts/releaseworkflow/workflow_policy.go
@@ -718,6 +720,8 @@ func recoveryOverlayPaths() []string {
 		"scripts/releaseworkflow/main_test.go",
 		"scripts/releaseworkflow/publish_policy.go",
 		"scripts/releaseworkflow/publish_security_test.go",
+		"scripts/releaseworkflow/release_notes_policy.go",
+		"scripts/releaseworkflow/release_notes_policy_test.go",
 		"scripts/releaseworkflow/recovery_policy.go",
 		"scripts/releaseworkflow/test_helpers_test.go",
 		"scripts/releaseworkflow/workflow_policy.go",

--- a/scripts/releaseworkflow/recovery_policy.go
+++ b/scripts/releaseworkflow/recovery_policy.go
@@ -154,6 +154,8 @@ recovery_overlay_paths=(
   scripts/releaseworkflow/main_test.go
   scripts/releaseworkflow/publish_policy.go
   scripts/releaseworkflow/publish_security_test.go
+  scripts/releaseworkflow/release_notes_policy.go
+  scripts/releaseworkflow/release_notes_policy_test.go
   scripts/releaseworkflow/recovery_policy.go
   scripts/releaseworkflow/test_helpers_test.go
   scripts/releaseworkflow/workflow_policy.go


### PR DESCRIPTION
## Summary

- extend the audited workflow-dispatch recovery overlay with the release-notes policy implementation and mutation test
- keep the exact allowlist verifier and maintainer recovery documentation in sync

## Scope and compatibility

Release recovery workflow only; no CLI, MCP, SDK, configuration, or release-tag input changes.

## Verification

- `gopls check scripts/releaseworkflow/recovery_policy.go scripts/releaseworkflow/build_recovery_test.go scripts/releaseworkflow/release_notes_policy.go scripts/releaseworkflow/release_notes_policy_test.go`
- `go test ./scripts/releaseworkflow -count=1`
- `sh scripts/test-release-workflow.sh`
- pre-commit: `go test ./...`

## Release note declaration

<!-- release-note
category: Maintenance
breaking: false
summary: Restore the audited workflow-dispatch recovery path for the current release-notes policy verifier.
none_reason:
-->

## Checklist

- [x] The change is focused.
- [x] I added or updated focused tests for changed behavior.
- [x] I ran the relevant tests and recorded the results above.
- [x] I updated the required maintainer documentation.
- [x] I completed the required release-note declaration above.
- [x] I did not add secrets, private URLs, downloaded works, local state, or private API responses.