### PR TITLE
docs(release): record native staticlib refresh

### DIFF
--- a/changelog/v1.0.0/en.md
+++ b/changelog/v1.0.0/en.md
@@ -20,6 +20,7 @@
 - Fix Pixiv authentication service initialization errors, verified current-user and endpoint contracts, FANBOX proxy conflict validation, and forward-compatible local account migrations. ([#67](https://github.com/FlanChanXwO/pixiv-cli/pull/67))
 - Make Windows release gates portable across file URIs, ACL-backed permissions, platform paths, and executable naming. ([#68](https://github.com/FlanChanXwO/pixiv-cli/pull/68))
 - Make the database permission test distinguish Windows ACL semantics from POSIX mode bits. ([#71](https://github.com/FlanChanXwO/pixiv-cli/pull/71))
+- Refresh the six pinned native ugoira static libraries from one source-matched evidence run so production release rebuilds are byte-for-byte reproducible. ([#72](https://github.com/FlanChanXwO/pixiv-cli/pull/72))
 
 ## Documentation
 

--- a/changelog/v1.0.0/en.md
+++ b/changelog/v1.0.0/en.md
@@ -27,6 +27,7 @@
 - Simplify the pull request template so review records contain the change, verification, and self-check evidence required by the repository workflow. ([#61](https://github.com/FlanChanXwO/pixiv-cli/pull/61))
 - Record the audited Windows portability fix in the bilingual v1.0.0 release notes. ([#69](https://github.com/FlanChanXwO/pixiv-cli/pull/69))
 - Complete the audited source coverage for the v1.0.0 release notes. ([#70](https://github.com/FlanChanXwO/pixiv-cli/pull/70))
+- Record the native staticlib refresh and its release provenance in the bilingual v1.0.0 notes. ([#73](https://github.com/FlanChanXwO/pixiv-cli/pull/73))
 
 ## Maintenance
 

--- a/changelog/v1.0.0/zh-CN.md
+++ b/changelog/v1.0.0/zh-CN.md
@@ -27,6 +27,7 @@
 - 简化 pull request template，使审查记录包含仓库流程要求的变更、验证和自查证据。 ([#61](https://github.com/FlanChanXwO/pixiv-cli/pull/61))
 - 在双语 v1.0.0 release notes 中记录经审计的 Windows 兼容性修复。 ([#69](https://github.com/FlanChanXwO/pixiv-cli/pull/69))
 - 完成 v1.0.0 release notes 的审计来源覆盖。 ([#70](https://github.com/FlanChanXwO/pixiv-cli/pull/70))
+- 在双语 v1.0.0 release notes 中记录 native 静态库回填及其发布来源。 ([#73](https://github.com/FlanChanXwO/pixiv-cli/pull/73))
 
 ## 维护
 

--- a/changelog/v1.0.0/zh-CN.md
+++ b/changelog/v1.0.0/zh-CN.md
@@ -20,6 +20,7 @@
 - 修复 Pixiv 认证服务初始化错误、已验证的当前用户与端点契约、FANBOX 代理冲突校验，以及本地账号数据库的向前兼容迁移。 ([#67](https://github.com/FlanChanXwO/pixiv-cli/pull/67))
 - 修复 Windows 发布门禁在文件 URI、ACL 权限、平台路径和可执行文件命名上的兼容性问题。 ([#68](https://github.com/FlanChanXwO/pixiv-cli/pull/68))
 - 让数据库权限测试区分 Windows ACL 语义与 POSIX 权限位。 ([#71](https://github.com/FlanChanXwO/pixiv-cli/pull/71))
+- 从单次与源码匹配的 evidence run 重新汇总 6 个 pinned native ugoira 静态库，使生产发布重建能够逐字节复现。 ([#72](https://github.com/FlanChanXwO/pixiv-cli/pull/72))
 
 ## 文档
 


### PR DESCRIPTION
## 变更

- 在 v1.0.0 中补充 PR #72 的双语来源记录。
- 记录 native-evidence 回填静态库的发布修复。

## 验证

- `git diff --check`
- 提交钩子中的 `go test ./...`

## 自查

- 仅修改 `changelog/v1.0.0/en.md` 与 `changelog/v1.0.0/zh-CN.md`。
- 未包含 token、下载内容或本地配置。
- 合并后会重新运行 release notes provenance audit。

## Sourcery 总结

在 v1.0.0 更新日志中记录原生静态库的刷新，以及其可复现发布构建的来源信息。

增强功能：
- 记录六个固定版本的原生 ugoira 静态库的刷新，以支持生产版本发布的逐字节可复现重建。

文档：
- 添加双语 v1.0.0 更新日志条目，并将原生静态库刷新关联至 PR #72。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

文档：
- 在双语 v1.0.0 变更日志中记录原生 ugoira 静态库的更新及其发布来源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document the native ugoira static library refresh and its release provenance in the bilingual v1.0.0 changelog.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 更新原生静态库发布内容，确保生产版本可进行逐字节一致的可复现重建。

- **文档**
  - 在中英文 v1.0.0 发布说明中补充静态库更新记录及发布来源信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->