### PR TITLE
chore(release): prepare v0.9.1 notes

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@ grouped by user outcome and carry inline PR or historical direct-commit sources;
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.9.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.9.0...v0.9.1) | 2026-08-01 | [English](v0.9.1/en.md) · [简体中文](v0.9.1/zh-CN.md) |
 | [v0.9.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.8.0...v0.9.0) | 2026-07-31 | [English](v0.9.0/en.md) · [简体中文](v0.9.0/zh-CN.md) |
 | [v0.8.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.2...v0.8.0) | 2026-07-28 | [English](v0.8.0/en.md) · [简体中文](v0.8.0/zh-CN.md) |
 | [v0.7.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.1...v0.7.2) | 2026-07-25 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,6 +5,7 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | 未发布 | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.9.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.9.0...v0.9.1) | 2026-08-01 | [English](v0.9.1/en.md) · [简体中文](v0.9.1/zh-CN.md) |
 | [v0.9.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.8.0...v0.9.0) | 2026-07-31 | [English](v0.9.0/en.md) · [简体中文](v0.9.0/zh-CN.md) |
 | [v0.8.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.2...v0.8.0) | 2026-07-28 | [English](v0.8.0/en.md) · [简体中文](v0.8.0/zh-CN.md) |
 | [v0.7.2](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.1...v0.7.2) | 2026-07-25 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |

--- a/changelog/v0.9.1/en.md
+++ b/changelog/v0.9.1/en.md
@@ -1,0 +1,12 @@
+# v0.9.1 — 2026-08-01
+
+## Fixed
+
+- Restore release validation for historical commits explicitly attributed by the audit, so valid release preparation is not rejected. ([#42](https://github.com/FlanChanXwO/pixiv-cli/pull/42))
+- Require the product Skill version to match the CLI release before protected release jobs run, so the matching SkillHub and ClawHub publication can proceed. ([#44](https://github.com/FlanChanXwO/pixiv-cli/pull/44))
+
+## Maintenance
+
+- Restore the audited workflow-dispatch recovery path used to verify release-notes policy for immutable release tags. ([#43](https://github.com/FlanChanXwO/pixiv-cli/pull/43))
+
+**Full Changelog**: [v0.9.0...v0.9.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.9.0...v0.9.1)

--- a/changelog/v0.9.1/zh-CN.md
+++ b/changelog/v0.9.1/zh-CN.md
@@ -1,0 +1,12 @@
+# v0.9.1 — 2026-08-01
+
+## 修复
+
+- 恢复对审计中明确标注来源的历史提交的发布校验，避免有效的发布准备被错误拒绝。 ([#42](https://github.com/FlanChanXwO/pixiv-cli/pull/42))
+- 在受保护的发布任务运行前校验产品 Skill 版本与 CLI release 一致，使对应版本能够发布到 SkillHub 和 ClawHub。 ([#44](https://github.com/FlanChanXwO/pixiv-cli/pull/44))
+
+## 维护
+
+- 恢复用于核验不可变 release tag 发布说明策略的、经审计的 workflow_dispatch 恢复路径。 ([#43](https://github.com/FlanChanXwO/pixiv-cli/pull/43))
+
+**完整变更**：[v0.9.0...v0.9.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.9.0...v0.9.1)


### PR DESCRIPTION
## Summary

Prepare bilingual v0.9.1 release notes and changelog indexes from the audited v0.9.0...434a262 range.

## Scope and compatibility

No CLI, MCP, SDK, configuration, or output-contract change. This release-prep PR records the already merged release fixes.

## Release authorization

The current session authorizes publishing `v0.9.1` from the `v0.9.0...v0.9.1` range. Expected impact: patch release with no breaking changes; it restores release-note recovery validation and ensures the matching product Skill can be published to SkillHub and ClawHub.

## Verification

```text
go run ./scripts/releasenotes audit --repo FlanChanXwO/pixiv-cli --from v0.9.0 --to HEAD --output /tmp/pixiv-cli-v0.9.1-audit.json --require-classified
go run ./scripts/releasenotes prepare --version 0.9.1 --previous v0.9.0 --date 2026-08-01 --plan /tmp/pixiv-cli-v0.9.1-plan.json --audit /tmp/pixiv-cli-v0.9.1-audit.json --apply
go run ./scripts/releasenotes validate --version 0.9.1 --dir changelog/v0.9.1 --previous v0.9.0 --audit /tmp/pixiv-cli-v0.9.1-audit.json
go test ./scripts/documentation ./scripts/releaseworkflow -count=1
sh scripts/test-release-workflow.sh
```

<!-- release-note
category: None
breaking: false
summary: Prepare bilingual v0.9.1 release notes.
none_reason: Release preparation only; all user-facing changes are already covered by audited PRs #42, #43, and #44.
-->

## Summary by Sourcery

为 v0.9.1 补丁版本准备双语文档，并基于已审计的 v0.9.0...v0.9.1 变更，将其从变更日志索引中进行链接。

Documentation:
- 添加 v0.9.1 双语发行说明，描述已审计的修复和维护性更改。
- 更新变更日志索引，以引用新的 v0.9.1 说明及比较范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare bilingual documentation for the v0.9.1 patch release and link it from the changelog indexes based on the audited v0.9.0...v0.9.1 changes.

Documentation:
- Add bilingual v0.9.1 release notes describing audited fixes and maintenance changes.
- Update changelog indexes to reference the new v0.9.1 notes and comparison range.

</details>