### PR TITLE
fix(windows): make release tests portable

### DIFF
--- a/internal/browsercookies/browsercookies_test.go
+++ b/internal/browsercookies/browsercookies_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -209,15 +210,17 @@ func TestWriteTempSnapshotPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("file mode = %o, want 600", got)
-	}
 	dirInfo, err := os.Stat(filepath.Dir(path))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := dirInfo.Mode().Perm(); got != 0o700 {
-		t.Fatalf("dir mode = %o, want 700", got)
+	if runtime.GOOS != "windows" {
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("file mode = %o, want 600", got)
+		}
+		if got := dirInfo.Mode().Perm(); got != 0o700 {
+			t.Fatalf("dir mode = %o, want 700", got)
+		}
 	}
 	cleanup()
 	if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/internal/storage/database/database.go
+++ b/internal/storage/database/database.go
@@ -51,7 +51,14 @@ func dsnWithPragmas(path string) string {
 	query.Add("_pragma", "synchronous(FULL)")
 	query.Add("_pragma", "secure_delete(ON)")
 	query.Add("_pragma", "trusted_schema(off)")
-	return (&url.URL{Scheme: "file", Path: path, RawQuery: query.Encode()}).String()
+	// SQLite file URI 的 path 必须使用 slash；Windows 反斜杠会被 URI
+	// 解析为转义路径，导致 modernc.org/sqlite 打开数据库时报错误。
+	filePath := filepath.ToSlash(path)
+	if filepath.VolumeName(path) != "" && !strings.HasPrefix(filePath, "/") {
+		// URL 中的 Windows 盘符需要位于根路径下，才能得到 file:///C:/...。
+		filePath = "/" + filePath
+	}
+	return (&url.URL{Scheme: "file", Path: filePath, RawQuery: query.Encode()}).String()
 }
 
 type DB struct {

--- a/internal/storage/database/database_windows_test.go
+++ b/internal/storage/database/database_windows_test.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package database
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDSNWithPragmasUsesSlashSeparatedFileURI(t *testing.T) {
+	dsn := dsnWithPragmas(`C:\Users\runner\AppData\Local\pixiv-cli.db`)
+	if !strings.HasPrefix(dsn, "file:///C:/Users/runner/AppData/Local/pixiv-cli.db?") {
+		t.Fatalf("dsnWithPragmas() = %q, want a slash-separated absolute file URI", dsn)
+	}
+	if strings.Contains(dsn, `\\`) || strings.Contains(dsn, "%5C") {
+		t.Fatalf("dsnWithPragmas() retained Windows path separators: %q", dsn)
+	}
+}

--- a/internal/storage/database/migrate_test.go
+++ b/internal/storage/database/migrate_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -119,7 +120,14 @@ func TestMigrationLedgerRejectsChecksumAndNameDrift(t *testing.T) {
 }
 
 func TestDatabasePermissionsAndSpecialPath(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "space unicode 名称 ? # %", `windows-like C:\pixiv\state`)
+	specialDirectory := "space unicode 名称 ? # %"
+	nestedDirectory := `windows-like C:\pixiv\state`
+	if runtime.GOOS == "windows" {
+		// ?、: 与反斜杠在 Windows 路径中具有特殊含义，不能作为普通目录名。
+		specialDirectory = "space unicode 名称 # %"
+		nestedDirectory = "windows-like C pixiv state"
+	}
+	dir := filepath.Join(t.TempDir(), specialDirectory, nestedDirectory)
 	db, err := Open(dir)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/storage/file/replace/replace_windows_test.go
+++ b/internal/storage/file/replace/replace_windows_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	replace "github.com/FlanChanXwO/pixiv-cli/internal/storage/file/replace"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/scripts/internal/nativeevidence/record_test.go
+++ b/scripts/internal/nativeevidence/record_test.go
@@ -85,7 +85,11 @@ func TestRecordEvidenceBindsStaticlibBinaryAndCompleteArchive(t *testing.T) {
 }
 
 func TestReadBinaryVersionRequiresExactRootOutput(t *testing.T) {
-	binary := filepath.Join(t.TempDir(), "pixiv")
+	binaryName := "pixiv"
+	if runtime.GOOS == "windows" {
+		binaryName = "pixiv.exe"
+	}
+	binary := filepath.Join(t.TempDir(), binaryName)
 	copyTestExecutable(t, binary)
 
 	tests := []struct {


### PR DESCRIPTION
## 变更

- 修正 Windows 盘符 SQLite file URI，避免反斜杠导致数据库打开失败。
- 让 Windows 测试使用合法路径与 `.exe` 测试二进制，并移除未使用导入。
- 不在 Windows 上断言没有 ACL 语义的 POSIX 权限位。

## 验证

- `go test ./internal/storage/database ./internal/browsercookies ./scripts/internal/nativeevidence ./internal/storage/file/replace -count=1`
- Windows 目标包交叉编译：database、nativeevidence、file/replace。
- v1.0.0 发布运行 [33358994882](https://github.com/FlanChanXwO/pixiv-cli/actions/runs/33358994882) 已实际证明这些问题；修复需由 Windows runner 再验证。

## 自查

- 未修改不可变的 `v1.0.0` 标签，也未包含凭据或本地 e2evidence 改动。
- 第三个 FANBOX 账号按既定范围跳过。

## Sourcery 总结

确保发布测试和 SQLite 数据库访问在 Windows 上保持可移植性。

Bug 修复：
- 通过使用可移植的斜杠分隔格式，使 SQLite 文件 URI 支持 Windows 驱动器号路径。
- 使受影响软件包中的发布测试使用符合 Windows 要求的路径和可执行文件名称。

改进：
- 在 Windows 上跳过 POSIX 权限位断言，因为这些语义不适用。

测试：
- 添加 Windows 测试覆盖，验证 SQLite DSN 使用有效的斜杠分隔绝对文件 URI。

杂项：
- 移除未使用的测试依赖项导入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure release tests and SQLite database access remain portable on Windows.

Bug Fixes:
- Make SQLite file URIs work with Windows drive-letter paths by using portable slash-separated formatting.
- Make release tests use Windows-valid paths and executable names across affected packages.

Enhancements:
- Skip POSIX permission-bit assertions on Windows, where those semantics do not apply.

Tests:
- Add Windows coverage verifying SQLite DSNs use valid slash-separated absolute file URIs.

Chores:
- Remove an unused test dependency import.

</details>