### PR TITLE
fix(ci): expand container release version arg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,7 +388,7 @@ jobs:
         run: |
           docker build \
             --build-arg REVISION="$(git rev-parse "$RELEASE_TAG^{commit}")" \
-            --build-arg VERSION='${RELEASE_TAG}' \
+            --build-arg VERSION="${RELEASE_TAG}" \
             --platform 'linux/${{ matrix.goarch }}' \
             --tag "pixiv-cli:${RELEASE_TAG}-${{ matrix.artifact }}" .
       # Includes the embedded license-notices bundle in every architecture check.

--- a/changelog/v1.0.0/en.md
+++ b/changelog/v1.0.0/en.md
@@ -21,6 +21,7 @@
 - Make Windows release gates portable across file URIs, ACL-backed permissions, platform paths, and executable naming. ([#68](https://github.com/FlanChanXwO/pixiv-cli/pull/68))
 - Make the database permission test distinguish Windows ACL semantics from POSIX mode bits. ([#71](https://github.com/FlanChanXwO/pixiv-cli/pull/71))
 - Refresh the six pinned native ugoira static libraries from one source-matched evidence run so production release rebuilds are byte-for-byte reproducible. ([#72](https://github.com/FlanChanXwO/pixiv-cli/pull/72))
+- Pass the expanded release tag to the container image version label so OCI provenance verification matches the immutable tag. ([#74](https://github.com/FlanChanXwO/pixiv-cli/pull/74))
 
 ## Documentation
 

--- a/changelog/v1.0.0/zh-CN.md
+++ b/changelog/v1.0.0/zh-CN.md
@@ -21,6 +21,7 @@
 - 修复 Windows 发布门禁在文件 URI、ACL 权限、平台路径和可执行文件命名上的兼容性问题。 ([#68](https://github.com/FlanChanXwO/pixiv-cli/pull/68))
 - 让数据库权限测试区分 Windows ACL 语义与 POSIX 权限位。 ([#71](https://github.com/FlanChanXwO/pixiv-cli/pull/71))
 - 从单次与源码匹配的 evidence run 重新汇总 6 个 pinned native ugoira 静态库，使生产发布重建能够逐字节复现。 ([#72](https://github.com/FlanChanXwO/pixiv-cli/pull/72))
+- 将展开后的 release tag 传入容器镜像版本标签，使 OCI provenance 校验与 immutable tag 保持一致。 ([#74](https://github.com/FlanChanXwO/pixiv-cli/pull/74))
 
 ## 文档
 

--- a/scripts/tests/containerrelease/containerrelease_test.go
+++ b/scripts/tests/containerrelease/containerrelease_test.go
@@ -270,6 +270,24 @@ func TestReleaseWorkflowQuotesOCILabelKeys(t *testing.T) {
 	}
 }
 
+// TestReleaseWorkflowExpandsContainerVersionBuildArg 确保 Docker 收到实际的
+// release tag，而不是被 Shell 单引号保护后的字面量 `${RELEASE_TAG}`。
+func TestReleaseWorkflowExpandsContainerVersionBuildArg(t *testing.T) {
+	t.Parallel()
+	root := repositoryRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, ".github/workflows/release.yml"))
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, `--build-arg VERSION="${RELEASE_TAG}"`) {
+		t.Fatal("release workflow must expand RELEASE_TAG when passing the container VERSION build arg")
+	}
+	if strings.Contains(text, "--build-arg VERSION='${RELEASE_TAG}'") {
+		t.Fatal("release workflow must not pass the literal ${RELEASE_TAG} as the container VERSION build arg")
+	}
+}
+
 // TestDockerfileIncludesLicenseNotices 确保镜像携带项目许可证与完整第三方声明。
 func TestDockerfileIncludesLicenseNotices(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
### 变更
- 修复 release workflow 中容器 VERSION build arg 被单引号阻止展开的问题。
- 增加回归测试，拒绝把 `${RELEASE_TAG}` 字面量传入 Docker。

### 验证
- Red：旧写法下回归测试实际失败。
- Green：`go test ./scripts/tests/containerrelease -count=1`
- `go test ./scripts/internal/releaseworkflow -count=1`
- `go run ./scripts/cmd/releaseworkflow --workflow .github/workflows/release.yml`
- `go test ./...`

### 自查
- [x] 未引入 secret、token、缓存或下载内容
- [x] 未暂存工作区中已有的用户改动
- [x] 该修复保持 release tag 与 OCI provenance 合约一致

## Sourcery 总结

修复容器发布版本传播问题，确保 Docker 接收到展开后的发布标签，从而实现准确的镜像来源追踪。

错误修复：
- 确保发布工作流在传递容器镜像版本构建参数时展开发布标签，使 OCI 来源信息与不可变标签保持一致。

文档：
- 在英文和中文 v1.0.0 更新日志中记录容器镜像版本和 OCI 来源信息修复。

测试：
- 添加回归测试，拒绝向 Docker 传递字面量 `${RELEASE_TAG}`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix container release version propagation so Docker receives the expanded release tag for accurate image provenance.

Bug Fixes:
- Ensure the release workflow expands the release tag when passing the container image version build argument, keeping OCI provenance aligned with the immutable tag.

Documentation:
- Document the container image version and OCI provenance fix in the English and Chinese v1.0.0 changelogs.

Tests:
- Add a regression test that rejects passing the literal `${RELEASE_TAG}` to Docker.

</details>