### PR TITLE
chore(release): prepare v0.10.0 notes

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@ grouped by user outcome and carry inline PR or historical direct-commit sources;
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.10.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.9.1...v0.10.0) | 2026-08-01 | [English](v0.10.0/en.md) · [简体中文](v0.10.0/zh-CN.md) |
 | [v0.9.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.9.0...v0.9.1) | 2026-08-01 | [English](v0.9.1/en.md) · [简体中文](v0.9.1/zh-CN.md) |
 | [v0.9.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.8.0...v0.9.0) | 2026-07-31 | [English](v0.9.0/en.md) · [简体中文](v0.9.0/zh-CN.md) |
 | [v0.8.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.2...v0.8.0) | 2026-07-28 | [English](v0.8.0/en.md) · [简体中文](v0.8.0/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,6 +5,7 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | 未发布 | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.10.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.9.1...v0.10.0) | 2026-08-01 | [English](v0.10.0/en.md) · [简体中文](v0.10.0/zh-CN.md) |
 | [v0.9.1](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.9.0...v0.9.1) | 2026-08-01 | [English](v0.9.1/en.md) · [简体中文](v0.9.1/zh-CN.md) |
 | [v0.9.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.8.0...v0.9.0) | 2026-07-31 | [English](v0.9.0/en.md) · [简体中文](v0.9.0/zh-CN.md) |
 | [v0.8.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.7.2...v0.8.0) | 2026-07-28 | [English](v0.8.0/en.md) · [简体中文](v0.8.0/zh-CN.md) |

--- a/changelog/unreleased/en.md
+++ b/changelog/unreleased/en.md
@@ -1,12 +1,3 @@
 # Unreleased
 
 > Release-prep staging area. Feature PRs provide their category and summary in the PR template; the approved release-prep plan groups those sources into the next versioned notes.
-
-## Breaking changes
-
-- Removed the standalone `pixiv filter` command. Apply `--filter EXPR` directly to visual list commands or `pixiv download`.
-- Replaced CLI `--ugoira-format` with `--ugoira-mode gif|apng|zip|frames`.
-
-## Added
-
-- Added safe typed illustration expressions, automatic NDJSON for piped visual lists, download archives, metadata sidecars, directory templates, retry controls, request pacing, Ugoira ZIP/frames output, open-ended page ranges, public-bookmark and illustration-series download sources, and SOCKS proxy URIs.

--- a/changelog/unreleased/zh-CN.md
+++ b/changelog/unreleased/zh-CN.md
@@ -1,12 +1,3 @@
 # 未发布
 
 > 此处是 release-prep 暂存区。功能 PR 在模板中提供分类和摘要；经审核的 release-prep plan 会将这些来源归并到下一个版本说明。
-
-## 破坏性变更
-
-- 移除独立的 `pixiv filter` 命令；视觉列表和 `pixiv download` 直接使用 `--filter EXPR`。
-- CLI 的 `--ugoira-format` 改为 `--ugoira-mode gif|apng|zip|frames`。
-
-## 新增
-
-- 新增安全的插画表达式筛选、管道视觉列表自动 NDJSON、下载归档、元数据 sidecar、目录模板、重试控制、请求间隔、Ugoira ZIP/frames 输出、开区间页选择、公开书签/插画系列下载来源，以及 SOCKS 代理 URI。

--- a/changelog/v0.10.0/en.md
+++ b/changelog/v0.10.0/en.md
@@ -1,0 +1,17 @@
+# v0.10.0 — 2026-08-01
+
+## Breaking changes
+
+- Move artwork filtering to <code>--filter EXPR</code> on visual list and download commands, replacing <code>pixiv filter</code>; replace the CLI <code>--ugoira-format</code> flag with <code>--ugoira-mode</code>. ([#46](https://github.com/FlanChanXwO/pixiv-cli/pull/46))
+
+## Added
+
+- Add a typed local illustration filter shared by the SDK, CLI, and MCP, including tag/tool collection predicates and preflight validation without extra Pixiv requests. ([#46](https://github.com/FlanChanXwO/pixiv-cli/pull/46))
+- Add resilient downloads with SQLite artwork archives, atomic metadata sidecars, extended file and directory templates, configurable retries and request pacing, open page ranges, and GIF/APNG/ZIP/frame ugoira outputs. ([#46](https://github.com/FlanChanXwO/pixiv-cli/pull/46))
+- Accept public-bookmark and illustration-series URLs as download sources with canonical artwork deduplication, and support HTTP(S), SOCKS5, and SOCKS5H proxy URIs consistently across runtime and update requests. ([#46](https://github.com/FlanChanXwO/pixiv-cli/pull/46))
+
+## Changed
+
+- Make visual list commands emit canonical Record NDJSON when stdout is non-interactive, so their output can be piped directly into <code>pixiv download</code> without an external JSON processor. ([#46](https://github.com/FlanChanXwO/pixiv-cli/pull/46))
+
+**Full Changelog**: [v0.9.1...v0.10.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.9.1...v0.10.0)

--- a/changelog/v0.10.0/zh-CN.md
+++ b/changelog/v0.10.0/zh-CN.md
@@ -1,0 +1,17 @@
+# v0.10.0 — 2026-08-01
+
+## 破坏性变更
+
+- 将作品筛选迁移到视觉列表和下载命令的 <code>--filter EXPR</code>，替代 <code>pixiv filter</code>；将 CLI <code>--ugoira-format</code> 替换为 <code>--ugoira-mode</code>。 ([#46](https://github.com/FlanChanXwO/pixiv-cli/pull/46))
+
+## 新增
+
+- 新增由 SDK、CLI 和 MCP 共用的类型化本地作品筛选器，支持标签与绘图工具集合谓词，并在请求 Pixiv 前完成校验。 ([#46](https://github.com/FlanChanXwO/pixiv-cli/pull/46))
+- 新增可靠下载能力：SQLite 作品归档、原子元数据 sidecar、扩展的文件名与目录模板、可配置重试与请求间隔、开放页码范围，以及 GIF/APNG/ZIP/逐帧 ugoira 输出。 ([#46](https://github.com/FlanChanXwO/pixiv-cli/pull/46))
+- 支持将公开书签页和插画系列 URL 作为下载来源，并按规范作品 ID 去重；运行期和更新请求一致支持 HTTP(S)、SOCKS5 与 SOCKS5H 代理 URI。 ([#46](https://github.com/FlanChanXwO/pixiv-cli/pull/46))
+
+## 变更
+
+- 视觉列表命令在 stdout 非交互时输出规范 Record NDJSON，可直接管道到 <code>pixiv download</code>，无需外部 JSON 处理器。 ([#46](https://github.com/FlanChanXwO/pixiv-cli/pull/46))
+
+**完整变更**：[v0.9.1...v0.10.0](https://github.com/FlanChanXwO/pixiv-cli/compare/v0.9.1...v0.10.0)


### PR DESCRIPTION
## Summary / 概述 / 概要

Prepare bilingual v0.10.0 release notes from the audited v0.9.1..PR #46 range.

## Scope and compatibility / 范围与兼容性 / 変更範囲と互换性

Release-prep only: adds versioned notes and indexes, then clears the consumed unreleased staging entries. It introduces no additional runtime behavior.

## Verification / 验证 / 検証

- `go run ./scripts/releasenotes audit --repo FlanChanXwO/pixiv-cli --from v0.9.1 --to eaeaa2f228dd479b496da82a08d57135e0cc6d7a --output /tmp/pixiv-cli-v0.10.0-audit.json --require-classified` — passed
- `go run ./scripts/releasenotes prepare --version 0.10.0 --previous v0.9.1 --date 2026-08-01 --plan /tmp/pixiv-cli-v0.10.0-plan.json --audit /tmp/pixiv-cli-v0.10.0-audit.json --apply` — passed
- `go run ./scripts/releasenotes validate --version 0.10.0 --previous v0.9.1 --dir changelog/v0.10.0 --audit /tmp/pixiv-cli-v0.10.0-audit.json` — passed
- `go test ./scripts/documentation ./scripts/releasenotes` — passed
- `git diff --check` — passed

## Release note declaration / Release note 声明 / リリースノート宣言

<!-- release-note
category: None
breaking: false
summary: Prepare audited v0.10.0 release notes.
none_reason: This PR only renders audited release notes for the already-classified PR #46.
-->

## Checklist / 检查清单 / チェックリスト

- [x] The change is focused and linked to an issue when appropriate.
- [x] I added or updated focused tests for changed behavior.
- [x] I ran the relevant tests and recorded the results above.
- [x] I updated the required documentation.
- [x] I completed the required release-note declaration.
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence.
- [x] I did not add refresh tokens, cookies, authorization codes, proxy credentials, private URLs, downloaded works, local state, or private API responses.
- [x] I updated migration guidance for every breaking change.