### PR TITLE
fix(release): handle pending ClawHub security scans

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -133,8 +133,8 @@ jobs:
           }
           fs.appendFileSync(output, `fingerprint=${result.fingerprint}\n`);
           NODE
-      # ClawHub 的普通 publish 将公开文件与扫描结果写入服务端，而 skill-card.md
-      # 是服务端扫描稳定后异步生成的证据文件。人工恢复只验证已有版本，绝不重发。
+      # ClawHub 的普通 publish 将公开文件与扫描结果写入服务端。skill-card.md 与汇总
+      # 安全结论都可能异步生成；人工恢复只验证已有版本，绝不重发。
       - name: Verify an already-published ClawHub skill
         if: inputs.verify_only == true
         shell: bash
@@ -199,14 +199,41 @@ jobs:
           const identityMatches = verify.schema === "clawhub.skill.verify.v1" && verify.slug === "pixiv-cli" && verify.version === version && verify.resolvedFrom === "version";
           const artifactMatches = verify.artifact?.sourceFingerprint === fingerprint;
           const securityIsClean = verify.security?.passed === true && verify.security?.status === "clean";
+          const staticScanClean = verify.security?.signals?.staticScan?.status === "clean";
+          const aggregateSecurityPending = verify.security?.passed === false && verify.security?.status === "pending";
           const cardPendingOnly = verify.ok === false && verify.decision === "fail" && verify.reasons?.length === 1 && verify.reasons[0] === "card.missing";
+          // ClawHub 0.23.1 在 aggregate security 尚未完成时实际返回这三条 reason；
+          // 允许集合必须保持封闭，新增或未知 reason 一律拒绝发布结果。
+          const pendingReasonCodes = new Set(["card.missing", "security.status_not_clean", "security.pending"]);
+          const pendingAggregationOnly = verify.ok === false && verify.decision === "fail" && Array.isArray(verify.reasons) && verify.reasons.length > 0 && verify.reasons.every((reason) => pendingReasonCodes.has(reason)) && staticScanClean && aggregateSecurityPending;
           const passed = verify.ok === true && verify.decision === "pass" && Array.isArray(verify.reasons) && verify.reasons.length === 0;
-          if (!identityMatches || !artifactMatches || !securityIsClean || (!passed && !cardPendingOnly) || (passed && exitCode !== "0") || (cardPendingOnly && exitCode !== "1")) {
+          const rejectVerification = () => {
             console.error(JSON.stringify(verify, null, 2));
             throw new Error("ClawHub verification did not establish the immutable published artifact");
+          };
+          if (!identityMatches || !artifactMatches) {
+            rejectVerification();
+          }
+          if (passed) {
+            if (!securityIsClean || exitCode !== "0") {
+              rejectVerification();
+            }
+          } else if (cardPendingOnly) {
+            if (!securityIsClean || exitCode !== "1") {
+              rejectVerification();
+            }
+          } else if (pendingAggregationOnly) {
+            if (exitCode !== "1") {
+              rejectVerification();
+            }
+          } else {
+            rejectVerification();
           }
           if (cardPendingOnly) {
             console.warn("::warning title=ClawHub skill card pending::The published artifact and security scan are verified, but ClawHub has not generated its asynchronous skill-card.md yet.");
+          }
+          if (pendingAggregationOnly) {
+            console.warn("::warning title=ClawHub aggregate security scan pending::The published artifact and ClawHub static scan are verified, but the platform has not completed its aggregate security decision. Run verify_only later; it requires a clean completed scan.");
           }
           if (verify.provenance?.source === "unavailable") {
             console.warn("::warning title=ClawHub source provenance unavailable::ClawHub does not expose server-resolved GitHub import provenance for this CLI publish; the workflow verified the trusted tag and exact artifact fingerprint locally.");

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -201,7 +201,9 @@ jobs:
           const securityIsClean = verify.security?.passed === true && verify.security?.status === "clean";
           const staticScanClean = verify.security?.signals?.staticScan?.status === "clean";
           const aggregateSecurityPending = verify.security?.passed === false && verify.security?.status === "pending";
-          const cardPendingOnly = verify.ok === false && verify.decision === "fail" && verify.reasons?.length === 1 && verify.reasons[0] === "card.missing";
+          // aggregate security pending 时 card.missing 也是平台返回的原因之一；该状态
+          // 必须交给下方的 aggregate 分支检查静态扫描与封闭 reason 集合。
+          const cardPendingOnly = !aggregateSecurityPending && verify.ok === false && verify.decision === "fail" && verify.reasons?.length === 1 && verify.reasons[0] === "card.missing";
           // ClawHub 0.23.1 在 aggregate security 尚未完成时实际返回这三条 reason；
           // 允许集合必须保持封闭，新增或未知 reason 一律拒绝发布结果。
           const pendingReasonCodes = new Set(["card.missing", "security.status_not_clean", "security.pending"]);

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -578,7 +578,7 @@ validation 会在受保护 E2E 和任何发布凭据之前拒绝不匹配的版�
 仅进入最后的提交步骤，CLI 必须返回 `skillId` 和审核状态；这证明 SkillHub 已接收提交，但平台审核完成前
 公开详情页可能仍不可见。
 若任一独立发布失败，可通过对应 workflow 的 `workflow_dispatch` 输入既有发布 tag 恢复，不能用 main 的
-后续内容替代该 tag。ClawHub workflow 与 SkillHub 使用同一不可变 tag handoff：它先验证公开非 draft Release、默认分支祖先关系、`SKILL.md` 版本与 tag 一致性以及产品 skill 的改动，再在不含凭据的环境运行固定版本的 ClawHub CLI dry-run，并以其 SHA-256 产物指纹校验实际发布物。只有最终 publish/inspect 步骤，以及不重发版本的 `verify_only` 人工恢复步骤会收到 `CLAWHUB_TOKEN`；后者只登录并读取审核结果，绝不调用 publish。验证必须确认产品 skill、对应版本、精确产物指纹与 clean 安全扫描。ClawHub 的普通 CLI publish 后，`skill-card.md` 由服务端异步生成；如果唯一原因是 `card.missing`，工作流会明确发 warning 而不把已完成的发布误报为失败。其他任何原因仍会失败。当前平台也不会为普通 CLI publish 暴露 server-resolved GitHub provenance，因此该项以受信 tag checkout 和指纹匹配替代，并同样保留 warning。
+后续内容替代该 tag。ClawHub workflow 与 SkillHub 使用同一不可变 tag handoff：它先验证公开非 draft Release、默认分支祖先关系、`SKILL.md` 版本与 tag 一致性以及产品 skill 的改动，再在不含凭据的环境运行固定版本的 ClawHub CLI dry-run，并以其 SHA-256 产物指纹校验实际发布物。只有最终 publish/inspect 步骤，以及不重发版本的 `verify_only` 人工恢复步骤会收到 `CLAWHUB_TOKEN`；后者只登录并读取审核结果，绝不调用 publish。正常 publish 必须确认产品 skill、对应版本和精确产物指纹；当 ClawHub static scan 已 clean、但聚合安全结论仍为 `pending` 时，会明确 warning 而不把已接收的发布物误报为失败。`skill-card.md` 也可能异步生成并产生 warning。两类 warning 都不等同于最终安全结论：`verify_only` 只在 aggregate security 为 clean 时通过，便于在平台扫描完成后作不重发的最终核验。任何其他原因仍会失败。当前平台也不会为普通 CLI publish 暴露 server-resolved GitHub provenance，因此该项以受信 tag checkout 和指纹匹配替代，并同样保留 warning。
 
 ## Git 与本地产物
 

--- a/scripts/clawhubworkflow/main_test.go
+++ b/scripts/clawhubworkflow/main_test.go
@@ -1,7 +1,9 @@
 package clawhubworkflow
 
 import (
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -106,6 +108,107 @@ func TestPublishWorkflowKeepsTheImmutableReleaseAndSecretBoundary(t *testing.T) 
 		if !strings.Contains(verifyRun, required) {
 			fatalf(t, "immutable-source verification is missing %q", required)
 		}
+	}
+}
+
+// TestPublishWorkflowAcceptsOnlyDocumentedPendingAggregation 验证工作流内嵌的
+// Node 校验器本身。ClawHub 的 aggregate security 是异步信号：只有静态扫描已
+// clean、reason 位于封闭白名单且命令以状态 1 退出时，发布后检查才可暂时通过。
+func TestPublishWorkflowAcceptsOnlyDocumentedPendingAggregation(t *testing.T) {
+	const version = "v0.10.0"
+	const fingerprint = "test-fingerprint"
+	publish := map[string]any{
+		"slug":        "pixiv-cli",
+		"version":     version,
+		"fingerprint": fingerprint,
+	}
+	pending := func(reasons []string, staticScan string) map[string]any {
+		return map[string]any{
+			"schema":       "clawhub.skill.verify.v1",
+			"slug":         "pixiv-cli",
+			"version":      version,
+			"resolvedFrom": "version",
+			"artifact":     map[string]any{"sourceFingerprint": fingerprint},
+			"security": map[string]any{
+				"passed": false,
+				"status": "pending",
+				"signals": map[string]any{
+					"staticScan": map[string]any{"status": staticScan},
+				},
+			},
+			"ok":       false,
+			"decision": "fail",
+			"reasons":  reasons,
+		}
+	}
+
+	publishScript := workflowNodeScript(t, "Publish and inspect ClawHub skill")
+	// card.missing 与 pending aggregate 同时出现时，必须走 aggregate 分支而不是
+	// 要求不可能成立的 clean aggregate security。
+	runWorkflowNodeVerification(t, publishScript, publish, pending([]string{"card.missing"}, "clean"), version, fingerprint, "1", true)
+	runWorkflowNodeVerification(t, publishScript, publish, pending([]string{"security.pending"}, "dirty"), version, fingerprint, "1", false)
+	runWorkflowNodeVerification(t, publishScript, publish, pending([]string{"unexpected.reason"}, "clean"), version, fingerprint, "1", false)
+	runWorkflowNodeVerification(t, publishScript, publish, pending([]string{"security.pending"}, "clean"), version, fingerprint, "0", false)
+
+	// verify_only 是最终严格检查：aggregate security 尚未完成时不得将本次发布
+	// 标记为已复核。
+	verifyOnlyScript := workflowNodeScript(t, "Verify an already-published ClawHub skill")
+	runWorkflowNodeVerification(t, verifyOnlyScript, nil, pending([]string{"security.pending"}, "clean"), version, fingerprint, "1", false)
+}
+
+func workflowNodeScript(t *testing.T, stepName string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "publish-clawhub.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document yaml.Node
+	if err := yaml.Unmarshal(body, &document); err != nil {
+		t.Fatalf("parse workflow: %v", err)
+	}
+	steps := mappingValue(t, mappingValue(t, mappingValue(t, document.Content[0], "jobs"), "publish"), "steps")
+	run := scalarValue(t, mappingValue(t, stepByName(t, steps, stepName), "run"))
+	_, script, found := strings.Cut(run, "<<'NODE'\n")
+	if !found {
+		t.Fatalf("step %q must contain a Node verifier", stepName)
+	}
+	script, _, found = strings.Cut(script, "\nNODE\n")
+	if !found {
+		t.Fatalf("step %q Node verifier must close its heredoc", stepName)
+	}
+	return script
+}
+
+func runWorkflowNodeVerification(t *testing.T, script string, publish, verify map[string]any, version, fingerprint, exitCode string, wantSuccess bool) {
+	t.Helper()
+	directory := t.TempDir()
+	verifyPath := filepath.Join(directory, "verify.json")
+	writeWorkflowJSON(t, verifyPath, verify)
+	arguments := []string{"-", verifyPath, version, fingerprint, exitCode}
+	if publish != nil {
+		publishPath := filepath.Join(directory, "publish.json")
+		writeWorkflowJSON(t, publishPath, publish)
+		arguments = []string{"-", publishPath, verifyPath, version, fingerprint, exitCode}
+	}
+	command := exec.Command("node", arguments...)
+	command.Stdin = strings.NewReader(script)
+	output, err := command.CombinedOutput()
+	if wantSuccess && err != nil {
+		t.Fatalf("workflow verifier unexpectedly rejected result: %v\n%s", err, output)
+	}
+	if !wantSuccess && err == nil {
+		t.Fatalf("workflow verifier unexpectedly accepted result: %s", output)
+	}
+}
+
+func writeWorkflowJSON(t *testing.T, path string, value map[string]any) {
+	t.Helper()
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/scripts/clawhubworkflow/main_test.go
+++ b/scripts/clawhubworkflow/main_test.go
@@ -74,6 +74,9 @@ func TestPublishWorkflowKeepsTheImmutableReleaseAndSecretBoundary(t *testing.T) 
 	if !strings.Contains(finalRun, "clawhub skill publish skills/pixiv-cli --version \"$SKILL_VERSION\"") || !strings.Contains(finalRun, "clawhub skill verify pixiv-cli --version \"$SKILL_VERSION\"") {
 		fatalf(t, "final step must publish and verify the exact versioned product skill")
 	}
+	if !strings.Contains(finalRun, "staticScanClean") || !strings.Contains(finalRun, "aggregateSecurityPending") || !strings.Contains(finalRun, "else if (pendingAggregationOnly)") || !strings.Contains(finalRun, "ClawHub aggregate security scan pending") {
+		fatalf(t, "publish step must make clean static scanning and pending aggregation an explicit verification branch")
+	}
 
 	dryRun := stepByName(t, steps, "Dry-run the exact tagged skill")
 	dryRunText := scalarValue(t, mappingValue(t, dryRun, "run"))
@@ -82,8 +85,8 @@ func TestPublishWorkflowKeepsTheImmutableReleaseAndSecretBoundary(t *testing.T) 
 	}
 	verifyOnlyStep := stepByName(t, steps, "Verify an already-published ClawHub skill")
 	verifyOnlyRun := scalarValue(t, mappingValue(t, verifyOnlyStep, "run"))
-	if !strings.Contains(renderNode(t, verifyOnlyStep), "CLAWHUB_TOKEN") || !strings.Contains(verifyOnlyRun, "clawhub --no-input login --token \"$CLAWHUB_TOKEN\"") || !strings.Contains(verifyOnlyRun, "clawhub skill verify pixiv-cli --version \"$SKILL_VERSION\" > \"$RUNNER_TEMP/clawhub-verify.json\" || verify_exit=$?") || !strings.Contains(verifyOnlyRun, "cardPendingOnly") || !strings.Contains(verifyOnlyRun, "verify.artifact?.sourceFingerprint === fingerprint") || strings.Contains(verifyOnlyRun, "clawhub skill publish") {
-		fatalf(t, "verify-only recovery must authenticate only for verification and must not republish the immutable version")
+	if !strings.Contains(renderNode(t, verifyOnlyStep), "CLAWHUB_TOKEN") || !strings.Contains(verifyOnlyRun, "clawhub --no-input login --token \"$CLAWHUB_TOKEN\"") || !strings.Contains(verifyOnlyRun, "clawhub skill verify pixiv-cli --version \"$SKILL_VERSION\" > \"$RUNNER_TEMP/clawhub-verify.json\" || verify_exit=$?") || !strings.Contains(verifyOnlyRun, "securityIsClean") || !strings.Contains(verifyOnlyRun, "cardPendingOnly") || !strings.Contains(verifyOnlyRun, "verify.artifact?.sourceFingerprint === fingerprint") || strings.Contains(verifyOnlyRun, "aggregateSecurityPending") || strings.Contains(verifyOnlyRun, "clawhub skill publish") {
+		fatalf(t, "verify-only recovery must require a completed clean scan and must not republish the immutable version")
 	}
 	install := stepByName(t, steps, "Install pinned ClawHub CLI without credentials")
 	if !strings.Contains(scalarValue(t, mappingValue(t, install, "run")), "clawhub@0.23.1") {


### PR DESCRIPTION
## Summary

- Preserve a successful ClawHub publication when the exact artifact and static scan are verified but the platform aggregate security result is still asynchronous and pending.
- Keep `verify_only` strict: it never republishes and still requires the completed clean aggregate security result.

## Scope and compatibility

None. No CLI, SDK, MCP, configuration, release asset, or published skill content changes.

## Verification

- `go test ./scripts/clawhubworkflow ./scripts/documentation -count=1` — passed.
- `pre-commit run --files .github/workflows/publish-clawhub.yml scripts/clawhubworkflow/main_test.go docs/maintainers/development.md` — passed.
- Commit hook `go test ./...` — passed.
- The failed v0.10.0 ClawHub runs provided real platform evidence: artifact fingerprint and static scan were clean while the aggregate result was `pending`.

<!-- release-note
category: None
breaking: false
summary: Harden ClawHub publication handling for asynchronous security aggregation.
none_reason: This only corrects release automation state handling; it does not change a public product surface or the immutable v0.10.0 release content.
-->

## Checklist

- [x] The change is focused.
- [x] I added or updated focused tests for changed behavior.
- [x] I ran the relevant tests and recorded the results above.
- [x] I updated required maintainer documentation.
- [x] I completed the release-note declaration with a concrete None reason.
- [x] I did not add sensitive data or private responses.

## Summary by Sourcery

调整 ClawHub 发布工作流处理逻辑：在静态扫描干净但聚合安全结果仍处于待定状态时，将其视为成功发布，同时保持仅验证模式下的恢复策略严格。

Enhancements:
- 扩展 ClawHub 验证逻辑，显式识别“静态扫描干净但聚合安全结果为待定”的情况，并通过工作流警告进行提示。
- 收紧仅验证模式（verify-only）的恢复行为，要求必须有“已完成且干净”的聚合安全结果，并且绝不重新发布已有的版本。
- 更新维护者文档，描述改进后的 ClawHub 安全聚合和技能卡处理流程，包括新的警告语义。

CI:
- 调整 `publish-clawhub` GitHub Actions 工作流，将新的安全验证路径和警告条件纳入其中，同时不改变不可变的发布边界。

Tests:
- 更新工作流测试，以断言新的待聚合检查和警告的存在，并强制执行更严格的仅验证模式要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust ClawHub release workflow handling to treat clean static scans with pending aggregate security results as successful publishes while keeping verify-only recovery strict.

Enhancements:
- Extend ClawHub verification logic to explicitly recognize pending aggregate security outcomes with clean static scans and surface them via workflow warnings.
- Tighten verify-only recovery behavior so it requires a completed clean aggregate security result and never republishes an existing release.
- Update maintainers documentation to describe the refined ClawHub security aggregation and skill-card handling, including the new warning semantics.

CI:
- Adjust the publish-clawhub GitHub Actions workflow to incorporate the new security verification paths and warning conditions without altering the immutable release boundary.

Tests:
- Update workflow tests to assert the presence of new pending-aggregation checks and warnings, and to enforce the stricter verify-only requirements.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化发布后的安全验证流程，区分静态扫描结果与聚合安全结论。
  * 当静态扫描通过但聚合安全检查仍处于允许的待处理状态时，发布流程将发出警告而非误判失败。
  * `skill-card.md` 异步生成期间仅提示警告，不阻断已接收的发布。
  * 仅在完整安全检查通过时，验证流程才会确认发布成功；其他安全异常仍会阻止流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->