### PR TITLE
fix(release): align product skill with v0.10.0

### DIFF
--- a/skills/pixiv-cli/SKILL.md
+++ b/skills/pixiv-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 slug: pixiv-cli
-version: 0.9.1
+version: 0.10.0
 displayName: Pixiv CLI
 summary: Safely operate Pixiv with the pixiv-cli binary for discovery, account actions, and downloads.
 license: MIT


### PR DESCRIPTION
## Summary / 概述 / 概要

Align the released product Skill metadata with the authorized v0.10.0 CLI release.

## Scope and compatibility / 范围与兼容性 / 変更範囲と互換性

Updates only the product Skill front-matter version from 0.9.1 to 0.10.0. No command, SDK, MCP, configuration, or output behavior changes.

## Verification / 验证 / 検証

- `go test ./scripts/documentation ./scripts/releaseworkflow` — passed
- `git diff --check` — passed

## Release note declaration / Release note 声明 / リリースノート宣言

<!-- release-note
category: None
breaking: false
summary: Align the product Skill metadata with v0.10.0.
none_reason: This is release metadata required for the already-authorized v0.10.0 tag and introduces no user-facing behavior.
-->

## Checklist / 检查清单 / チェックリスト

- [x] I ran the relevant tests and recorded the results above.
- [x] I updated the required documentation.
- [x] I completed the required release-note declaration.
- [x] I did not add credentials, private URLs, downloaded works, local state, or private API responses.

## Summary by Sourcery

Enhancements:
- 将 Pixiv CLI Skill 的 front-matter 版本号从 0.9.1 更新为 0.10.0，以与已授权的 CLI 发行版本保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update Pixiv CLI Skill front-matter version from 0.9.1 to 0.10.0 to match the authorized CLI release.

</details>