### PR TITLE
fix(release): validate product skill version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
           fi
           git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"
           tag_commit=$(git rev-parse "$RELEASE_TAG^{commit}")
+          tag_skill="$RUNNER_TEMP/pixiv-cli-SKILL.md"
+          git show "$RELEASE_TAG:skills/pixiv-cli/SKILL.md" > "$tag_skill"
+          go run ./scripts/releaseassets validate-source --version "${RELEASE_TAG#v}" --product-skill "$tag_skill"
           git show-ref --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH"
           git merge-base --is-ancestor "$tag_commit" "origin/$DEFAULT_BRANCH"
           set +e
@@ -181,7 +184,7 @@ jobs:
       # 恢复 run 的 workflow 定义来自默认分支，但版本、CHANGELOG 与 Release notes 必须来自不可变 tag。
       - name: Validate the exact immutable release source
         shell: bash
-        run: go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"
+        run: go run ./scripts/releaseassets validate-source --version "${RELEASE_TAG#v}" --product-skill skills/pixiv-cli/SKILL.md
       - name: Install the pinned native Rust toolchain
         shell: bash
         run: rustup toolchain install '${{ matrix.rust_toolchain }}' --profile minimal --component 'clippy,rustfmt' --target '${{ matrix.rust_target }}' --no-self-update
@@ -340,7 +343,7 @@ jobs:
           cache: false
       - name: Validate the exact immutable production source
         shell: bash
-        run: go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"
+        run: go run ./scripts/releaseassets validate-source --version "${RELEASE_TAG#v}" --product-skill skills/pixiv-cli/SKILL.md
       - name: Install the pinned native Rust toolchain
         shell: bash
         run: rustup toolchain install '${{ matrix.rust_toolchain }}' --profile minimal --target '${{ matrix.rust_target }}' --no-self-update

--- a/README.ja.md
+++ b/README.ja.md
@@ -60,7 +60,7 @@ Also install the pixiv-cli Skill that matches the same stable release tag (not m
 
 ### SkillHub から pixiv-cli Skill をインストールする
 
-SkillHub に対応した Agent は、公開済みの [`pixiv-cli` Skill](https://www.skillhub.cn/skills/pixiv-cli) を SkillHub から直接インストールできます。Skill には独自の version があり、インストール済み CLI の使い方を案内します。command の syntax は常に `pixiv <cmd> --help` を最終的な根拠にしてください。
+SkillHub に対応した Agent は、公開済みの [`pixiv-cli` Skill](https://www.skillhub.cn/skills/pixiv-cli) を SkillHub から直接インストールできます。各 Skill version は案内対象の CLI release と対応しています。command の syntax は常に `pixiv <cmd> --help` を最終的な根拠にしてください。
 
 ### ClawHub から pixiv-cli Skill をインストールする
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Also install the `pixiv-cli` Skill that matches the same stable release tag (not
 
 ### Install the pixiv-cli Skill from SkillHub
 
-Agents with SkillHub support can install the published [`pixiv-cli` Skill](https://www.skillhub.cn/skills/pixiv-cli) directly from SkillHub. The Skill has its own version and teaches the installed CLI; always use `pixiv <cmd> --help` as the final source of command syntax.
+Agents with SkillHub support can install the published [`pixiv-cli` Skill](https://www.skillhub.cn/skills/pixiv-cli) directly from SkillHub. Each Skill version matches the CLI release it teaches; always use `pixiv <cmd> --help` as the final source of command syntax.
 
 ### Install the pixiv-cli Skill from ClawHub
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,7 +62,7 @@ binary，并在修改 PATH 前完成用户级安装。可用 `--no-path` 保持 
 
 ### 通过 SkillHub 安装 pixiv-cli Skill
 
-支持 SkillHub 的 Agent 可直接从 [SkillHub 的 `pixiv-cli` Skill 页面](https://www.skillhub.cn/skills/pixiv-cli) 安装已发布的 `pixiv-cli` Skill。Skill 有独立版本并用于指导已安装的 CLI；命令语法始终以 `pixiv <cmd> --help` 为最终依据。
+支持 SkillHub 的 Agent 可直接从 [SkillHub 的 `pixiv-cli` Skill 页面](https://www.skillhub.cn/skills/pixiv-cli) 安装已发布的 `pixiv-cli` Skill。每个 Skill 版本均与其指导的 CLI release 对应；命令语法始终以 `pixiv <cmd> --help` 为最终依据。
 
 ### 通过 ClawHub 安装 pixiv-cli Skill
 

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -562,7 +562,8 @@ workflow artifact 读取、生成或记录 deploy key。
 `workflow_run.head_branch` 为 `main` 时把分支名误作版本。SkillHub workflow 只 checkout 该不可变 tag，
 并确认该 tag 属于默认分支、对应 GitHub Release 已公开且版本满足 SemVer 后，才对
 `skills/pixiv-cli/` 与前一个已合并的语义版本 tag 比较。目录未变化时工作流成功跳过；目录变化时才运行
-SkillHub CLI 的 dry-run 和提交，并使用 `SKILL.md` 内的独立 SemVer，而非 CLI Release tag。`SKILLHUB_TOKEN`
+SkillHub CLI 的 dry-run 和提交。产品 `SKILL.md` 的 SemVer 必须与 CLI Release tag 相同；release 的 tag-source
+validation 会在受保护 E2E 和任何发布凭据之前拒绝不匹配的版本。`SKILLHUB_TOKEN`
 仅进入最后的提交步骤，CLI 必须返回 `skillId` 和审核状态；这证明 SkillHub 已接收提交，但平台审核完成前
 公开详情页可能仍不可见。
 若任一独立发布失败，可通过对应 workflow 的 `workflow_dispatch` 输入既有发布 tag 恢复，不能用 main 的

--- a/scripts/releaseassets/main.go
+++ b/scripts/releaseassets/main.go
@@ -49,11 +49,13 @@ func main() {
 
 func run(arguments []string) error {
 	if len(arguments) == 0 {
-		return errors.New("a subcommand is required: validate, channel, package, or finalize")
+		return errors.New("a subcommand is required: validate, validate-source, channel, package, or finalize")
 	}
 	switch arguments[0] {
 	case "validate":
 		return runValidate(arguments[1:])
+	case "validate-source":
+		return runValidateSource(arguments[1:])
 	case "channel":
 		return runChannel(arguments[1:])
 	case "package":
@@ -61,7 +63,7 @@ func run(arguments []string) error {
 	case "finalize":
 		return runFinalize(arguments[1:])
 	case "-h", "--help", "help":
-		return errors.New("usage: releaseassets validate|channel|package|finalize")
+		return errors.New("usage: releaseassets validate|validate-source|channel|package|finalize")
 	default:
 		return fmt.Errorf("unknown subcommand %q", arguments[0])
 	}
@@ -117,6 +119,76 @@ func runValidate(arguments []string) error {
 		return fmt.Errorf("validate accepts no positional arguments: %q", flags.Arg(0))
 	}
 	return validateVersion(*version)
+}
+
+// runValidateSource 在 SemVer 之外校验待发布 source 的产品 Skill metadata。
+// SkillHub 和 ClawHub 都以该 metadata 的版本发布，因此必须与不可变 release tag 一致。
+func runValidateSource(arguments []string) error {
+	flags := flag.NewFlagSet("validate-source", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	version := flags.String("version", "", "semantic version without v")
+	productSkill := flags.String("product-skill", "", "path to the released product SKILL.md")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("validate-source accepts no positional arguments: %q", flags.Arg(0))
+	}
+	if err := validateVersion(*version); err != nil {
+		return err
+	}
+	skillVersion, err := productSkillVersion(*productSkill)
+	if err != nil {
+		return err
+	}
+	if skillVersion != *version {
+		return fmt.Errorf("product skill version %q does not match release version %q", skillVersion, *version)
+	}
+	return nil
+}
+
+// productSkillVersion 只读取 SKILL.md YAML front matter 中唯一的 version 字段。
+// 这里不解析正文，以免文档内的示例或说明意外改变发布身份。
+func productSkillVersion(path string) (string, error) {
+	if err := requireRegularFile(path, "product skill"); err != nil {
+		return "", err
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read product skill %q: %w", path, err)
+	}
+	lines := strings.Split(string(contents), "\n")
+	if len(lines) < 3 || strings.TrimSpace(lines[0]) != "---" {
+		return "", fmt.Errorf("product skill %q must start with YAML front matter", path)
+	}
+	version := ""
+	foundVersion := false
+	frontMatterClosed := false
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) == "---" {
+			frontMatterClosed = true
+			break
+		}
+		key, value, found := strings.Cut(line, ":")
+		if !found || strings.TrimSpace(key) != "version" {
+			continue
+		}
+		if foundVersion {
+			return "", fmt.Errorf("product skill %q defines version more than once", path)
+		}
+		foundVersion = true
+		version = strings.TrimSpace(value)
+	}
+	if !frontMatterClosed {
+		return "", fmt.Errorf("product skill %q has unterminated YAML front matter", path)
+	}
+	if !foundVersion || version == "" {
+		return "", fmt.Errorf("product skill %q has no version", path)
+	}
+	if err := validateVersion(version); err != nil {
+		return "", fmt.Errorf("product skill %q has invalid version: %w", path, err)
+	}
+	return version, nil
 }
 
 func runPackage(arguments []string) error {

--- a/scripts/releaseassets/main.go
+++ b/scripts/releaseassets/main.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/FlanChanXwO/pixiv-cli/scripts/internal/releasenotesrender"
+	"gopkg.in/yaml.v3"
 )
 
 var semanticVersionPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
@@ -131,6 +132,9 @@ func runValidateSource(arguments []string) error {
 	if err := flags.Parse(arguments); err != nil {
 		return err
 	}
+	if *productSkill == "" {
+		return errors.New("--product-skill is required")
+	}
 	if flags.NArg() != 0 {
 		return fmt.Errorf("validate-source accepts no positional arguments: %q", flags.Arg(0))
 	}
@@ -147,8 +151,8 @@ func runValidateSource(arguments []string) error {
 	return nil
 }
 
-// productSkillVersion 只读取 SKILL.md YAML front matter 中唯一的 version 字段。
-// 这里不解析正文，以免文档内的示例或说明意外改变发布身份。
+// productSkillVersion 只读取 SKILL.md 的 YAML front matter 中唯一的 version 字段。
+// YAML decoder 兼容有效的字段顺序、注释和引号；正文不参与解析，避免示例或说明改变发布身份。
 func productSkillVersion(path string) (string, error) {
 	if err := requireRegularFile(path, "product skill"); err != nil {
 		return "", err
@@ -161,34 +165,29 @@ func productSkillVersion(path string) (string, error) {
 	if len(lines) < 3 || strings.TrimSpace(lines[0]) != "---" {
 		return "", fmt.Errorf("product skill %q must start with YAML front matter", path)
 	}
-	version := ""
-	foundVersion := false
-	frontMatterClosed := false
-	for _, line := range lines[1:] {
+	frontMatterEnd := -1
+	for index, line := range lines[1:] {
 		if strings.TrimSpace(line) == "---" {
-			frontMatterClosed = true
+			frontMatterEnd = index + 1
 			break
 		}
-		key, value, found := strings.Cut(line, ":")
-		if !found || strings.TrimSpace(key) != "version" {
-			continue
-		}
-		if foundVersion {
-			return "", fmt.Errorf("product skill %q defines version more than once", path)
-		}
-		foundVersion = true
-		version = strings.TrimSpace(value)
 	}
-	if !frontMatterClosed {
+	if frontMatterEnd == -1 {
 		return "", fmt.Errorf("product skill %q has unterminated YAML front matter", path)
 	}
-	if !foundVersion || version == "" {
+	var metadata struct {
+		Version string `yaml:"version"`
+	}
+	if err := yaml.Unmarshal([]byte(strings.Join(lines[1:frontMatterEnd], "\n")), &metadata); err != nil {
+		return "", fmt.Errorf("parse product skill %q YAML front matter: %w", path, err)
+	}
+	if metadata.Version == "" {
 		return "", fmt.Errorf("product skill %q has no version", path)
 	}
-	if err := validateVersion(version); err != nil {
+	if err := validateVersion(metadata.Version); err != nil {
 		return "", fmt.Errorf("product skill %q has invalid version: %w", path, err)
 	}
-	return version, nil
+	return metadata.Version, nil
 }
 
 func runPackage(arguments []string) error {

--- a/scripts/releaseassets/main_test.go
+++ b/scripts/releaseassets/main_test.go
@@ -31,16 +31,21 @@ func TestValidateRejectsNonSemanticVersion(t *testing.T) {
 func TestValidateSourceRequiresMatchingProductSkillVersion(t *testing.T) {
 	t.Parallel()
 
+	err := run([]string{"validate-source", "--version", "0.1.0"})
+	if err == nil || !strings.Contains(err.Error(), "--product-skill is required") {
+		t.Fatalf("validate-source without product skill = %v, want required-flag error", err)
+	}
+
 	workDir := newTestWorkDir(t)
 	skill := filepath.Join(workDir, "SKILL.md")
-	if err := os.WriteFile(skill, []byte("---\nslug: pixiv-cli\nversion: 0.1.0\n---\n"), 0o644); err != nil {
+	if err := os.WriteFile(skill, []byte("---\n# Product metadata\nversion: \"0.1.0\"\nslug: pixiv-cli\n---\n"), 0o644); err != nil {
 		t.Fatalf("write product skill fixture: %v", err)
 	}
 	if err := run([]string{"validate-source", "--version", "0.1.0", "--product-skill", skill}); err != nil {
 		t.Fatalf("validate matching product skill source: %v", err)
 	}
 
-	err := run([]string{"validate-source", "--version", "0.1.1", "--product-skill", skill})
+	err = run([]string{"validate-source", "--version", "0.1.1", "--product-skill", skill})
 	if err == nil || !strings.Contains(err.Error(), "product skill version") {
 		t.Fatalf("validate mismatched product skill = %v, want version rejection", err)
 	}

--- a/scripts/releaseassets/main_test.go
+++ b/scripts/releaseassets/main_test.go
@@ -28,6 +28,45 @@ func TestValidateRejectsNonSemanticVersion(t *testing.T) {
 	}
 }
 
+func TestValidateSourceRequiresMatchingProductSkillVersion(t *testing.T) {
+	t.Parallel()
+
+	workDir := newTestWorkDir(t)
+	skill := filepath.Join(workDir, "SKILL.md")
+	if err := os.WriteFile(skill, []byte("---\nslug: pixiv-cli\nversion: 0.1.0\n---\n"), 0o644); err != nil {
+		t.Fatalf("write product skill fixture: %v", err)
+	}
+	if err := run([]string{"validate-source", "--version", "0.1.0", "--product-skill", skill}); err != nil {
+		t.Fatalf("validate matching product skill source: %v", err)
+	}
+
+	err := run([]string{"validate-source", "--version", "0.1.1", "--product-skill", skill})
+	if err == nil || !strings.Contains(err.Error(), "product skill version") {
+		t.Fatalf("validate mismatched product skill = %v, want version rejection", err)
+	}
+}
+
+func TestValidateSourceRejectsInvalidProductSkillMetadata(t *testing.T) {
+	t.Parallel()
+
+	for name, contents := range map[string]string{
+		"missing version":   "---\nslug: pixiv-cli\n---\n",
+		"duplicate version": "---\nversion: 0.1.0\nversion: 0.1.0\n---\n",
+		"missing delimiter": "---\nversion: 0.1.0\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			workDir := newTestWorkDir(t)
+			skill := filepath.Join(workDir, "SKILL.md")
+			if err := os.WriteFile(skill, []byte(contents), 0o644); err != nil {
+				t.Fatalf("write product skill fixture: %v", err)
+			}
+			if err := run([]string{"validate-source", "--version", "0.1.0", "--product-skill", skill}); err == nil {
+				t.Fatal("validate-source accepted invalid product skill metadata")
+			}
+		})
+	}
+}
+
 func TestChannelClassifiesSemanticPrereleaseInsteadOfBuildMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/releaseworkflow/build_policy.go
+++ b/scripts/releaseworkflow/build_policy.go
@@ -50,7 +50,7 @@ func checkValidateJob(job *yaml.Node) error {
 		return err
 	}
 	validateStep := steps[3]
-	if err := requireRunFragments(validateStep, "validate release tag step", "test \"$GITHUB_REF\" = \"refs/heads/$DEFAULT_BRANCH\"", "git show-ref --verify --quiet \"refs/tags/$RELEASE_TAG\"", "git merge-base --is-ancestor \"$tag_commit\" \"origin/$DEFAULT_BRANCH\"", "gh api --include \"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG\"", "HTTP/[0-9.]+ 404"); err != nil {
+	if err := requireRunFragments(validateStep, "validate release tag step", "test \"$GITHUB_REF\" = \"refs/heads/$DEFAULT_BRANCH\"", "git show-ref --verify --quiet \"refs/tags/$RELEASE_TAG\"", "git show \"$RELEASE_TAG:skills/pixiv-cli/SKILL.md\" > \"$tag_skill\"", "go run ./scripts/releaseassets validate-source --version \"${RELEASE_TAG#v}\" --product-skill \"$tag_skill\"", "git merge-base --is-ancestor \"$tag_commit\" \"origin/$DEFAULT_BRANCH\"", "gh api --include \"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG\"", "HTTP/[0-9.]+ 404"); err != nil {
 		return err
 	}
 	if !hasCommand(job, "", "sh scripts/test-release-workflow.sh") {
@@ -104,7 +104,7 @@ func checkBuildJob(job *yaml.Node) error {
 		workingDirectory string
 		command          string
 	}{
-		{command: "go run ./scripts/releaseassets validate --version \"${RELEASE_TAG#v}\""},
+		{command: "go run ./scripts/releaseassets validate-source --version \"${RELEASE_TAG#v}\" --product-skill skills/pixiv-cli/SKILL.md"},
 		{command: "sh scripts/test-rust-vendor.sh"},
 		{workingDirectory: "internal/download/ugoira_rs", command: "cargo fmt --check"},
 		{workingDirectory: "internal/download/ugoira_rs", command: "cargo clippy --locked --offline --all-targets -- -D warnings"},
@@ -188,7 +188,7 @@ func checkProductionBuildJob(job *yaml.Node) error {
 	if err := requireExactActionStep(steps[1], "build_production Go setup", setupGoAction, map[string]string{"go-version": "1.26.3", "cache": "false"}); err != nil {
 		return err
 	}
-	if err := requireCanonicalNamedRunStep(steps[2], "Validate the exact immutable production source", `go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"`); err != nil {
+	if err := requireCanonicalNamedRunStep(steps[2], "Validate the exact immutable production source", `go run ./scripts/releaseassets validate-source --version "${RELEASE_TAG#v}" --product-skill skills/pixiv-cli/SKILL.md`); err != nil {
 		return err
 	}
 	if err := requireCanonicalNamedRunStep(steps[3], "Install the pinned native Rust toolchain", prodRustInstallCommand); err != nil {

--- a/scripts/releaseworkflow/build_policy.go
+++ b/scripts/releaseworkflow/build_policy.go
@@ -50,7 +50,7 @@ func checkValidateJob(job *yaml.Node) error {
 		return err
 	}
 	validateStep := steps[3]
-	if err := requireRunFragments(validateStep, "validate release tag step", "test \"$GITHUB_REF\" = \"refs/heads/$DEFAULT_BRANCH\"", "git show-ref --verify --quiet \"refs/tags/$RELEASE_TAG\"", "git show \"$RELEASE_TAG:skills/pixiv-cli/SKILL.md\" > \"$tag_skill\"", "go run ./scripts/releaseassets validate-source --version \"${RELEASE_TAG#v}\" --product-skill \"$tag_skill\"", "git merge-base --is-ancestor \"$tag_commit\" \"origin/$DEFAULT_BRANCH\"", "gh api --include \"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG\"", "HTTP/[0-9.]+ 404"); err != nil {
+	if err := requireRunFragments(validateStep, "validate release tag step", "test \"$GITHUB_REF\" = \"refs/heads/$DEFAULT_BRANCH\"", "git show-ref --verify --quiet \"refs/tags/$RELEASE_TAG\"", "tag_skill=\"$RUNNER_TEMP/pixiv-cli-SKILL.md\"", "git show \"$RELEASE_TAG:skills/pixiv-cli/SKILL.md\" > \"$tag_skill\"", "go run ./scripts/releaseassets validate-source --version \"${RELEASE_TAG#v}\" --product-skill \"$tag_skill\"", "git merge-base --is-ancestor \"$tag_commit\" \"origin/$DEFAULT_BRANCH\"", "gh api --include \"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG\"", "HTTP/[0-9.]+ 404"); err != nil {
 		return err
 	}
 	if !hasCommand(job, "", "sh scripts/test-release-workflow.sh") {

--- a/scripts/releaseworkflow/build_recovery_test.go
+++ b/scripts/releaseworkflow/build_recovery_test.go
@@ -851,6 +851,43 @@ func TestCheckWorkflowRequiresValidateSemVerCommandBoundToReleaseTag(t *testing.
 	}
 }
 
+func TestCheckWorkflowRequiresProductSkillVersionValidationFromReleaseTag(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name   string
+		mutate func(step *yaml.Node)
+	}{
+		{
+			name: "product skill blob replaced",
+			mutate: func(step *yaml.Node) {
+				replaceRunFragment(t, step,
+					`git show "$RELEASE_TAG:skills/pixiv-cli/SKILL.md" > "$tag_skill"`,
+					`git show "$RELEASE_TAG:README.md" > "$tag_skill"`,
+				)
+			},
+		},
+		{
+			name: "product skill version binding removed",
+			mutate: func(step *yaml.Node) {
+				replaceRunFragment(t, step,
+					`go run ./scripts/releaseassets validate-source --version "${RELEASE_TAG#v}" --product-skill "$tag_skill"`,
+					`go run ./scripts/releaseassets validate-source --version "1.2.3" --product-skill "$tag_skill"`,
+				)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := releaseWorkflowRoot(t)
+			step := stepWithRun(t, jobNode(t, root, "validate"), `git show "$RELEASE_TAG:skills/pixiv-cli/SKILL.md" > "$tag_skill"`)
+			test.mutate(step)
+			if err := checkWorkflow(mustMarshalYAML(t, root)); err == nil || !strings.Contains(err.Error(), "validate release tag step") {
+				t.Fatalf("policy error = %v, want product skill version validation rejection", err)
+			}
+		})
+	}
+}
+
 func TestCheckRecoveryPolicyRejectsRecoveryTrustMutations(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/releaseworkflow/build_recovery_test.go
+++ b/scripts/releaseworkflow/build_recovery_test.go
@@ -859,6 +859,15 @@ func TestCheckWorkflowRequiresProductSkillVersionValidationFromReleaseTag(t *tes
 		mutate func(step *yaml.Node)
 	}{
 		{
+			name: "product skill temp path removed",
+			mutate: func(step *yaml.Node) {
+				replaceRunFragment(t, step,
+					`tag_skill="$RUNNER_TEMP/pixiv-cli-SKILL.md"`,
+					`product_skill_path="$RUNNER_TEMP/pixiv-cli-SKILL.md"`,
+				)
+			},
+		},
+		{
 			name: "product skill blob replaced",
 			mutate: func(step *yaml.Node) {
 				replaceRunFragment(t, step,

--- a/scripts/releaseworkflow/recovery_policy.go
+++ b/scripts/releaseworkflow/recovery_policy.go
@@ -106,7 +106,7 @@ func requireCanonicalBuildSteps(steps []*yaml.Node) error {
 		command   string
 		directory string
 	}{
-		{name: "Validate the exact immutable release source", command: `go run ./scripts/releaseassets validate --version "${RELEASE_TAG#v}"`},
+		{name: "Validate the exact immutable release source", command: `go run ./scripts/releaseassets validate-source --version "${RELEASE_TAG#v}" --product-skill skills/pixiv-cli/SKILL.md`},
 		{name: "Install the pinned native Rust toolchain", command: testRustInstallCommand},
 		{name: "Check vendored Rust sources", command: "sh scripts/test-rust-vendor.sh"},
 		{name: "Check Rust formatting from vendored sources", command: "cargo fmt --check", directory: "internal/download/ugoira_rs"},

--- a/scripts/releaseworkflow/test_helpers_test.go
+++ b/scripts/releaseworkflow/test_helpers_test.go
@@ -239,7 +239,7 @@ func mappingNode(entries ...any) *yaml.Node {
 
 func requiredQualityGateCommands() []string {
 	return []string{
-		"go run ./scripts/releaseassets validate --version \"${RELEASE_TAG#v}\"",
+		"go run ./scripts/releaseassets validate-source --version \"${RELEASE_TAG#v}\" --product-skill skills/pixiv-cli/SKILL.md",
 		"sh scripts/test-rust-vendor.sh",
 		"cargo fmt --check",
 		"cargo clippy --locked --offline --all-targets -- -D warnings",

--- a/skills/pixiv-cli/SKILL.md
+++ b/skills/pixiv-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 slug: pixiv-cli
-version: 0.8.0
+version: 0.9.1
 displayName: Pixiv CLI
 summary: Safely operate Pixiv with the pixiv-cli binary for discovery, account actions, and downloads.
 license: MIT


### PR DESCRIPTION
## Summary

- align the product Skill metadata with the forthcoming v0.9.1 CLI release
- reject a release tag before protected E2E or credentials when its product Skill version differs from the tag
- repeat the source validation in test and production builds, with policy mutation coverage

## Scope and compatibility

Release tooling and distributed Skill metadata only; no CLI, MCP, SDK, account, or configuration contract changes. The product Skill version now intentionally matches the CLI release it teaches.

## Verification

- `go run ./scripts/releaseassets validate-source --version 0.9.1 --product-skill skills/pixiv-cli/SKILL.md`
- `go test ./scripts/releaseassets ./scripts/releaseworkflow ./scripts/documentation ./scripts/clawhubworkflow -count=1`
- `sh scripts/test-release-workflow.sh`
- pre-commit: `go test ./...`

## Release note declaration

<!-- release-note
category: Fixed
breaking: false
summary: Prevent releases whose product Skill version cannot be published with the matching CLI release.
none_reason:
-->

## Checklist

- [x] The change is focused.
- [x] I added or updated focused tests for changed behavior.
- [x] I ran the relevant tests and recorded the results above.
- [x] I updated the required README and maintainer documentation.
- [x] I completed the required release-note declaration above.
- [x] I did not add secrets, private URLs, downloaded works, local state, or private API responses.

## Summary by Sourcery

在发布阶段添加验证，确保 `pixiv-cli` 产品 Skill 元数据版本与不可变的 CLI 发布标签一致，并将其集成到所有受保护的发布工作流中。

New Features:
- 引入 `releaseassets validate-source` 子命令，用于根据指定的发布版本验证产品 Skill 文件的版本。

Bug Fixes:
- 当 `pixiv-cli` 产品 Skill 版本与对应的 CLI 发布标签不匹配时，阻止发布继续进行。

Enhancements:
- 更新 `pixiv-cli` Skill 元数据，使其版本与 CLI 0.9.1 发布对齐。

CI:
- 在受保护测试和发布凭据之前，将发布工作流中的验证任务绑定到针对 `pixiv-cli` 的 `SKILL.md` 的 `validate-source` 检查。
- 更新恢复、测试和生产构建策略，要求将 `validate-source` 作为发布标签的质量门槛。

Documentation:
- 在维护者和用户的 README 文档中明确说明，每个 `pixiv-cli` Skill 版本现已与其所描述的 CLI 发布版本相匹配。

Tests:
- 为 `validate-source` 和产品 Skill 元数据验证添加单元测试，包括对缺失或修改验证步骤的工作流策略变更的覆盖。

Chores:
- 将 `pixiv-cli` 的 `SKILL.md` 版本修订为 0.9.1，以匹配即将发布的 CLI 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add release-time validation that the pixiv-cli product Skill metadata version matches the immutable CLI release tag and integrate it into all protected release workflows.

New Features:
- Introduce a releaseassets validate-source subcommand to verify a product Skill file version against a given release version.

Bug Fixes:
- Prevent releases from proceeding when the pixiv-cli product Skill version does not match the corresponding CLI release tag.

Enhancements:
- Update pixiv-cli Skill metadata to align its version with CLI release 0.9.1.

CI:
- Bind the release workflow validate job to validate-source checks on the pixiv-cli SKILL.md before protected tests and publishing credentials.
- Update recovery, test, and production build policies to require validate-source as a quality gate for release tags.

Documentation:
- Clarify in maintainer and user README documentation that each pixiv-cli Skill version now matches the CLI release it describes.

Tests:
- Add unit tests for validate-source and product Skill metadata validation, including workflow policy mutation coverage for missing or altered validation steps.

Chores:
- Revise SKILL.md version for pixiv-cli to 0.9.1 to match the upcoming CLI release.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增发布源校验，确保技能版本、发布标签及元数据保持一致。
  * 发布验证和构建流程现在会校验对应发布标签中的技能内容。

* **文档**
  * 更新中、英、日文档，明确技能版本与 CLI 发布版本保持一致。
  * 更新维护者发布流程说明。

* **其他**
  * `pixiv-cli` 技能版本更新至 0.9.1。
  * 增加相关校验场景的自动化测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->