### PR TITLE
test(database): respect Windows ACL permissions

### DIFF
--- a/changelog/v1.0.0/en.md
+++ b/changelog/v1.0.0/en.md
@@ -19,6 +19,7 @@
 - Handle pending ClawHub security scans without misreporting a received publication as a failed release. ([#50](https://github.com/FlanChanXwO/pixiv-cli/pull/50))
 - Fix Pixiv authentication service initialization errors, verified current-user and endpoint contracts, FANBOX proxy conflict validation, and forward-compatible local account migrations. ([#67](https://github.com/FlanChanXwO/pixiv-cli/pull/67))
 - Make Windows release gates portable across file URIs, ACL-backed permissions, platform paths, and executable naming. ([#68](https://github.com/FlanChanXwO/pixiv-cli/pull/68))
+- Make the database permission test distinguish Windows ACL semantics from POSIX mode bits. ([#71](https://github.com/FlanChanXwO/pixiv-cli/pull/71))
 
 ## Documentation
 

--- a/changelog/v1.0.0/zh-CN.md
+++ b/changelog/v1.0.0/zh-CN.md
@@ -19,6 +19,7 @@
 - 处理 ClawHub pending security scan，避免已接收的发布被错误报告为失败。 ([#50](https://github.com/FlanChanXwO/pixiv-cli/pull/50))
 - 修复 Pixiv 认证服务初始化错误、已验证的当前用户与端点契约、FANBOX 代理冲突校验，以及本地账号数据库的向前兼容迁移。 ([#67](https://github.com/FlanChanXwO/pixiv-cli/pull/67))
 - 修复 Windows 发布门禁在文件 URI、ACL 权限、平台路径和可执行文件命名上的兼容性问题。 ([#68](https://github.com/FlanChanXwO/pixiv-cli/pull/68))
+- 让数据库权限测试区分 Windows ACL 语义与 POSIX 权限位。 ([#71](https://github.com/FlanChanXwO/pixiv-cli/pull/71))
 
 ## 文档
 

--- a/internal/storage/database/migrate_test.go
+++ b/internal/storage/database/migrate_test.go
@@ -140,11 +140,17 @@ func TestDatabasePermissionsAndSpecialPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	info, err := os.Stat(db.Path())
-	if err != nil || info.Mode().Perm() != 0o600 {
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("database mode = %v, err=%v", info.Mode().Perm(), err)
 	}
 	dirInfo, err := os.Stat(filepath.Dir(db.Path()))
-	if err != nil || dirInfo.Mode().Perm() != 0o700 {
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && dirInfo.Mode().Perm() != 0o700 {
 		t.Fatalf("directory mode = %v, err=%v", dirInfo.Mode().Perm(), err)
 	}
 }


### PR DESCRIPTION
## 变更

- 让数据库权限测试在 Windows 上保留文件/目录存在性校验，并避免把 POSIX 权限位误当作 Windows ACL 结果。

## 验证

- `go test ./internal/storage/database -run TestDatabasePermissionsAndSpecialPath -count=1`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/pixiv-database-windows-perms-amd64.exe ./internal/storage/database`
- `GOOS=windows GOARCH=arm64 go test -c -o /tmp/pixiv-database-windows-perms-arm64.exe ./internal/storage/database`
- `git diff --check`

## 自查

- [x] 修复对应正式 v1.0.0 release run 的 Windows amd64/arm64 真实失败
- [x] 未修改 release workflow 或绕过跨平台门禁
- [x] 未包含 token、Cookie、本地数据库或下载内容

## Sourcery 摘要

修复数据库权限测试，使其能够在 Windows 和 POSIX 平台上正确验证数据库和目录行为。

错误修复：
- 修复 Windows 上的数据库权限测试：保留文件和目录存在性检查，同时不再将 POSIX 权限位解释为 Windows ACL 结果。

测试：
- 使数据库权限断言适配 Windows 平台，并保留对数据库路径和父目录存在性的验证。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

更新数据库权限验证，以正确处理 Windows ACL，同时不削弱 POSIX 权限检查。

Bug 修复：
- 通过区分 Windows ACL 语义与 POSIX 模式位，同时保留数据库和目录存在性检查，使数据库权限测试在 Windows 上可靠通过。

维护：
- 在 v1.0.0 英文和中文变更日志中记录跨平台数据库权限测试修复。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

使数据库权限验证兼容 Windows 和 POSIX 平台。

错误修复：
- 通过区分 Windows ACL 行为与 POSIX 权限位，同时保留文件和目录存在性检查，使数据库权限测试在 Windows 上更加可靠。

文档：
- 在 v1.0.0 英文和中文变更日志中记录跨平台数据库权限测试修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make database permission validation portable across Windows and POSIX platforms.

Bug Fixes:
- Make database permission tests reliable on Windows by distinguishing Windows ACL behavior from POSIX permission bits while retaining file and directory existence checks.

Documentation:
- Document the cross-platform database permission test fix in the v1.0.0 English and Chinese changelogs.

</details>

</details>

</details>