### PR TITLE
docs(release): include Windows fix in v1.0.0 notes

### DIFF
--- a/changelog/v1.0.0/en.md
+++ b/changelog/v1.0.0/en.md
@@ -18,6 +18,7 @@
 - Restore release validation for the audited v0.10.0 recovery path so valid release preparation is not rejected. ([#49](https://github.com/FlanChanXwO/pixiv-cli/pull/49))
 - Handle pending ClawHub security scans without misreporting a received publication as a failed release. ([#50](https://github.com/FlanChanXwO/pixiv-cli/pull/50))
 - Fix Pixiv authentication service initialization errors, verified current-user and endpoint contracts, FANBOX proxy conflict validation, and forward-compatible local account migrations. ([#67](https://github.com/FlanChanXwO/pixiv-cli/pull/67))
+- Make Windows release gates portable across file URIs, ACL-backed permissions, platform paths, and executable naming. ([#68](https://github.com/FlanChanXwO/pixiv-cli/pull/68))
 
 ## Documentation
 

--- a/changelog/v1.0.0/zh-CN.md
+++ b/changelog/v1.0.0/zh-CN.md
@@ -18,6 +18,7 @@
 - 恢复经审计的 v0.10.0 recovery 路径发布校验，避免有效的发布准备被拒绝。 ([#49](https://github.com/FlanChanXwO/pixiv-cli/pull/49))
 - 处理 ClawHub pending security scan，避免已接收的发布被错误报告为失败。 ([#50](https://github.com/FlanChanXwO/pixiv-cli/pull/50))
 - 修复 Pixiv 认证服务初始化错误、已验证的当前用户与端点契约、FANBOX 代理冲突校验，以及本地账号数据库的向前兼容迁移。 ([#67](https://github.com/FlanChanXwO/pixiv-cli/pull/67))
+- 修复 Windows 发布门禁在文件 URI、ACL 权限、平台路径和可执行文件命名上的兼容性问题。 ([#68](https://github.com/FlanChanXwO/pixiv-cli/pull/68))
 
 ## 文档
 


### PR DESCRIPTION
## 变更

- 将已合并的 Windows 发布门禁兼容性修复（#68）补充到 v1.0.0 的英文和简体中文 changelog。

## 验证

- `go run ./scripts/cmd/releasenotes validate --version 1.0.0 --dir changelog/v1.0.0 --previous v0.10.0 --audit /tmp/pixiv-cli-release-audit-v1.0.0.json`
- `go test ./scripts/internal/releasenotes ./scripts/tests/documentation -count=1`
- `git diff --check`

## 自查

- [x] 双语说明覆盖审计范围内的相同来源集合
- [x] 未修改产品行为、workflow 或已有用户文件
- [x] 未包含 token、Cookie、本地数据库或下载内容

## Sourcery 摘要

文档：
- 在 v1.0.0 英文版和简体中文版变更日志中记录 Windows 发布门兼容性修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document the Windows release-gate compatibility fix in the v1.0.0 English and Simplified Chinese changelogs.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * 修复 Windows 发布检查在文件 URI、ACL 权限、平台路径及可执行文件命名方面的兼容性问题。
* **文档**
  * 更新中英文 v1.0.0 变更日志，记录上述修复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->