### PR TITLE
fix(release): recover v0.10.0 e2e gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,41 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: '1.26.3'
+      # 已发布 tag 的 E2E 测试协议可能在发布前已修正；恢复只允许从默认分支覆盖这两份
+      # 测试，随后仍在 tag 的产品源码上运行，且本 step 不接触受保护的 E2E secret。
+      - name: Apply the audited E2E test recovery overlay
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          test -z "$(git diff --cached --name-only)"
+          e2e_recovery_overlay_paths=(
+            e2e/authenticated_r18_regression_test.go
+            e2e/pixiv_binary_test.go
+          )
+          git archive --format=tar "$GITHUB_SHA" -- "${e2e_recovery_overlay_paths[@]}" | tar -xf -
+          actual_overlay_paths="$(
+            {
+              git diff --name-only
+              git ls-files --others --exclude-standard
+            } | LC_ALL=C sort -u
+          )"
+          test -n "$actual_overlay_paths"
+          while IFS= read -r path; do
+            overlay_path_allowed=false
+            for allowed_path in "${e2e_recovery_overlay_paths[@]}"; do
+              if [ "$path" = "$allowed_path" ]; then
+                overlay_path_allowed=true
+                break
+              fi
+            done
+            if [ "$overlay_path_allowed" != true ]; then
+              printf 'unexpected E2E recovery overlay path: %s\n' "$path" >&2
+              exit 1
+            fi
+          done <<< "$actual_overlay_paths"
+          test -z "$(git diff --cached --name-only)"
       - name: Run authenticated Pixiv E2E
         shell: bash
         env:

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -379,8 +379,8 @@ policy 锁定 finalize 参数及完整八资产上传集合；Homebrew renderer 
 
 若不可变 tag 的首次 run 在创建 GitHub Release 前失败，维护者只能从默认分支通过
 `workflow_dispatch` 提交同一个 `release_tag` 进行恢复。validate 会校验该 tag 为 SemVer、存在、
-已包含于默认分支且尚未有 Release；构建与发布始终 checkout 该 tag。恢复 run 可以只在无 Environment
-的六平台 test job 中应用固定白名单的默认分支测试覆盖。v0.2.0 已完成的历史恢复使用四条路径：当时的
+已包含于默认分支且尚未有 Release；构建与发布始终 checkout 该 tag。恢复 run 只能在受审计的 test
+gate 中应用固定白名单的默认分支测试覆盖；生产构建与发布不会读取覆盖内容。v0.2.0 已完成的历史恢复使用四条路径：当时的
 release workflow、位于 `pixiv/account_external_test.go` 的 Windows ACL 测试，以及 canonical
 verifier 与其测试；这是不可改写的历史证据，不定义后续 tag 的 allowlist。
 
@@ -421,6 +421,17 @@ artifact。该 job 成功后，独立的新 runner
 才会以 `clean: true` checkout tag、重新构建 selected staticlib 并生成唯一可被 publish 下载的
 `verified-release-*` assets；测试进程对环境变量、PATH 或临时目录的副作用不会进入生产 job。因此它不能用于
 替换生产资产源码、移动 tag，或重发已经存在的 Release。
+
+受保护 E2E gate 另有独立、逐字固定的恢复 allowlist，仅用于修补已发布 tag 的测试契约：
+
+- `e2e/authenticated_r18_regression_test.go`
+- `e2e/pixiv_binary_test.go`
+
+该覆盖只在 `workflow_dispatch` 的 tag checkout 后发生，必须使用与六平台 gate 相同的 clean-worktree、
+cached diff、一次 `git archive`、非空 diff 与逐路径比对；它在受保护测试凭据注入前运行，不能包含产品源码、
+workflow、配置或任意额外文件。随后的真实 E2E 仍链接和执行 tag 中的产品源码；production job 则在新的
+worktree 只从 tag 重建资产。此例外用于恢复 v0.10.0 发现的旧 ugoira flag 与非交互 NDJSON 断言，不能扩展为
+通用的 tag 代码修补机制。
 
 恢复 workflow 的定义可以来自受审计的默认分支，但 production worktree 仍只含 tag bytes。为重现
 v0.3.0 tag 已提交 staticlib，test 与 production job 从相同六目标 matrix 读取上述 per-target Rust

--- a/e2e/authenticated_r18_regression_test.go
+++ b/e2e/authenticated_r18_regression_test.go
@@ -217,7 +217,7 @@ func TestPixivBinaryAuthenticatedR18RegressionCanary(t *testing.T) {
 
 	apngPath := filepath.Join(t.TempDir(), "download-apng")
 	_ = runPixivCanary(t, repoRoot, binaryPath, env, auth,
-		"download", "--ugoira-format", "apng", "--download-path", apngPath, strconvFormatInt(ids.ugoira))
+		"download", "--ugoira-mode", "apng", "--download-path", apngPath, strconvFormatInt(ids.ugoira))
 	requireCanaryAnimation(t, apngPath, ".apng", []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'})
 }
 

--- a/e2e/pixiv_binary_test.go
+++ b/e2e/pixiv_binary_test.go
@@ -339,16 +339,8 @@ func TestPixivBinaryRealAPISearchOptIn(t *testing.T) {
 	refreshToken := os.Getenv("PIXIV_E2E_REFRESH_TOKEN")
 
 	if refreshToken == "" {
-		run := exec.CommandContext(testCommandContext(t), binaryPath, "search", "初音ミク")
-		run.Dir = repoRoot
-		run.Env = env
-		out, err := run.CombinedOutput()
-		if err != nil {
-			t.Fatalf("unauthenticated real web fallback search failed: %v\n%s", err, string(out))
-		}
-		if !strings.Contains(string(out), `illustrations for "初音ミク"`) {
-			t.Fatalf("unauthenticated real web fallback search did not print the illustrations heading:\n%s", string(out))
-		}
+		out := runPixiv(t, repoRoot, binaryPath, env, "search", "初音ミク")
+		requireIllustRecordNDJSON(t, out, "unauthenticated real web fallback search")
 		return
 	}
 
@@ -360,8 +352,48 @@ func TestPixivBinaryRealAPISearchOptIn(t *testing.T) {
 	// App API 认证失败时，stdout/stderr 都可能带上服务端回显；统一交给
 	// canary helper 分流并在测试诊断前脱敏，避免显式注入的 token 泄露。
 	stdout := runPixivCanary(t, repoRoot, binaryPath, env, auth, "search", "初音ミク")
-	if !strings.Contains(string(stdout), `illustrations for "初音ミク"`) {
-		t.Fatalf("real API search did not print the illustrations heading:\n%s", redactCanaryDiagnostic(refreshToken, string(stdout)))
+	requireIllustRecordNDJSON(t, []byte(redactCanaryDiagnostic(refreshToken, string(stdout))), "real API search")
+}
+
+func TestValidateIllustRecordNDJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "accepts visual records",
+			body: `{"id":123,"type":"illust"}
+{"id":"456","type":"manga"}
+{"id":789,"type":"ugoira"}`,
+		},
+		{
+			name:    "rejects null id",
+			body:    `{"id":null,"type":"illust"}`,
+			wantErr: "has no id",
+		},
+		{
+			name:    "rejects unsupported type",
+			body:    `{"id":123,"type":"novel"}`,
+			wantErr: "unsupported type",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateIllustRecordNDJSON([]byte(test.body), test.name)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateIllustRecordNDJSON() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("validateIllustRecordNDJSON() error = %v, want %q", err, test.wantErr)
+			}
+		})
 	}
 }
 
@@ -877,6 +909,47 @@ func requireJSON(t *testing.T, body []byte, out any) {
 	if err := json.Unmarshal(body, out); err != nil {
 		t.Fatalf("decode JSON failed: %v\n%s", err, string(body))
 	}
+}
+
+// requireIllustRecordNDJSON 验证非交互 stdout 的视觉列表协议：每条记录都是可
+// 独立消费的 canonical Record，而不是只适合终端展示的标题和表格文本。
+func requireIllustRecordNDJSON(t *testing.T, body []byte, operation string) {
+	t.Helper()
+
+	if err := validateIllustRecordNDJSON(body, operation); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// validateIllustRecordNDJSON 把 stdout 记录协议保持为可直接单测的纯校验：每行必须是
+// 可独立消费的视觉 Record，且须带有非空 id。
+func validateIllustRecordNDJSON(body []byte, operation string) error {
+	seen := false
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var record struct {
+			ID   json.RawMessage `json:"id"`
+			Type string          `json:"type"`
+		}
+		if err := json.Unmarshal(line, &record); err != nil {
+			return fmt.Errorf("%s emitted invalid NDJSON: %w\n%s", operation, err, string(line))
+		}
+		if id := bytes.TrimSpace(record.ID); len(id) == 0 || bytes.Equal(id, []byte("null")) {
+			return fmt.Errorf("%s NDJSON record has no id: %s", operation, string(line))
+		}
+		switch record.Type {
+		case "illust", "manga", "ugoira":
+			seen = true
+		default:
+			return fmt.Errorf("%s NDJSON record has unsupported type %q: %s", operation, record.Type, string(line))
+		}
+	}
+	if !seen {
+		return fmt.Errorf("%s emitted no visual NDJSON records", operation)
+	}
+	return nil
 }
 
 func requireIllustListJSONShape(t *testing.T, body []byte, operation string) []pixiv.Illust {

--- a/scripts/releaseworkflow/e2e_policy.go
+++ b/scripts/releaseworkflow/e2e_policy.go
@@ -18,6 +18,38 @@ var authenticatedE2EVariableNames = []string{
 	"PIXIV_E2E_PROXY",
 }
 
+const e2eRecoveryOverlayCommands = `
+set -euo pipefail
+test -z "$(git status --porcelain=v1 --untracked-files=all)"
+test -z "$(git diff --cached --name-only)"
+e2e_recovery_overlay_paths=(
+  e2e/authenticated_r18_regression_test.go
+  e2e/pixiv_binary_test.go
+)
+git archive --format=tar "$GITHUB_SHA" -- "${e2e_recovery_overlay_paths[@]}" | tar -xf -
+actual_overlay_paths="$(
+  {
+    git diff --name-only
+    git ls-files --others --exclude-standard
+  } | LC_ALL=C sort -u
+)"
+test -n "$actual_overlay_paths"
+while IFS= read -r path; do
+  overlay_path_allowed=false
+  for allowed_path in "${e2e_recovery_overlay_paths[@]}"; do
+    if [ "$path" = "$allowed_path" ]; then
+      overlay_path_allowed=true
+      break
+    fi
+  done
+  if [ "$overlay_path_allowed" != true ]; then
+    printf 'unexpected E2E recovery overlay path: %s\n' "$path" >&2
+    exit 1
+  fi
+done <<< "$actual_overlay_paths"
+test -z "$(git diff --cached --name-only)"
+`
+
 func checkE2EJob(job *yaml.Node) error {
 	if err := requireRequiredJobExecution(job, "e2e job"); err != nil {
 		return err
@@ -41,8 +73,8 @@ func checkE2EJob(job *yaml.Node) error {
 		return fmt.Errorf("e2e job: %w", err)
 	}
 	steps, err := jobSteps(job)
-	if err != nil || len(steps) != 3 {
-		return errors.New("e2e job must contain only checkout, Go setup, and the authenticated test gate")
+	if err != nil || len(steps) != 4 {
+		return errors.New("e2e job must contain only checkout, Go setup, the audited recovery overlay, and the authenticated test gate")
 	}
 	if err := requireCanonicalCheckout(steps[0], "e2e job", checkoutWithRequirement{"fetch-depth", "0"}, checkoutWithRequirement{"persist-credentials", "false"}, checkoutWithRequirement{"ref", "${{ env.RELEASE_TAG }}"}); err != nil {
 		return err
@@ -50,7 +82,22 @@ func checkE2EJob(job *yaml.Node) error {
 	if err := requireExactActionStep(steps[1], "e2e Go setup", setupGoAction, map[string]string{"go-version": "1.26.3"}); err != nil {
 		return err
 	}
-	return checkAuthenticatedE2EStep(steps[2])
+	if err := requireE2ERecoveryOverlayStep(steps[2]); err != nil {
+		return err
+	}
+	return checkAuthenticatedE2EStep(steps[3])
+}
+
+// requireE2ERecoveryOverlayStep 限定恢复只能修补两个已验证失败的 E2E 契约测试；
+// 不可变 tag 的生产源码、发布资产及受保护凭据均不参与该覆盖。
+func requireE2ERecoveryOverlayStep(step *yaml.Node) error {
+	if err := requireCanonicalConditionalRunStep(step, "E2E recovery overlay", "github.event_name == 'workflow_dispatch'", e2eRecoveryOverlayCommands); err != nil {
+		return errors.New("E2E recovery overlay must use only the exact audited test paths and verifier")
+	}
+	if err := workflowpolicy.RequireScalar(step, "name", "Apply the audited E2E test recovery overlay"); err != nil {
+		return errors.New("E2E recovery overlay must keep its canonical name")
+	}
+	return nil
 }
 
 func checkAuthenticatedE2EStep(step *yaml.Node) error {

--- a/scripts/releaseworkflow/e2e_policy_test.go
+++ b/scripts/releaseworkflow/e2e_policy_test.go
@@ -27,14 +27,34 @@ func TestReleaseWorkflowHasProtectedAuthenticatedE2EGate(t *testing.T) {
 	}
 
 	steps := requireMappingValue(t, e2e, "steps").Content
-	if len(steps) != 3 {
-		t.Fatalf("e2e step count = %d, want 3", len(steps))
+	if len(steps) != 4 {
+		t.Fatalf("e2e step count = %d, want 4", len(steps))
 	}
-	run := requireMappingValue(t, steps[2], "run").Value
+	overlay := steps[2]
+	if got := requireMappingValue(t, overlay, "name").Value; got != "Apply the audited E2E test recovery overlay" {
+		t.Fatalf("e2e recovery overlay name = %q", got)
+	}
+	if got := requireMappingValue(t, overlay, "if").Value; got != "github.event_name == 'workflow_dispatch'" {
+		t.Fatalf("e2e recovery overlay condition = %q", got)
+	}
+	overlayRun := requireMappingValue(t, overlay, "run").Value
+	for _, path := range []string{
+		"e2e/authenticated_r18_regression_test.go",
+		"e2e/pixiv_binary_test.go",
+	} {
+		if strings.Count(overlayRun, path) != 1 {
+			t.Fatalf("e2e recovery overlay must include only one %s entry", path)
+		}
+	}
+	if strings.Contains(overlayRun, "pixiv/") || strings.Contains(overlayRun, "internal/") {
+		t.Fatal("e2e recovery overlay must not include product source paths")
+	}
+
+	run := requireMappingValue(t, steps[3], "run").Value
 	if !strings.Contains(run, "go test ./e2e -count=1 -v") {
 		t.Fatal("e2e gate must run the complete e2e suite")
 	}
-	env := requireMappingValue(t, steps[2], "env")
+	env := requireMappingValue(t, steps[3], "env")
 	if got := requireMappingValue(t, env, "PIXIV_E2E_REFRESH_TOKEN").Value; got != "${{ secrets.PIXIV_E2E_REFRESH_TOKEN }}" {
 		t.Fatal("e2e refresh token must come from the protected environment secret")
 	}
@@ -49,8 +69,8 @@ func TestReleaseWorkflowHasProtectedAuthenticatedE2EGate(t *testing.T) {
 			t.Fatalf("e2e %s must come from the protected environment variable", name)
 		}
 	}
-	if workflowpolicy.ContainsSecretReference(steps[0]) || workflowpolicy.ContainsSecretReference(steps[1]) {
-		t.Fatal("e2e checkout and setup steps must not reference secrets")
+	if workflowpolicy.ContainsSecretReference(steps[0]) || workflowpolicy.ContainsSecretReference(steps[1]) || workflowpolicy.ContainsSecretReference(steps[2]) {
+		t.Fatal("e2e checkout, setup, and recovery overlay steps must not reference secrets")
 	}
 
 	buildNeeds := requireMappingValue(t, jobNode(t, root, "build"), "needs").Content
@@ -92,7 +112,7 @@ func TestCheckWorkflowRejectsAuthenticatedE2EGateMutations(t *testing.T) {
 			name: "refresh token secret changes",
 			want: "PIXIV_E2E_REFRESH_TOKEN",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				env := requireMappingValue(t, requireMappingValue(t, jobNode(t, root, "e2e"), "steps").Content[2], "env")
+				env := requireMappingValue(t, requireMappingValue(t, jobNode(t, root, "e2e"), "steps").Content[3], "env")
 				requireMappingValue(t, env, "PIXIV_E2E_REFRESH_TOKEN").Value = "${{ secrets.OTHER }}"
 			},
 		},
@@ -100,7 +120,7 @@ func TestCheckWorkflowRejectsAuthenticatedE2EGateMutations(t *testing.T) {
 			name: "required input changes source",
 			want: "PIXIV_E2E_DISCOVERY_WORD",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				env := requireMappingValue(t, requireMappingValue(t, jobNode(t, root, "e2e"), "steps").Content[2], "env")
+				env := requireMappingValue(t, requireMappingValue(t, jobNode(t, root, "e2e"), "steps").Content[3], "env")
 				requireMappingValue(t, env, "PIXIV_E2E_DISCOVERY_WORD").Value = "hard-coded"
 			},
 		},
@@ -108,8 +128,20 @@ func TestCheckWorkflowRejectsAuthenticatedE2EGateMutations(t *testing.T) {
 			name: "direct test command is softened",
 			want: "authenticated e2e step must run the complete direct E2E command sequence",
 			mutate: func(t *testing.T, root *yaml.Node) {
-				step := requireMappingValue(t, jobNode(t, root, "e2e"), "steps").Content[2]
+				step := requireMappingValue(t, jobNode(t, root, "e2e"), "steps").Content[3]
 				requireMappingValue(t, step, "run").Value += " || true"
+			},
+		},
+		{
+			name: "e2e recovery overlay writes product source",
+			want: "E2E recovery overlay must use only the exact audited test paths and verifier",
+			mutate: func(t *testing.T, root *yaml.Node) {
+				step := requireMappingValue(t, jobNode(t, root, "e2e"), "steps").Content[2]
+				requireMappingValue(t, step, "run").Value = strings.ReplaceAll(
+					requireMappingValue(t, step, "run").Value,
+					"e2e/pixiv_binary_test.go",
+					"pixiv/client.go",
+				)
 			},
 		},
 		{

--- a/scripts/releaseworkflow/recovery_policy.go
+++ b/scripts/releaseworkflow/recovery_policy.go
@@ -78,8 +78,8 @@ func checkRecoveryPolicy(root *yaml.Node) error {
 	if containsScalarFragment(root, "GITHUB_REF_NAME") {
 		return errors.New("release workflow must not derive production identity from GITHUB_REF_NAME")
 	}
-	if countScalarFragment(root, "GITHUB_SHA") != 1 {
-		return errors.New("only the test overlay may read the audited workflow GITHUB_SHA")
+	if countScalarFragment(root, "GITHUB_SHA") != 2 {
+		return errors.New("only the audited E2E and build test overlays may read the workflow GITHUB_SHA")
 	}
 	steps, err := jobSteps(build)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Correct the v0.10.0 E2E canary assertions for the released ugoira flag and non-interactive NDJSON contract.
- Permit a tightly audited test-only overlay when recovering the already-created immutable tag.

## Scope and compatibility

None. The immutable tag remains the only source of CLI, SDK, MCP, configuration, release notes, and production assets.

## Verification

- `go test ./...` — passed.
- `go test -race ./...` — passed.
- `go vet ./...` — passed.
- `sh scripts/build.sh` — passed.
- `go test ./e2e -count=1 -v` — passed; real Pixiv canaries skipped locally because protected credentials were not injected.
- `go test ./scripts/releaseworkflow ./scripts/documentation -count=1` — passed.
- `sh scripts/test-release-workflow.sh` and `pre-commit run --files ...` — passed.

<!-- release-note
category: None
breaking: false
summary: Recover the v0.10.0 protected E2E gate before publication.
none_reason: This only corrects test contracts and the audited recovery workflow for the existing immutable tag; it does not alter public behavior or release content.
-->

## Checklist

- [x] The change is focused.
- [x] I added or updated focused tests for changed behavior.
- [x] I ran the relevant tests and recorded the results above.
- [x] I updated the required maintainer documentation.
- [x] I completed the required release-note declaration above; None has a concrete reason.
- [x] I did not add sensitive data or private responses.

## Summary by Sourcery

通过收紧恢复工作流并更新 Pixiv 二进制测试契约以匹配已发布行为，恢复受保护的 v0.10.0 版本 E2E gate。

Bug Fixes（缺陷修复）:
- 更新已认证的 Pixiv 二进制 E2E 断言，以验证 NDJSON 输出以及已发布 CLI 的正确 ugoira 模式标志。

Enhancements（增强）:
- 在发布工作流中引入一个经审计、作用范围严格限定的 E2E 测试恢复覆盖步骤，仅从默认分支中修补特定测试文件，而不触及产品源码。
- 扩展发布恢复策略和维护者文档，以涵盖新的 E2E 恢复覆盖限制以及经审计的 GITHUB_SHA 使用方式。

Build（构建）:
- 通过调整对 GITHUB_SHA 使用方式的预期，在发布恢复策略中允许额外一个经审计的测试覆盖层。

Documentation（文档）:
- 在维护者文档中记录 E2E gate 恢复允许列表、`workflow_dispatch` 约束，以及 v0.10.0 测试契约修复的非扩展性特征。

Tests（测试）:
- 加强发布工作流 E2E 策略测试，要求必须存在经审计的恢复覆盖步骤，并拒绝任何不在允许列表中或涉及产品源码的覆盖操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore the protected v0.10.0 release E2E gate by tightening its recovery workflow and updating Pixiv binary test contracts for the released behavior.

Bug Fixes:
- Update authenticated Pixiv binary E2E assertions to validate NDJSON output and the correct ugoira mode flag for the released CLI.

Enhancements:
- Introduce an audited, tightly scoped E2E test recovery overlay step in the release workflow that only patches specific test files from the default branch without touching product sources.
- Extend release recovery policy and maintainer documentation to cover the new E2E recovery overlay constraints and audited GITHUB_SHA usage.

Build:
- Allow an additional audited test overlay in the release recovery policy by adjusting GITHUB_SHA usage expectations.

Documentation:
- Document the E2E gate recovery allowlist, workflow_dispatch constraints, and the non-expanding nature of the v0.10.0 test contract fix in maintainer docs.

Tests:
- Strengthen release workflow E2E policy tests to require the audited recovery overlay step and to reject any non-allowlisted or product-source overlays.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **发布流程**
  * 手动恢复发布时增加受审计的 E2E 测试覆盖机制，严格限制可恢复内容，避免影响产品源码及正式构建。
  * 发布前强化工作区、变更路径和暂存状态校验，提升发布安全性与可追溯性。

* **测试改进**
  * 修正 APNG 下载回归测试参数。
  * 改进搜索结果验证，支持检查视觉内容记录及其关键字段。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->